### PR TITLE
fix(mobile): reduce unnecessary rebuilds from Android notification shade

### DIFF
--- a/apps/mobile/lib/features/chat_session/widgets/bottom_overlay_layout.dart
+++ b/apps/mobile/lib/features/chat_session/widgets/bottom_overlay_layout.dart
@@ -45,7 +45,7 @@ class _BottomOverlayLayoutState extends State<BottomOverlayLayout> {
 
   @override
   Widget build(BuildContext context) {
-    final keyboardInset = MediaQuery.of(context).viewInsets.bottom;
+    final keyboardInset = MediaQuery.viewInsetsOf(context).bottom;
 
     return LayoutBuilder(
       builder: (context, constraints) {

--- a/apps/mobile/lib/features/chat_session/widgets/status_line_flexible_space.dart
+++ b/apps/mobile/lib/features/chat_session/widgets/status_line_flexible_space.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+
+import '../../../models/messages.dart';
+import 'status_line.dart';
+
+/// Isolates [MediaQuery.paddingOf] so only this widget rebuilds when system
+/// insets change (e.g. Android notification shade).
+class StatusLineFlexibleSpace extends StatelessWidget {
+  const StatusLineFlexibleSpace({
+    super.key,
+    required this.status,
+    required this.inPlanMode,
+  });
+
+  final ProcessStatus status;
+  final bool inPlanMode;
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        Positioned(
+          left: 0,
+          right: 0,
+          top: MediaQuery.paddingOf(context).top,
+          child: StatusLine(status: status, inPlanMode: inPlanMode),
+        ),
+      ],
+    );
+  }
+}

--- a/apps/mobile/lib/features/claude_session/claude_session_screen.dart
+++ b/apps/mobile/lib/features/claude_session/claude_session_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 
+import '../../hooks/use_app_resume_callback.dart';
 import '../../hooks/use_scroll_tracking.dart';
 import '../../l10n/app_localizations.dart';
 import '../../models/messages.dart';
@@ -39,7 +40,7 @@ import '../chat_session/widgets/chat_input_with_overlays.dart';
 import '../chat_session/widgets/chat_message_list.dart';
 import '../chat_session/widgets/reconnect_banner.dart';
 import '../chat_session/widgets/session_mode_bar.dart';
-import '../chat_session/widgets/status_line.dart';
+import '../chat_session/widgets/status_line_flexible_space.dart';
 import 'widgets/rewind_action_sheet.dart';
 import 'widgets/rewind_message_list_sheet.dart' show UserMessageHistorySheet;
 import 'widgets/usage_summary_bar.dart';
@@ -407,19 +408,13 @@ class _ChatScreenBody extends HookWidget {
     }, [sessionId]);
 
     // --- App resume: verify WebSocket health + refresh history ---
-    // If still connected, refresh history directly (BlocListener won't fire).
-    // If disconnected, ensureConnected triggers reconnect → BlocListener
-    // fires → refreshHistory is called there.
-    useEffect(() {
-      if (lifecycleState == AppLifecycleState.resumed) {
-        final bridge = context.read<BridgeService>();
-        bridge.ensureConnected();
-        if (bridge.isConnected) {
-          context.read<ChatSessionCubit>().refreshHistory();
-        }
+    useAppResumeCallback(lifecycleState, () {
+      final bridge = context.read<BridgeService>();
+      bridge.ensureConnected();
+      if (bridge.isConnected) {
+        context.read<ChatSessionCubit>().refreshHistory();
       }
-      return null;
-    }, [lifecycleState]);
+    });
 
     // --- Destructure state ---
     final status = sessionState.status;
@@ -545,15 +540,9 @@ class _ChatScreenBody extends HookWidget {
                 sessionId: sessionId,
                 projectPath: projectPath,
               ),
-              flexibleSpace: Stack(
-                children: [
-                  Positioned(
-                    left: 0,
-                    right: 0,
-                    top: MediaQuery.of(context).padding.top,
-                    child: StatusLine(status: status, inPlanMode: inPlanMode),
-                  ),
-                ],
+              flexibleSpace: StatusLineFlexibleSpace(
+                status: status,
+                inPlanMode: inPlanMode,
               ),
               actions: [
                 // View Changes button

--- a/apps/mobile/lib/features/codex_session/codex_session_screen.dart
+++ b/apps/mobile/lib/features/codex_session/codex_session_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 
+import '../../hooks/use_app_resume_callback.dart';
 import '../../hooks/use_scroll_tracking.dart';
 import '../../l10n/app_localizations.dart';
 import '../../models/messages.dart';
@@ -38,7 +39,7 @@ import '../chat_session/widgets/bottom_overlay_layout.dart';
 import '../chat_session/widgets/chat_message_list.dart';
 import '../chat_session/widgets/reconnect_banner.dart';
 import '../chat_session/widgets/session_mode_bar.dart';
-import '../chat_session/widgets/status_line.dart';
+import '../chat_session/widgets/status_line_flexible_space.dart';
 import '../../router/app_router.dart';
 import '../claude_session/widgets/rewind_message_list_sheet.dart'
     show UserMessageHistorySheet;
@@ -398,16 +399,13 @@ class _CodexChatBody extends HookWidget {
     }, [sessionId]);
 
     // --- App resume: verify WebSocket health + refresh history ---
-    useEffect(() {
-      if (lifecycleState == AppLifecycleState.resumed) {
-        final bridge = context.read<BridgeService>();
-        bridge.ensureConnected();
-        if (bridge.isConnected) {
-          context.read<ChatSessionCubit>().refreshHistory();
-        }
+    useAppResumeCallback(lifecycleState, () {
+      final bridge = context.read<BridgeService>();
+      bridge.ensureConnected();
+      if (bridge.isConnected) {
+        context.read<ChatSessionCubit>().refreshHistory();
       }
-      return null;
-    }, [lifecycleState]);
+    });
 
     // --- Destructure state ---
     final status = sessionState.status;
@@ -531,15 +529,9 @@ class _CodexChatBody extends HookWidget {
                 sessionId: sessionId,
                 projectPath: projectPath,
               ),
-              flexibleSpace: Stack(
-                children: [
-                  Positioned(
-                    left: 0,
-                    right: 0,
-                    top: MediaQuery.of(context).padding.top,
-                    child: StatusLine(status: status, inPlanMode: inPlanMode),
-                  ),
-                ],
+              flexibleSpace: StatusLineFlexibleSpace(
+                status: status,
+                inPlanMode: inPlanMode,
               ),
               actions: [
                 // View Changes button

--- a/apps/mobile/lib/hooks/use_app_resume_callback.dart
+++ b/apps/mobile/lib/hooks/use_app_resume_callback.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+
+/// Calls [onResume] only on genuine resume from background (paused/detached),
+/// not from inactive (e.g. Android notification shade).
+void useAppResumeCallback(
+  AppLifecycleState? lifecycleState,
+  VoidCallback onResume,
+) {
+  final prevLifecycleState = useRef<AppLifecycleState?>(null);
+  useEffect(() {
+    final prev = prevLifecycleState.value;
+    prevLifecycleState.value = lifecycleState;
+
+    if (lifecycleState == AppLifecycleState.resumed &&
+        (prev == AppLifecycleState.paused ||
+         prev == AppLifecycleState.detached)) {
+      onResume();
+    }
+    return null;
+  }, [lifecycleState]);
+}

--- a/apps/mobile/lib/hooks/use_scroll_tracking.dart
+++ b/apps/mobile/lib/hooks/use_scroll_tracking.dart
@@ -5,6 +5,10 @@ import 'package:scroll_to_index/scroll_to_index.dart';
 /// Cross-session scroll offset persistence.
 final Map<String, double> _scrollOffsets = {};
 
+/// Minimum change in maxScrollExtent (in logical pixels) to be considered a
+/// layout-driven shift rather than floating-point rounding noise.
+const _kExtentChangeTolerance = 1.0;
+
 /// Result record returned by [useScrollTracking].
 typedef ScrollTrackingResult = ({
   AutoScrollController controller,
@@ -18,8 +22,8 @@ typedef ScrollTrackingResult = ({
 ///    more than 100px from the bottom.
 /// 2. **Cross-session offset persistence**: Saves/restores scroll offset keyed
 ///    by [sessionId] so switching sessions preserves position.
-/// 3. **Scroll-to-bottom**: Provides a [scrollToBottom] callback that smoothly
-///    animates to the bottom (skipped when the user has scrolled up).
+/// 3. **Scroll-to-bottom**: Provides a [scrollToBottom] callback that jumps
+///    to the bottom (skipped when the user has scrolled up).
 ScrollTrackingResult useScrollTracking(String sessionId) {
   final controller = useMemoized(AutoScrollController.new);
   // Dispose the controller when the hook is disposed.
@@ -30,10 +34,28 @@ ScrollTrackingResult useScrollTracking(String sessionId) {
   // Ref to track isScrolledUp without rebuilds (for scrollToBottom closure).
   final isScrolledUpRef = useRef(false);
 
+  // Track previous maxScrollExtent to detect layout-driven changes
+  // (e.g. Android notification shade toggling safe-area padding).
+  final prevMaxExtent = useRef<double?>(null);
+
   useEffect(() {
     void onScroll() {
       if (!controller.hasClients) return;
       final pos = controller.position;
+
+      final prevMax = prevMaxExtent.value;
+      prevMaxExtent.value = pos.maxScrollExtent;
+
+      // When maxScrollExtent shifts (viewport/layout change) while we were
+      // already at the bottom, ignore this event — don't flip isScrolledUp.
+      // The framework will settle the scroll position on the next frame.
+      // This prevents the FAB from flashing when the Android notification
+      // shade is pulled down/up.
+      if (prevMax != null && !isScrolledUpRef.value) {
+        final extentDelta = (pos.maxScrollExtent - prevMax).abs();
+        if (extentDelta > _kExtentChangeTolerance) return;
+      }
+
       final scrolled = pos.pixels < pos.maxScrollExtent - 100;
       isScrolledUpRef.value = scrolled;
       if (scrolled != isScrolledUp.value) {
@@ -57,6 +79,7 @@ ScrollTrackingResult useScrollTracking(String sessionId) {
         _scrollOffsets[sessionId] = controller.offset;
       }
       controller.removeListener(onScroll);
+      prevMaxExtent.value = null;
     };
   }, [sessionId]);
 
@@ -64,11 +87,7 @@ ScrollTrackingResult useScrollTracking(String sessionId) {
     if (isScrolledUpRef.value) return;
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (controller.hasClients) {
-        controller.animateTo(
-          controller.position.maxScrollExtent,
-          duration: const Duration(milliseconds: 200),
-          curve: Curves.easeOut,
-        );
+        controller.jumpTo(controller.position.maxScrollExtent);
       }
     });
   }

--- a/apps/mobile/pubspec.lock
+++ b/apps/mobile/pubspec.lock
@@ -1053,10 +1053,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1722,26 +1722,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
+      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.29.0"
+    version: "1.30.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.10"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
+      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.15"
+    version: "0.6.16"
   timezone:
     dependency: transitive
     description:


### PR DESCRIPTION
## Problem

On Android, pulling down the notification shade causes three issues:

1. **Full screen repaint** — `MediaQuery.of(context).padding.top` is called directly in `build()` at the Scaffold level, making the entire widget tree depend on MediaQuery. When system insets change (notification shade), the entire screen rebuilds.

2. **Message duplicates and cost recalculation** — `useEffect([lifecycleState])` calls `refreshHistory()` on every return to `resumed`. On Android, the notification shade triggers `resumed → inactive → resumed` (without going through `paused`), causing a full history re-fetch and cost recalculation.

3. **Chat scroll jump and FAB appearing** — When `maxScrollExtent` changes due to layout shift (notification shade changes safe area), the scroll tracker incorrectly determines the user has scrolled up, showing the scroll-to-bottom FAB and shifting the position.

## Changes

- Replace `MediaQuery.of(context)` with `paddingOf`/`viewInsetsOf` to isolate rebuild scope
- Extract `StatusLineFlexibleSpace` to a shared widget in `chat_session/widgets/` (was duplicated in both session screens)
- Extract `useAppResumeCallback` hook that skips `inactive` lifecycle state — only triggers on genuine resume from `paused`/`detached`
- Ignore layout-driven `maxScrollExtent` shifts in scroll tracking to prevent FAB flicker
- Switch `scrollToBottom` from `animateTo` to `jumpTo` to prevent animation flicker

## Test environment

- **Device**: Android physical device (Pixel) via ADB
- **Tested**: Notification shade swipe down/up while chat is scrolled to bottom

## Test plan

- [x] Pull down Android notification shade — no screen repaint, no message duplicates, no cost recalculation
- [x] Chat stays at bottom position after shade toggle (no scroll jump, no FAB appearing)
- [ ] StatusLine renders correctly under AppBar on both Claude and Codex screens
- [ ] Send messages and verify auto-scroll works without flicker
- [ ] Minimize app to background and return — verify reconnect and history refresh still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)