### PR TITLE
feat(bridge): auto-enable loginctl linger on systemd setup

### DIFF
--- a/packages/bridge/src/setup-systemd.test.ts
+++ b/packages/bridge/src/setup-systemd.test.ts
@@ -119,6 +119,42 @@ describe("setup-systemd", () => {
       ]);
     });
 
+    it("enables linger when not already enabled", () => {
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (cmd === "command -v npx") return "/usr/bin/npx\n";
+        if (cmd.includes("show-user")) return "Linger=no\n";
+        return "";
+      });
+
+      setupSystemd({});
+
+      const allCmds = mockExecSync.mock.calls.map((c) => c[0] as string);
+      expect(allCmds).toContain("loginctl enable-linger $USER");
+    });
+
+    it("skips linger when already enabled", () => {
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (cmd === "command -v npx") return "/usr/bin/npx\n";
+        if (cmd.includes("show-user")) return "Linger=yes\n";
+        return "";
+      });
+
+      setupSystemd({});
+
+      const allCmds = mockExecSync.mock.calls.map((c) => c[0] as string);
+      expect(allCmds).not.toContain("loginctl enable-linger $USER");
+    });
+
+    it("handles linger check failure gracefully", () => {
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (cmd === "command -v npx") return "/usr/bin/npx\n";
+        if (cmd.includes("loginctl")) throw new Error("loginctl failed");
+        return "";
+      });
+
+      expect(() => setupSystemd({})).not.toThrow();
+    });
+
     it("exits with code 1 when npx is not found", () => {
       mockExecSync.mockImplementation((cmd: string) => {
         if (cmd === "command -v npx") throw new Error("not found");

--- a/packages/bridge/src/setup-systemd.ts
+++ b/packages/bridge/src/setup-systemd.ts
@@ -117,9 +117,23 @@ WantedBy=default.target
     );
   }
 
+  // Enable lingering so the user service persists after logout.
+  // Without this, systemd user services stop when the last session ends
+  // (e.g. SSH disconnect), which defeats the purpose of a background service.
+  try {
+    const lingerStatus = execSync("loginctl show-user $USER --property=Linger", {
+      encoding: "utf-8",
+    }).trim();
+    if (lingerStatus !== "Linger=yes") {
+      console.log("==> Enabling linger to keep service running after logout...");
+      execSync("loginctl enable-linger $USER");
+      console.log("    Linger enabled.");
+    }
+  } catch {
+    console.log(
+      "    Note: Could not enable linger. Run `loginctl enable-linger $USER` manually to keep the service running after logout.",
+    );
+  }
+
   console.log("    Done.");
-  console.log("");
-  console.log(
-    "    Tip: Run `loginctl enable-linger $USER` to keep the service running after logout.",
-  );
 }


### PR DESCRIPTION
## Summary / 概要

Sorry, this should have been included in the systemd support PR but I missed it! 🙇
すみません、前回のsystemd対応PRに含めるべきでしたが、漏れてしまいました！

Without `loginctl enable-linger`, systemd user services stop when the user's last session ends (e.g. SSH disconnect). This means the Bridge Server would silently stop running after logout — which defeats the purpose of registering it as a service.

`loginctl enable-linger` が無い場合、ユーザーの最後のセッション終了時（SSH切断など）にsystemd user serviceが停止してしまいます。つまり、ログアウト後にBridge Serverが知らないうちに止まってしまい、サービスとして登録した意味がなくなります。

## Changes / 変更内容

- **Auto-enable linger**: `setupSystemd()` now runs `loginctl enable-linger $USER` after service registration
- **Idempotent**: Checks `loginctl show-user $USER --property=Linger` first — skips if already `Linger=yes`
- **Graceful fallback**: If `loginctl` fails (e.g. permission issues, container environments), prints a note with the manual command instead of crashing
- **Tests**: 3 new test cases (enable / skip / failure handling), total 13 tests

- **linger自動有効化**: `setupSystemd()` でサービス登録後に `loginctl enable-linger $USER` を自動実行
- **冪等性**: 事前に `Linger=yes` か確認し、既に有効なら何もしない
- **フォールバック**: `loginctl` が失敗した場合（権限不足、コンテナ環境など）はクラッシュせず、手動コマンドを案内
- **テスト**: 3件追加（有効化 / スキップ / 失敗ハンドリング）、合計13件

## Verification / 動作確認

Tested across 3 distros using LXC containers:

LXCコンテナで3ディストリ検証:

| Distro | loginctl auto-enable | Fallback message | Service status |
|---|---|---|---|
| Ubuntu 24.04 | ❌ (LXC constraint) | ✅ Displayed | ✅ active (running) |
| Debian 12 | ❌ (LXC constraint) | ✅ Displayed | ✅ active (running) |
| Fedora 42 | ✅ Linger=yes | — | ✅ active (running) |

Also verified on a real Linux server (Ubuntu, nvm environment) — linger was successfully enabled and the Bridge Server persisted after SSH disconnect.

実機の Linux サーバー（Ubuntu, nvm環境）でも確認済み。lingerが有効化され、SSH切断後もBridge Serverが動き続けることを確認しました。

### Note on LXC ❌ results / LXC で ❌ になっている理由

Ubuntu and Debian showing ❌ for `loginctl auto-enable` is **not a bug** — it's a limitation of the LXC test environment. `loginctl` talks to the host's `systemd-logind`, but inside an LXC container there is no real login session, so it fails with "User ID 0 is not logged in or lingering". `systemctl --user` works fine because it uses the container's own systemd instance. Fedora 42 passed because its newer systemd (v257) handles this differently within LXC.

The ❌ results actually serve as validation that the **fallback path** (catch block → print manual command) works correctly.

Ubuntu と Debian で ❌ になっているのは**バグではなく、LXC テスト環境の制約**です。`loginctl` はホストの `systemd-logind` に問い合わせますが、LXC コンテナ内にはログインセッションが存在しないため失敗します。`systemctl --user` はコンテナ内の独自の systemd で動くので問題ありません。Fedora 42 は systemd v257 で LXC 内でも対応できたため成功しています。

❌ の結果はむしろ、**フォールバック処理（catchブロック → 手動コマンド案内）が正しく機能する**ことの検証になっています。

## Test plan

- [x] Unit tests pass (13/13)
- [x] `loginctl enable-linger` runs when `Linger=no`
- [x] Skipped when `Linger=yes`
- [x] Graceful fallback when `loginctl` unavailable
- [x] No impact on macOS (`setup-launchd.ts` unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)