### PR TITLE
docs: Add community health files (issue templates, PR template, CONTRIBUTING, SECURITY)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,71 @@
+name: Bug Report
+description: Report a bug in CC Pocket
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug!
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of CC Pocket is affected?
+      options:
+        - Mobile App (iOS)
+        - Mobile App (Android)
+        - Bridge Server
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+      placeholder: Tell us what went wrong
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce the bug?
+      placeholder: |
+        1. Open the app
+        2. Go to ...
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Version and environment details.
+      placeholder: |
+        - App version: x.x.x
+        - Bridge version: x.x.x
+        - OS: macOS / iOS / Android
+        - Node.js version (Bridge): x.x
+      render: markdown
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / Screenshots
+      description: If applicable, add logs or screenshots.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Documentation
+    url: https://github.com/K9i-0/ccpocket#readme
+    about: Check the README for setup and usage instructions

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,54 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature!
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of CC Pocket does this relate to?
+      options:
+        - Mobile App
+        - Bridge Server
+        - Both
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem does this feature solve?
+      placeholder: I find it difficult to ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: How would you like this to work?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any alternative solutions or workarounds you've thought about?
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Any other context, screenshots, or mockups.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Summary
+
+<!-- What does this PR do? Keep it brief. -->
+
+## Changes
+
+<!-- List the key changes. -->
+
+-
+
+## Test plan
+
+<!-- How was this tested? -->
+
+- [ ] Bridge Server tests pass (`npm run test:bridge`)
+- [ ] Flutter tests pass (`cd apps/mobile && flutter test`)
+- [ ] Manual testing done
+
+## Notes
+
+<!-- Anything reviewers should know? Breaking changes, migration steps, etc. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contributing to CC Pocket
+
+Thanks for your interest in contributing! Here's how to get started.
+
+## Getting started
+
+### Prerequisites
+
+- [Node.js](https://nodejs.org/) >= 18
+- [Flutter](https://flutter.dev/) (Dart SDK ^3.11.0)
+- [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) or [Codex CLI](https://github.com/openai/codex) (for testing sessions)
+
+### Setup
+
+```bash
+git clone https://github.com/K9i-0/ccpocket.git
+cd ccpocket
+npm install
+cd apps/mobile && flutter pub get && cd ../..
+```
+
+### Common commands
+
+| Command | Description |
+|---------|-------------|
+| `npm run bridge` | Run Bridge Server in dev mode |
+| `npm run bridge:build` | Build Bridge Server |
+| `npm run test:bridge` | Run Bridge Server tests |
+| `npm run test:bridge:coverage` | Run tests with coverage |
+| `cd apps/mobile && flutter test` | Run Flutter tests |
+| `cd apps/mobile && dart analyze` | Run Dart static analysis |
+
+## Making changes
+
+1. Fork the repository and create a branch from `main`
+2. Make your changes
+3. Add tests for new functionality
+4. Ensure all tests pass
+5. Open a pull request
+
+## Code style
+
+- **Bridge Server (TypeScript)**: Follows the existing project conventions. Run tests with `npm run test:bridge` before submitting.
+- **Mobile App (Flutter/Dart)**: Run `dart analyze` to check for issues.
+
+## Reporting bugs
+
+Please use the [bug report template](https://github.com/K9i-0/ccpocket/issues/new?template=bug_report.yml) when filing bugs.
+
+## Suggesting features
+
+Please use the [feature request template](https://github.com/K9i-0/ccpocket/issues/new?template=feature_request.yml) for feature ideas.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Supported versions
+
+| Component | Version | Supported |
+|-----------|---------|-----------|
+| Bridge Server (`@ccpocket/bridge`) | latest | Yes |
+| Mobile App | latest | Yes |
+
+## Reporting a vulnerability
+
+If you discover a security vulnerability, **please do not open a public issue**.
+
+Instead, report it privately via [GitHub Security Advisories](https://github.com/K9i-0/ccpocket/security/advisories/new).
+
+Please include:
+
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Suggested fix (if any)
+
+## Security considerations
+
+CC Pocket's Bridge Server exposes filesystem operations over WebSocket. Key security measures include:
+
+- **`BRIDGE_ALLOWED_DIRS`**: Restricts which directories can be accessed
+- **`BRIDGE_API_KEY`**: Optional API key authentication for connections
+- **Path validation**: All paths are resolved and checked against allowed directories before any operation
+- **Network security**: Tailscale or local network recommended for remote access; no data is sent to external servers
+- **Credential storage**: API keys and SSH keys are stored using platform-native encrypted storage (iOS Keychain / Android Keystore)


### PR DESCRIPTION
## Summary

- Add issue templates (bug report + feature request) and PR template to standardize contributions
- Add CONTRIBUTING.md with setup instructions and development workflow
- Add SECURITY.md with vulnerability reporting process and security considerations

## Changes

- `.github/ISSUE_TEMPLATE/bug_report.yml` — Structured bug report form (component, steps to reproduce, environment)
- `.github/ISSUE_TEMPLATE/feature_request.yml` — Structured feature request form (problem, proposed solution, alternatives)
- `.github/ISSUE_TEMPLATE/config.yml` — Template chooser config, blank issues allowed, README link
- `.github/PULL_REQUEST_TEMPLATE.md` — PR template with summary, changes, and test plan checklist
- `CONTRIBUTING.md` — Prerequisites, setup, common commands, and contribution workflow
- `SECURITY.md` — Supported versions, private vulnerability reporting via GitHub Security Advisories, overview of existing security measures

## Notes

- CONTRIBUTING.md references the existing README for detailed usage; kept intentionally lightweight to avoid duplication
- SECURITY.md directs reporters to GitHub Security Advisories (private) rather than public issues, which is important given the Bridge Server's filesystem access surface
- No code changes; documentation only