### PR TITLE
fix(bridge): support ANTHROPIC_AUTH_TOKEN env var for authentication

### DIFF
--- a/packages/bridge/src/sdk-process.ts
+++ b/packages/bridge/src/sdk-process.ts
@@ -179,7 +179,7 @@ export function buildAuthError(
  */
 async function checkClaudeAuth(): Promise<AuthCheckResult> {
   // Skip auth check when using API key directly
-  if (process.env.ANTHROPIC_API_KEY) {
+  if (process.env.ANTHROPIC_API_KEY || process.env.ANTHROPIC_AUTH_TOKEN) {
     return { authenticated: true };
   }
   try {

--- a/packages/bridge/src/usage.ts
+++ b/packages/bridge/src/usage.ts
@@ -299,6 +299,14 @@ export async function getClaudeAuthStatus(): Promise<ClaudeAuthStatus> {
     };
   }
 
+  if (process.env.ANTHROPIC_AUTH_TOKEN) {
+    return {
+      authenticated: true,
+      source: "api_key",
+      message: "Authenticated with ANTHROPIC_AUTH_TOKEN.",
+    };
+  }
+
   try {
     const creds = await getClaudeOAuthCredentials();
     if (!creds.accessToken) {


### PR DESCRIPTION
## Summary
- Bridge server only checked `ANTHROPIC_API_KEY` to skip OAuth, causing users with `ANTHROPIC_AUTH_TOKEN` to get "not logged in" errors
- Now `checkClaudeAuth()` and `getClaudeAuthStatus()` both recognize `ANTHROPIC_AUTH_TOKEN` alongside `ANTHROPIC_API_KEY`

## Context
`ANTHROPIC_AUTH_TOKEN` is an officially supported authentication method for Claude Code ([docs](https://docs.anthropic.com/en/docs/claude-code/overview)). It allows users to authenticate without going through the OAuth login flow. The bridge server should recognize this env var the same way it already handles `ANTHROPIC_API_KEY`.