### PR TITLE
feat(bridge): Linux (systemd) 対応の setup/uninstall コマンド追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2075,6 +2075,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2352,6 +2353,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -2393,6 +2395,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -2468,6 +2471,7 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -2651,7 +2655,7 @@
     },
     "packages/bridge": {
       "name": "@ccpocket/bridge",
-      "version": "1.13.2",
+      "version": "1.14.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.50",

--- a/packages/bridge/src/cli.ts
+++ b/packages/bridge/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
+import { platform } from "node:os";
 import { startServer } from "./index.js";
-import { setupLaunchd, uninstallLaunchd } from "./setup-launchd.js";
 
 const args = process.argv.slice(2);
 
@@ -31,15 +31,36 @@ if (subcommand === "doctor") {
       process.exit(1);
     });
 } else if (subcommand === "setup") {
-  // launchd setup subcommand
-  if (hasFlag("uninstall")) {
-    uninstallLaunchd();
+  // Service setup subcommand (platform-specific)
+  const opts = {
+    port: parseFlag("port"),
+    host: parseFlag("host"),
+    apiKey: parseFlag("api-key"),
+  };
+
+  if (platform() === "darwin") {
+    import("./setup-launchd.js")
+      .then(({ setupLaunchd, uninstallLaunchd }) => {
+        hasFlag("uninstall") ? uninstallLaunchd() : setupLaunchd(opts);
+      })
+      .catch((err) => {
+        console.error("Setup failed:", err);
+        process.exit(1);
+      });
+  } else if (platform() === "linux") {
+    import("./setup-systemd.js")
+      .then(({ setupSystemd, uninstallSystemd }) => {
+        hasFlag("uninstall") ? uninstallSystemd() : setupSystemd(opts);
+      })
+      .catch((err) => {
+        console.error("Setup failed:", err);
+        process.exit(1);
+      });
   } else {
-    setupLaunchd({
-      port: parseFlag("port"),
-      host: parseFlag("host"),
-      apiKey: parseFlag("api-key"),
-    });
+    console.error(
+      `ERROR: 'setup' is not supported on ${platform()}. Supported: macOS (launchd), Linux (systemd).`,
+    );
+    process.exit(1);
   }
 } else {
   // Server mode: set env vars from CLI flags, then start

--- a/packages/bridge/src/doctor.ts
+++ b/packages/bridge/src/doctor.ts
@@ -428,6 +428,45 @@ export async function checkLaunchdService(): Promise<CheckResult> {
   }
 }
 
+export async function checkSystemdService(): Promise<CheckResult> {
+  if (process.platform !== "linux") {
+    return {
+      name: "systemd service",
+      status: "skip",
+      message: "Linux only",
+    };
+  }
+  try {
+    const out = execSync(
+      "systemctl --user is-active ccpocket-bridge.service",
+      {
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+      },
+    );
+    if (out.trim() === "active") {
+      return {
+        name: "systemd service",
+        status: "pass",
+        message: "Active",
+      };
+    }
+    return {
+      name: "systemd service",
+      status: "skip",
+      message: `Status: ${out.trim()}`,
+      remediation: "Register with: ccpocket-bridge setup",
+    };
+  } catch {
+    return {
+      name: "systemd service",
+      status: "skip",
+      message: "Not registered",
+      remediation: "Register with: ccpocket-bridge setup",
+    };
+  }
+}
+
 // ---------------------------------------------------------------------------
 // macOS permission checks
 // ---------------------------------------------------------------------------
@@ -577,6 +616,11 @@ function getAllChecks(): CheckDefinition[] {
       name: "launchd service",
       category: "optional",
       run: checkLaunchdService,
+    },
+    {
+      name: "systemd service",
+      category: "optional",
+      run: checkSystemdService,
     },
   ];
 }

--- a/packages/bridge/src/setup-systemd.test.ts
+++ b/packages/bridge/src/setup-systemd.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock child_process before importing the module
+const mockExecSync = vi.fn();
+vi.mock("node:child_process", () => ({
+  execSync: (...args: unknown[]) => mockExecSync(...args),
+}));
+
+// Mock node:fs
+const mockExistsSync = vi.fn();
+const mockMkdirSync = vi.fn();
+const mockWriteFileSync = vi.fn();
+const mockUnlinkSync = vi.fn();
+vi.mock("node:fs", () => ({
+  existsSync: (...args: unknown[]) => mockExistsSync(...args),
+  mkdirSync: (...args: unknown[]) => mockMkdirSync(...args),
+  writeFileSync: (...args: unknown[]) => mockWriteFileSync(...args),
+  unlinkSync: (...args: unknown[]) => mockUnlinkSync(...args),
+}));
+
+// Mock node:os
+vi.mock("node:os", () => ({
+  homedir: () => "/home/testuser",
+}));
+
+// Import after mocks
+const { setupSystemd, uninstallSystemd } = await import("./setup-systemd.js");
+
+const SERVICE_PATH =
+  "/home/testuser/.config/systemd/user/ccpocket-bridge.service";
+
+describe("setup-systemd", () => {
+  const originalPlatform = process.platform;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(process, "platform", { value: "linux" });
+    // Default: directory exists, npx found
+    mockExistsSync.mockReturnValue(true);
+    mockExecSync.mockReturnValue("/usr/bin/npx\n");
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+  });
+
+  describe("setupSystemd", () => {
+    it("writes correct service file with default options", () => {
+      setupSystemd({});
+
+      expect(mockWriteFileSync).toHaveBeenCalledOnce();
+      const [path, content] = mockWriteFileSync.mock.calls[0] as [
+        string,
+        string,
+      ];
+      expect(path).toBe(SERVICE_PATH);
+      expect(content).toContain("[Unit]");
+      expect(content).toContain("Description=CC Pocket Bridge Server");
+      expect(content).toContain(
+        "ExecStart=/usr/bin/npx @ccpocket/bridge@latest",
+      );
+      expect(content).toContain(
+        "Environment=PATH=/usr/bin:/usr/local/bin:/usr/bin:/bin",
+      );
+      expect(content).toContain("Environment=BRIDGE_PORT=8765");
+      expect(content).toContain("Environment=BRIDGE_HOST=0.0.0.0");
+      expect(content).toContain("Restart=on-failure");
+      expect(content).toContain("WantedBy=default.target");
+      expect(content).not.toContain("BRIDGE_API_KEY");
+    });
+
+    it("includes BRIDGE_API_KEY when apiKey is provided", () => {
+      setupSystemd({ apiKey: "my-secret" });
+
+      const content = mockWriteFileSync.mock.calls[0]![1] as string;
+      expect(content).toContain("Environment=BRIDGE_API_KEY=my-secret");
+    });
+
+    it("omits BRIDGE_API_KEY when apiKey is empty", () => {
+      setupSystemd({ apiKey: "" });
+
+      const content = mockWriteFileSync.mock.calls[0]![1] as string;
+      expect(content).not.toContain("BRIDGE_API_KEY");
+    });
+
+    it("uses custom port and host", () => {
+      setupSystemd({ port: "9999", host: "127.0.0.1" });
+
+      const content = mockWriteFileSync.mock.calls[0]![1] as string;
+      expect(content).toContain("Environment=BRIDGE_PORT=9999");
+      expect(content).toContain("Environment=BRIDGE_HOST=127.0.0.1");
+    });
+
+    it("creates directory when it does not exist", () => {
+      mockExistsSync.mockImplementation((p: string) => {
+        if (p.includes("systemd/user")) return false;
+        return true;
+      });
+
+      setupSystemd({});
+
+      expect(mockMkdirSync).toHaveBeenCalledWith(
+        "/home/testuser/.config/systemd/user",
+        { recursive: true },
+      );
+    });
+
+    it("calls systemctl daemon-reload, enable, and restart in order", () => {
+      setupSystemd({});
+
+      const systemctlCalls = mockExecSync.mock.calls
+        .map((c) => c[0] as string)
+        .filter((cmd: string) => cmd.includes("systemctl"));
+
+      expect(systemctlCalls).toEqual([
+        "systemctl --user daemon-reload",
+        'systemctl --user enable "ccpocket-bridge"',
+        'systemctl --user restart "ccpocket-bridge"',
+      ]);
+    });
+
+    it("exits with code 1 when npx is not found", () => {
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (cmd === "command -v npx") throw new Error("not found");
+        return "";
+      });
+
+      const mockExit = vi
+        .spyOn(process, "exit")
+        .mockImplementation(() => undefined as never);
+
+      setupSystemd({});
+
+      expect(mockExit).toHaveBeenCalledWith(1);
+      mockExit.mockRestore();
+    });
+  });
+
+  describe("uninstallSystemd", () => {
+    it("calls stop, disable, deletes file, and daemon-reload", () => {
+      mockExistsSync.mockReturnValue(true);
+
+      uninstallSystemd();
+
+      const allCmds = mockExecSync.mock.calls.map((c) => c[0] as string);
+      expect(allCmds).toContain(
+        'systemctl --user stop "ccpocket-bridge"',
+      );
+      expect(allCmds).toContain(
+        'systemctl --user disable "ccpocket-bridge"',
+      );
+      expect(allCmds).toContain("systemctl --user daemon-reload");
+      expect(mockUnlinkSync).toHaveBeenCalledWith(SERVICE_PATH);
+    });
+
+    it("does not delete file when it does not exist", () => {
+      mockExistsSync.mockImplementation((p: string) => {
+        if (p.endsWith(".service")) return false;
+        return true;
+      });
+
+      uninstallSystemd();
+
+      expect(mockUnlinkSync).not.toHaveBeenCalled();
+    });
+
+    it("handles systemctl errors gracefully", () => {
+      mockExecSync.mockImplementation(() => {
+        throw new Error("systemctl failed");
+      });
+      mockExistsSync.mockReturnValue(false);
+
+      expect(() => uninstallSystemd()).not.toThrow();
+    });
+  });
+});

--- a/packages/bridge/src/setup-systemd.ts
+++ b/packages/bridge/src/setup-systemd.ts
@@ -1,0 +1,125 @@
+import { execSync } from "node:child_process";
+import { existsSync, mkdirSync, writeFileSync, unlinkSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+const SERVICE_NAME = "ccpocket-bridge";
+
+function getServiceDir(): string {
+  const dir = join(homedir(), ".config", "systemd", "user");
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function getServicePath(): string {
+  return join(getServiceDir(), `${SERVICE_NAME}.service`);
+}
+
+export function uninstallSystemd(): void {
+  const servicePath = getServicePath();
+  console.log("==> Uninstalling Bridge Server service...");
+
+  try {
+    execSync(`systemctl --user stop "${SERVICE_NAME}"`, { stdio: "ignore" });
+  } catch {
+    /* ok */
+  }
+  try {
+    execSync(`systemctl --user disable "${SERVICE_NAME}"`, { stdio: "ignore" });
+  } catch {
+    /* ok */
+  }
+
+  if (existsSync(servicePath)) {
+    unlinkSync(servicePath);
+  }
+
+  try {
+    execSync("systemctl --user daemon-reload", { stdio: "ignore" });
+  } catch {
+    /* ok */
+  }
+
+  console.log("    Service removed.");
+}
+
+interface SetupOptions {
+  port?: string;
+  host?: string;
+  apiKey?: string;
+}
+
+export function setupSystemd(opts: SetupOptions): void {
+  const port = opts.port ?? process.env.BRIDGE_PORT ?? "8765";
+  const host = opts.host ?? process.env.BRIDGE_HOST ?? "0.0.0.0";
+  const apiKey = opts.apiKey ?? process.env.BRIDGE_API_KEY ?? "";
+  const servicePath = getServicePath();
+
+  // Resolve the npx binary path
+  let npxPath: string;
+  try {
+    npxPath = execSync("command -v npx", { encoding: "utf-8" }).trim();
+  } catch {
+    console.error("ERROR: npx not found in PATH. Install Node.js first.");
+    process.exit(1);
+    return; // unreachable, but helps TypeScript and tests
+  }
+  console.log(`==> npx: ${npxPath}`);
+
+  // Resolve the directory containing npx (and node)
+  // This is needed because systemd doesn't load .bashrc, so tools like
+  // nvm/mise/volta won't add node to PATH automatically.
+  const nodeBinDir = dirname(npxPath);
+
+  // Build environment lines
+  let envLines = `Environment=PATH=${nodeBinDir}:/usr/local/bin:/usr/bin:/bin
+Environment=BRIDGE_PORT=${port}
+Environment=BRIDGE_HOST=${host}`;
+
+  if (apiKey) {
+    envLines += `\nEnvironment=BRIDGE_API_KEY=${apiKey}`;
+  }
+
+  // Generate systemd user service unit
+  // Run npx directly with its full path. We set Environment=PATH to include
+  // the node bin directory so that npx can find node (since systemd doesn't
+  // load .bashrc/.profile where nvm/mise/volta set up PATH).
+  const unit = `[Unit]
+Description=CC Pocket Bridge Server
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=${npxPath} @ccpocket/bridge@latest
+${envLines}
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+`;
+
+  console.log(`==> Writing ${servicePath}`);
+  writeFileSync(servicePath, unit);
+
+  // Reload and enable
+  console.log("==> Registering service...");
+  execSync("systemctl --user daemon-reload");
+  execSync(`systemctl --user enable "${SERVICE_NAME}"`);
+
+  // Start the service
+  try {
+    execSync(`systemctl --user restart "${SERVICE_NAME}"`);
+    console.log(`==> Bridge Server started on port ${port}`);
+  } catch {
+    console.log(
+      "==> Service registered (start may have failed — check logs with: journalctl --user -u ccpocket-bridge)",
+    );
+  }
+
+  console.log("    Done.");
+  console.log("");
+  console.log(
+    "    Tip: Run `loginctl enable-linger $USER` to keep the service running after logout.",
+  );
+}


### PR DESCRIPTION
## 概要

こんにちは！CC Pocket を Linux で使いたかったので、`setup` コマンドの systemd 対応を実装しました。
Claude Code を使って開発しています。

現状 `npx @ccpocket/bridge setup` は macOS (launchd) のみ対応ですが、この PR で Linux (systemd) でも同じように使えるようになります。

## 変更内容

- **`setup-systemd.ts`** (新規): systemd user service の生成・登録・アンインストール
- **`cli.ts`**: `platform()` で macOS / Linux を自動判定して分岐
- **`doctor.ts`**: systemd サービスの状態チェックを追加
- **`setup-systemd.test.ts`** (新規): ユニットテスト 10 件

## 設計のポイント

### npx のフルパス解決 + PATH 設定

systemd の user service は `.bashrc` を読み込まないため、nvm / mise / volta 等でインストールした Node.js の PATH が通りません。
これに対応するため：

1. `setup` 実行時に `command -v npx` でフルパスを解決
2. `ExecStart` にフルパスを直接指定（例: `/home/user/.nvm/versions/node/v22.x/bin/npx`）
3. `Environment=PATH=` で node の bin ディレクトリを含めて設定

```ini
[Service]
ExecStart=/home/user/.nvm/versions/node/v22.15.0/bin/npx @ccpocket/bridge@latest
Environment=PATH=/home/user/.nvm/versions/node/v22.15.0/bin:/usr/local/bin:/usr/bin:/bin
```

### 既存の macOS 対応への影響なし

`cli.ts` で dynamic import + `platform()` 分岐しているため、macOS 側の挙動は一切変わりません。

## 動作確認

### ユニットテスト
- `setup-systemd.test.ts`: 10 件全パス

### 実環境テスト (Ubuntu 24.04 + nvm)

```
$ node dist/cli.js setup --port 8765
==> npx: /home/user/.nvm/versions/node/v24.12.0/bin/npx
==> Writing /home/user/.config/systemd/user/ccpocket-bridge.service
==> Registering service...
==> Bridge Server started on port 8765

$ systemctl --user status ccpocket-bridge
● ccpocket-bridge.service - CC Pocket Bridge Server
     Active: active (running)
```

### LXC コンテナでのマトリクステスト

3 ディストリ × 3 Node.js バージョンマネージャー = 9 パターンすべてパス:

| | nvm | mise | volta |
|---|---|---|---|
| **Ubuntu 24.04** | ✅ | ✅ | ✅ |
| **Debian 12** | ✅ | ✅ | ✅ |
| **Fedora 41** | ✅ | ✅ | ✅ |

各パターンで service ファイル生成 → `ExecStart` にフルパスが入っていること → `Environment=PATH` に node bin ディレクトリが含まれることを確認しました。

## 補足

- `loginctl enable-linger $USER` しないとログアウト後に user service が止まる場合があります。`setup` 完了時に Tip として表示しています。
- 未対応 OS (Windows 等) では明確なエラーメッセージを出して終了します。

🤖 Generated with [Claude Code](https://claude.ai/code)