### PR TITLE
fix: set RunAtLoad and KeepAlive to true in setup-launchd

### DIFF
--- a/packages/bridge/src/setup-launchd.ts
+++ b/packages/bridge/src/setup-launchd.ts
@@ -82,10 +82,10 @@ ${envBlock}
     </dict>
 
     <key>RunAtLoad</key>
-    <false/>
+    <true/>
 
     <key>KeepAlive</key>
-    <false/>
+    <true/>
 
     <key>StandardOutPath</key>
     <string>/tmp/ccpocket-bridge.log</string>


### PR DESCRIPTION
## Summary

- `ccpocket-bridge setup` が生成する launchd plist で `RunAtLoad` と `KeepAlive` が `false` になっていたのを `true` に修正

Fixes #13

## Changes

- `packages/bridge/src/setup-launchd.ts`: `RunAtLoad` と `KeepAlive` を `<true/>` に変更（テンプレート plist `com.ccpocket.bridge.plist` と一致させる）

## Test plan

- [x] `ccpocket-bridge setup` を実行し、生成された plist で `RunAtLoad` と `KeepAlive` が `<true/>` であることを確認
- [x] サービスがログイン時に自動起動し、クラッシュ後に自動再起動することを確認（macOS 15, Node.js v22.16.0）

## Notes

### Prompt (for Prompt Request style contribution)

> `packages/bridge/src/setup-launchd.ts` の84〜88行目で、`RunAtLoad` と `KeepAlive` が `<false/>` にハードコードされている。テンプレート plist (`com.ccpocket.bridge.plist`) では両方 `<true/>` なので、setup コマンドの出力もそれに合わせて `<true/>` にする。