### PR TITLE
feat(i18n): add Simplified Chinese support

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -2,7 +2,7 @@
 
 CC Pocket は、Claude Code / Codex のセッションをスマホだけで開始・完結できるアプリです。ラップトップを開く必要なし。アプリを開いて、プロジェクトを選んで、どこからでもコーディング。
 
-[English README](README.md)
+[English README](README.md) | [简体中文版 README](README.zh-CN.md)
 
 <p align="center">
   <img src="docs/images/screenshots-ja.png" alt="CC Pocket screenshots" width="800">

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 CC Pocket lets you start and run Claude Code and Codex sessions entirely from your phone. No laptop needed — just open the app, pick a project, and code from anywhere.
 
-[日本語版 README](README.ja.md)
+[日本語版 README](README.ja.md) | [简体中文版 README](README.zh-CN.md)
 
 <p align="center">
   <img src="docs/images/screenshots.png" alt="CC Pocket screenshots" width="800">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,277 @@
+# CC Pocket
+
+CC Pocket 是一款可以让你只用手机就启动并完成 Claude Code / Codex 会话的应用。不需要打开笔记本电脑，只要打开 App、选择项目，就能随时随地开始编码。
+
+[English README](README.md) | [日本語 README](README.ja.md)
+
+<p align="center">
+  <img src="docs/images/screenshots.png" alt="CC Pocket screenshots" width="800">
+</p>
+
+CC Pocket 与 Anthropic 或 OpenAI 没有任何关联，也未获得其认可、赞助或官方合作。
+
+## 为什么做 CC Pocket？
+
+AI 编程代理已经越来越接近能够自主完成整个功能开发。开发者的角色，也从“亲手写代码”逐渐转向“做判断” 例如批准工具调用、回答问题、审查 diff。
+
+做判断不需要键盘，只需要一块屏幕和一根手指。
+
+CC Pocket 就是围绕这种工作方式设计的：你在手机上发起会话，让自己机器上的 Claude Code / Codex 在后台执行，而你无论身在何处，都可以只做关键决策。
+
+## 适合谁用
+
+CC Pocket 面向已经在日常工作中依赖编程代理、并希望离开电脑时也能持续跟进会话的人。
+
+- **运行长时间代理会话的独立开发者**，例如使用 Mac mini、Raspberry Pi、Linux 服务器或笔记本
+- **希望在通勤、散步、外出时也能继续交付的独立开发者和创业者**
+- **同时管理多个会话、频繁处理审批请求的 AI Native 工程师**
+- **希望代码始终留在自己机器上，而不是托管在云 IDE 中的自托管用户**
+
+如果你的工作方式是“启动一个代理，让它跑起来，只在必要时介入”，那 CC Pocket 就是为你准备的。
+
+## 它的价值在哪里
+
+- **在手机上发起或恢复会话**，只要你的 Bridge Server 可以连通
+- **用触屏优先的 UI 快速处理审批**，而不是盯着终端提示
+- **实时查看流式输出**，包括计划、工具活动和代理回复
+- **更轻松地查看 diff**，支持语法高亮和图片差异预览
+- **写出更好的提示词**，支持 Markdown、自动补全列表和图片附件
+- **跟踪多个会话**，支持按项目分组、搜索和审批徽标
+- **在需要你操作时收到推送通知**，例如审批请求或任务完成
+- **使用你喜欢的连接方式**，包括已保存机器、二维码、mDNS 自动发现或手动输入 URL
+- **通过 SSH 管理远程主机**，完成启动、停止和更新流程
+
+## CC Pocket 和 Remote Control 的区别
+
+Claude Code 自带的 Remote Control 会把一个已经在 Mac 上启动的终端会话交接到手机上 也就是你先在桌面端开始，再从移动端继续。
+
+CC Pocket 走的是另一条路：**会话从手机发起，并在手机上完成整个流程。** 你的 Mac 在后台工作，而手机才是主界面。
+
+| | Remote Control | CC Pocket |
+|---|---------------|-----------|
+| 会话起点 | 先在 Mac 上开始，再交接给手机 | 直接从手机开始 |
+| 主要设备 | Mac（手机后续加入） | 手机（Mac 在后台执行） |
+| 典型场景 | 把桌面任务带到路上继续 | 随时随地直接开始编码 |
+| 配置方式 | Claude Code 内置 | 自托管 Bridge Server |
+
+**实际意味着：**
+- 你**可以**从手机直接启动一个全新的会话，并完整跑完
+- 你**可以**重新打开保存在 Mac 上的历史会话
+- 你**不能**接入一个已经直接在 Mac 上启动的实时会话
+
+## 快速开始
+
+<p align="center">
+  <img src="docs/images/install-banner.png" alt="CC Pocket — 30 秒完成设置" width="720">
+</p>
+
+### 1. 启动 Bridge Server
+
+在你的主机上安装 [Node.js](https://nodejs.org/) 18+，以及至少一个 CLI 提供方（[Claude Code](https://docs.anthropic.com/en/docs/claude-code) 或 [Codex](https://github.com/openai/codex)），然后运行：
+
+```bash
+npx @ccpocket/bridge@latest
+```
+
+服务启动后会在终端中打印一个二维码，你可以直接在 App 里扫描并快速连接。
+
+### 2. 安装移动端 App
+
+扫描上方横幅中的二维码，或者直接从应用商店下载：
+
+<div align="center">
+<a href="https://apps.apple.com/us/app/cc-pocket-dev-agent-remote/id6759188790"><img height="40" alt="Download on the App Store" src="docs/images/app-store-badge.svg" /></a>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="https://play.google.com/store/apps/details?id=com.k9i.ccpocket"><img height="40" alt="Get it on Google Play" src="docs/images/google-play-badge-en.svg" /></a>
+</div>
+
+### macOS 桌面版（Beta）
+
+我们也提供了原生的 macOS 应用。它最初只是一个实验，因为有些用户非常喜欢移动端优先的 UI，于是希望在 Mac 上也能获得同样的体验。
+
+它目前仍然是 Beta，但已经可以正常使用。你可以从 [GitHub Releases](https://github.com/K9i-0/ccpocket/releases?q=macos) 下载最新的 `.dmg`（查找带有 `macos/v*` 标签的发行版）。
+
+### 3. 连接并开始编码
+
+| 连接方式 | 最适合的场景 |
+|----------|--------------|
+| **二维码** | 首次配置最快速，直接扫描终端里的 QR |
+| **已保存机器** | 日常使用、重连和状态检查 |
+| **mDNS 自动发现** | 同一局域网中免输 IP |
+| **手动输入** | Tailscale、远程主机或自定义端口 |
+
+在 App 中选择项目和 permission mode，然后就可以启动会话。
+
+| Permission Mode | 行为 |
+|----------------|------|
+| `Default` | 标准交互模式 |
+| `Accept Edits` | 自动批准文件编辑，其他操作仍然询问 |
+| `Plan` | 保持在规划模式，直到你批准执行 |
+| `Bypass All` | 自动批准所有操作 |
+
+你也可以启用 **Worktree**，把每个会话隔离到独立的 git worktree 中。
+
+## Worktree 配置（`.gtrconfig`）
+
+在启动会话时启用 **Worktree** 后，应用会自动创建一个带独立分支和目录的 [git worktree](https://git-scm.com/docs/git-worktree)。这样你就可以在同一个项目上并行运行多个会话，而不会互相冲突。
+
+你可以在项目根目录放置一个 [`.gtrconfig`](https://github.com/coderabbitai/git-worktree-runner?tab=readme-ov-file#team-configuration-gtrconfig) 文件，配置文件复制规则和生命周期钩子：
+
+| 区块 | 键 | 说明 |
+|------|----|------|
+| `[copy]` | `include` | 需要复制的文件 glob，例如 `.env` 或配置文件 |
+| `[copy]` | `exclude` | 从复制中排除的 glob 模式 |
+| `[copy]` | `includeDirs` | 需要递归复制的目录名 |
+| `[copy]` | `excludeDirs` | 需要排除的目录名 |
+| `[hook]` | `postCreate` | worktree 创建后执行的 shell 命令 |
+| `[hook]` | `preRemove` | worktree 删除前执行的 shell 命令 |
+
+**提示：** 特别推荐把 `.claude/settings.local.json` 加进 `include`。这样每个 worktree 会话都能自动继承你的 MCP 服务器配置和权限设置。
+
+<details>
+<summary><code>.gtrconfig</code> 示例</summary>
+
+```ini
+[copy]
+# Claude Code 设置（MCP 服务器、权限、额外目录）
+include = .claude/settings.local.json
+
+# 复制 node_modules，加快 worktree 初始化
+includeDirs = node_modules
+
+[hook]
+# 创建 worktree 后恢复 Flutter 依赖
+postCreate = cd apps/mobile && flutter pub get
+```
+
+</details>
+
+## Sandbox 配置（Claude Code）
+
+当你在 App 中启用 sandbox mode 时，Claude Code 会使用它原生的 `.claude/settings.json`（或 `.claude/settings.local.json`）来读取更细粒度的 sandbox 配置。Bridge 端不需要单独配置。
+
+完整的 `sandbox` schema 请参考 [Claude Code 文档](https://docs.anthropic.com/en/docs/claude-code)。
+
+## 理想使用场景
+
+- **一台常驻在线的主机**（Mac mini、Raspberry Pi、Linux 服务器）运行代理，而你用手机远程盯进度
+- **一种轻量的移动审查循环**，代理负责写代码，而你只在需要时批准命令或回答问题
+- **跨多个项目并行运行多个会话**，所有待审批项都集中在一个移动端收件箱里
+- **通过 Tailscale 连接你自己的远程基础设施**，而不是把端口直接暴露到公网
+
+## 远程访问与机器管理
+
+### Tailscale
+
+如果你要在家庭或办公室网络之外访问 Bridge Server，最简单的方式就是 Tailscale。
+
+1. 在主机和手机上都安装 [Tailscale](https://tailscale.com/)
+2. 加入同一个 tailnet
+3. 在 App 中连接 `ws://<host-tailscale-ip>:8765`
+
+### 已保存机器与 SSH
+
+你可以在 App 中登记机器信息，包括 host、port、API key，以及可选的 SSH 凭据。
+
+启用 SSH 后，CC Pocket 可以直接在机器卡片上触发这些远程操作：
+
+- `Start`
+- `Stop Server`
+- `Update Bridge`
+
+这个流程支持 **macOS（launchd）** 和 **Linux（systemd）** 主机。
+
+### 服务化设置
+
+`setup` 命令会自动识别你的操作系统，并把 Bridge Server 注册成一个受管理的后台服务。
+
+```bash
+npx @ccpocket/bridge@latest setup
+npx @ccpocket/bridge@latest setup --port 9000 --api-key YOUR_KEY
+npx @ccpocket/bridge@latest setup --uninstall
+
+# 全局安装后的写法
+ccpocket-bridge setup
+```
+
+#### macOS（launchd）
+
+在 macOS 上，`setup` 会创建 launchd plist，并使用 `launchctl` 注册服务。服务通过 `zsh -li -c` 启动，因此能够继承你的 shell 环境（nvm、pyenv、Homebrew 等）。
+
+#### Linux（systemd）
+
+在 Linux 上，`setup` 会创建 systemd user service。它会在 setup 阶段解析 `npx` 的完整路径，从而确保 nvm、mise、volta 管理的 Node.js 也能在 systemd 下正常工作。
+
+> **提示：** 运行 `loginctl enable-linger $USER` 后，服务会在你退出登录后继续运行。
+
+## 平台说明
+
+- **Bridge Server**：只要 Node.js 和对应的 CLI 提供方能运行，就可以使用
+- **服务化设置**：支持 macOS（launchd）和 Linux（systemd）
+- **通过 App 使用 SSH 执行 start/stop/update**：要求主机是 macOS（launchd）或 Linux（systemd）
+- **窗口列表和截图能力**：仅支持 macOS 主机
+- **Tailscale**：不是必须，但强烈推荐用于远程访问
+
+如果你想搭一个整洁、稳定、长期在线的环境，目前最适合的主机依然是 Mac mini 或无头 Linux 机器。
+
+## 截图功能所需的主机配置
+
+如果你要在 macOS 上使用截图功能，请为运行 Bridge Server 的终端应用授予 **屏幕录制** 权限。
+
+否则，`screencapture` 可能会返回全黑的图片。
+
+路径：
+
+`系统设置 -> 隐私与安全性 -> 屏幕录制`
+
+如果你的主机是长期在线的，为了让窗口截图更稳定，也建议关闭显示器休眠和自动锁屏。
+
+```bash
+sudo pmset -a displaysleep 0 sleep 0
+```
+
+## 开发
+
+### 仓库结构
+
+```text
+ccpocket/
+├── packages/bridge/    # Bridge Server (TypeScript, WebSocket)
+├── apps/mobile/        # Flutter mobile app
+└── package.json        # npm workspaces root
+```
+
+### 从源码构建
+
+```bash
+git clone https://github.com/K9i-0/ccpocket.git
+cd ccpocket
+npm install
+cd apps/mobile && flutter pub get && cd ../..
+```
+
+### 常用命令
+
+| 命令 | 说明 |
+|------|------|
+| `npm run bridge` | 以开发模式启动 Bridge Server |
+| `npm run bridge:build` | 构建 Bridge Server |
+| `npm run dev` | 重启 Bridge 并启动 Flutter 应用 |
+| `npm run dev -- <device-id>` | 与上面相同，但指定设备 |
+| `npm run setup` | 将 Bridge Server 注册为后台服务（launchd/systemd） |
+| `npm run test:bridge` | 运行 Bridge Server 测试 |
+| `cd apps/mobile && flutter test` | 运行 Flutter 测试 |
+| `cd apps/mobile && dart analyze` | 运行 Dart 静态分析 |
+
+### 环境变量
+
+| 变量 | 默认值 | 说明 |
+|------|--------|------|
+| `BRIDGE_PORT` | `8765` | WebSocket 端口 |
+| `BRIDGE_HOST` | `0.0.0.0` | 绑定地址 |
+| `BRIDGE_API_KEY` | 未设置 | 启用 API key 认证 |
+| `BRIDGE_ALLOWED_DIRS` | `$HOME` | 允许访问的项目目录，逗号分隔 |
+| `DIFF_IMAGE_AUTO_DISPLAY_KB` | `1024` | 图片 diff 自动显示阈值 |
+| `DIFF_IMAGE_MAX_SIZE_MB` | `5` | diff 图片预览允许的最大大小 |
+
+## 许可证
+
+[FSL-1.1-MIT](LICENSE) — 源码可用，并将于 2028-03-17 自动转换为 MIT。

--- a/apps/mobile/android/app/build.gradle.kts
+++ b/apps/mobile/android/app/build.gradle.kts
@@ -52,7 +52,9 @@ if (keystorePropertiesFile.exists()) {
 android {
     namespace = "com.k9i.ccpocket"
     compileSdk = flutter.compileSdkVersion
-    ndkVersion = flutter.ndkVersion
+    // Align with the highest NDK required by native plugins to avoid
+    // repeated side-by-side NDK resolution during local Android builds.
+    ndkVersion = "29.0.13846066"
 
     compileOptions {
         isCoreLibraryDesugaringEnabled = true

--- a/apps/mobile/assets/docs/auth-troubleshooting.zh-CN.md
+++ b/apps/mobile/assets/docs/auth-troubleshooting.zh-CN.md
@@ -1,0 +1,39 @@
+# Claude 认证故障排查
+
+CC Pocket 会使用保存在你的 Bridge 机器上的 Claude Code 登录状态。
+如果认证失败，请在那台机器上重新登录 Claude Code。
+
+## 当你不在 Bridge 机器旁边时
+
+在 CC Pocket 的使用场景里，你的 Bridge 机器可能是家里的 Mac mini，或者另一台一直开着的 Mac。
+即使如此，你也可以直接用手机远程重新登录 Claude Code。
+
+1. 用终端应用连接到 Bridge 机器
+   - 可以使用 Moshi、Termius、Blink 或任意 SSH 客户端
+2. 运行 `claude`
+3. 在 Claude Code 中执行 `/login`
+4. 在手机或电脑浏览器中打开显示出来的 URL
+5. 完成登录
+6. 如果终端提示需要粘贴结果，就把结果贴回去
+
+从下一次请求开始，CC Pocket 就会使用更新后的登录状态。
+
+## 当你就在 Bridge 机器旁边时
+
+1. 在 Bridge 机器上运行 `claude`
+2. 执行 `/login`
+3. 在浏览器中完成登录流程
+
+## Shell 方式
+
+如果你愿意，也可以直接运行下面的命令：
+
+```bash
+claude auth login
+```
+
+## 常见原因
+
+- 你的 Claude 登录已过期
+- Claude Code 更新后，旧的登录状态失效了
+- Anthropic 撤销了已保存的令牌

--- a/apps/mobile/lib/features/chat_session/widgets/reconnect_banner.dart
+++ b/apps/mobile/lib/features/chat_session/widgets/reconnect_banner.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../../l10n/app_localizations.dart';
 import '../../../models/messages.dart';
 
 class ReconnectBanner extends StatelessWidget {
@@ -10,6 +11,7 @@ class ReconnectBanner extends StatelessWidget {
   Widget build(BuildContext context) {
     final isReconnecting = bridgeState == BridgeConnectionState.reconnecting;
     final errorColor = Theme.of(context).colorScheme.error;
+    final l = AppLocalizations.of(context);
     return Container(
       width: double.infinity,
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
@@ -26,7 +28,7 @@ class ReconnectBanner extends StatelessWidget {
             Icon(Icons.cloud_off, size: 16, color: errorColor),
           const SizedBox(width: 8),
           Text(
-            isReconnecting ? 'Reconnecting...' : 'Disconnected',
+            isReconnecting ? l.reconnecting : l.disconnected,
             style: TextStyle(
               fontSize: 13,
               fontWeight: FontWeight.w500,

--- a/apps/mobile/lib/features/chat_session/widgets/session_mode_bar.dart
+++ b/apps/mobile/lib/features/chat_session/widgets/session_mode_bar.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
+import '../../../l10n/app_localizations.dart';
 import '../../../models/messages.dart';
 import '../../../theme/app_theme.dart';
 import '../state/chat_session_cubit.dart';
@@ -246,6 +247,7 @@ class _RotatingBorderPainter extends CustomPainter {
 void showPermissionModeMenu(BuildContext context, ChatSessionCubit chatCubit) {
   final currentMode = chatCubit.state.permissionMode;
   final appColors = Theme.of(context).extension<AppColors>()!;
+  final l = AppLocalizations.of(context);
 
   const purple = Color(0xFFBB86FC);
 
@@ -253,22 +255,22 @@ void showPermissionModeMenu(BuildContext context, ChatSessionCubit chatCubit) {
       <PermissionMode, ({IconData icon, String description, Color color})>{
         PermissionMode.defaultMode: (
           icon: Icons.tune,
-          description: 'Standard permission prompts',
+          description: l.permissionDefaultDescription,
           color: Theme.of(context).colorScheme.onSurfaceVariant,
         ),
         PermissionMode.acceptEdits: (
           icon: Icons.edit_note,
-          description: 'Auto-approve file edits',
+          description: l.permissionAcceptEditsDescription,
           color: purple,
         ),
         PermissionMode.plan: (
           icon: Icons.assignment,
-          description: 'Analyze & plan without executing',
+          description: l.permissionPlanDescription,
           color: appColors.statusPlan,
         ),
         PermissionMode.bypassPermissions: (
           icon: Icons.flash_on,
-          description: 'Skip all permission prompts',
+          description: l.permissionBypassDescription,
           color: Theme.of(context).colorScheme.error,
         ),
       };
@@ -286,7 +288,7 @@ void showPermissionModeMenu(BuildContext context, ChatSessionCubit chatCubit) {
               child: Align(
                 alignment: Alignment.centerLeft,
                 child: Text(
-                  'Permission Mode',
+                  l.permissionModeTitle,
                   style: TextStyle(
                     fontSize: 14,
                     fontWeight: FontWeight.w600,
@@ -303,7 +305,7 @@ void showPermissionModeMenu(BuildContext context, ChatSessionCubit chatCubit) {
                       ? modeDetails[mode]!.color
                       : sheetCs.onSurfaceVariant,
                 ),
-                title: Text(mode.label),
+                title: Text(_permissionModeLabel(l, mode)),
                 subtitle: Text(
                   modeDetails[mode]!.description,
                   style: const TextStyle(fontSize: 12),
@@ -341,27 +343,27 @@ Future<void> _confirmPermissionModeChange(
   ChatSessionCubit chatCubit,
   PermissionMode mode,
 ) async {
+  final l = AppLocalizations.of(context);
   final confirmed = await showDialog<bool>(
     context: context,
     builder: (dialogContext) {
       final cs = Theme.of(dialogContext).colorScheme;
       return AlertDialog(
-        title: const Text('Change Permission Mode'),
+        title: Text(l.changePermissionModeTitle),
         content: Text(
-          'Switching to ${mode.label} will restart the session. '
-          'Your conversation will be preserved.',
+          l.changePermissionModeBody(_permissionModeLabel(l, mode)),
         ),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(dialogContext, false),
-            child: const Text('Cancel'),
+            child: Text(l.cancel),
           ),
           FilledButton(
             onPressed: () => Navigator.pop(dialogContext, true),
             style: mode == PermissionMode.bypassPermissions
                 ? FilledButton.styleFrom(backgroundColor: cs.error)
                 : null,
-            child: const Text('Restart'),
+            child: Text(l.restart),
           ),
         ],
       );
@@ -375,6 +377,7 @@ Future<void> _confirmPermissionModeChange(
 void showSandboxModeMenu(BuildContext context, ChatSessionCubit chatCubit) {
   final currentMode = chatCubit.state.sandboxMode;
   final isClaude = chatCubit.provider != Provider.codex;
+  final l = AppLocalizations.of(context);
 
   showModalBottomSheet(
     context: context,
@@ -389,7 +392,7 @@ void showSandboxModeMenu(BuildContext context, ChatSessionCubit chatCubit) {
               child: Align(
                 alignment: Alignment.centerLeft,
                 child: Text(
-                  'Sandbox Mode',
+                  l.sandboxModeTitle,
                   style: TextStyle(
                     fontSize: 14,
                     fontWeight: FontWeight.w600,
@@ -408,7 +411,7 @@ void showSandboxModeMenu(BuildContext context, ChatSessionCubit chatCubit) {
                       : _sandboxMenuIconColor(mode, isClaude, sheetCs),
                 ),
                 title: Text(
-                  _sandboxMenuTitle(mode, isClaude),
+                  _sandboxMenuTitle(l, mode, isClaude),
                   style: TextStyle(
                     color:
                         !isClaude &&
@@ -419,7 +422,7 @@ void showSandboxModeMenu(BuildContext context, ChatSessionCubit chatCubit) {
                   ),
                 ),
                 subtitle: Text(
-                  _sandboxMenuSubtitle(mode, isClaude),
+                  _sandboxMenuSubtitle(l, mode, isClaude),
                   style: const TextStyle(fontSize: 12),
                 ),
                 trailing: mode == currentMode
@@ -455,22 +458,26 @@ Color _sandboxMenuIconColor(SandboxMode mode, bool isClaude, ColorScheme cs) {
   return cs.onSurfaceVariant;
 }
 
-String _sandboxMenuTitle(SandboxMode mode, bool isClaude) {
+String _sandboxMenuTitle(AppLocalizations l, SandboxMode mode, bool isClaude) {
   if (isClaude) {
-    return mode == SandboxMode.on ? 'Sandbox (Safe Mode)' : 'Standard';
+    return mode == SandboxMode.on ? l.sandboxSafeMode : l.sandboxStandard;
   }
-  return mode == SandboxMode.on ? 'Sandbox On' : 'Sandbox Off';
+  return mode == SandboxMode.on ? l.sandboxOnLabel : l.sandboxOffLabel;
 }
 
-String _sandboxMenuSubtitle(SandboxMode mode, bool isClaude) {
+String _sandboxMenuSubtitle(
+  AppLocalizations l,
+  SandboxMode mode,
+  bool isClaude,
+) {
   if (isClaude) {
     return mode == SandboxMode.on
-        ? 'Run commands in restricted environment'
-        : 'Run commands natively';
+        ? l.sandboxRestrictedDescription
+        : l.sandboxNativeDescription;
   }
   return mode == SandboxMode.on
-      ? 'Run commands in restricted environment'
-      : 'Run commands natively (CAUTION)';
+      ? l.sandboxRestrictedDescription
+      : l.sandboxNativeCautionDescription;
 }
 
 /// Show confirmation dialog before changing sandbox mode, because
@@ -481,9 +488,10 @@ Future<void> _confirmSandboxModeChange(
   SandboxMode mode, {
   bool isClaude = false,
 }) async {
+  final l = AppLocalizations.of(context);
   final modeLabel = isClaude
-      ? (mode == SandboxMode.on ? 'Sandbox (Safe Mode)' : 'Standard')
-      : mode.label;
+      ? (mode == SandboxMode.on ? l.sandboxSafeMode : l.sandboxStandard)
+      : (mode == SandboxMode.on ? l.sandboxOnLabel : l.sandboxOffLabel);
   final confirmed = await showDialog<bool>(
     context: context,
     builder: (dialogContext) {
@@ -492,22 +500,19 @@ Future<void> _confirmSandboxModeChange(
       // For Claude, turning off is standard — no red.
       final useErrorStyle = mode == SandboxMode.off && !isClaude;
       return AlertDialog(
-        title: const Text('Change Sandbox Mode'),
-        content: Text(
-          'Switching to $modeLabel will restart the session. '
-          'Your conversation will be preserved.',
-        ),
+        title: Text(l.changeSandboxModeTitle),
+        content: Text(l.changeSandboxModeBody(modeLabel)),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(dialogContext, false),
-            child: const Text('Cancel'),
+            child: Text(l.cancel),
           ),
           FilledButton(
             onPressed: () => Navigator.pop(dialogContext, true),
             style: useErrorStyle
                 ? FilledButton.styleFrom(backgroundColor: cs.error)
                 : null,
-            child: const Text('Restart'),
+            child: Text(l.restart),
           ),
         ],
       );
@@ -532,6 +537,7 @@ class PermissionModeChip extends StatelessWidget {
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final appColors = Theme.of(context).extension<AppColors>()!;
+    final l = AppLocalizations.of(context);
 
     // Colors aligned with Claude Code CLI
     const purple = Color(0xFFBB86FC);
@@ -539,12 +545,24 @@ class PermissionModeChip extends StatelessWidget {
     final (IconData icon, String label, Color fg) = switch (currentMode) {
       PermissionMode.defaultMode => (
         Icons.tune,
-        'Default',
+        l.defaultLabel,
         cs.onSurfaceVariant,
       ),
-      PermissionMode.acceptEdits => (Icons.edit_note, 'Edits', purple),
-      PermissionMode.plan => (Icons.assignment, 'Plan', appColors.statusPlan),
-      PermissionMode.bypassPermissions => (Icons.flash_on, 'Bypass', cs.error),
+      PermissionMode.acceptEdits => (
+        Icons.edit_note,
+        l.permissionChipAcceptEdits,
+        purple,
+      ),
+      PermissionMode.plan => (
+        Icons.assignment,
+        l.permissionPlanMode,
+        appColors.statusPlan,
+      ),
+      PermissionMode.bypassPermissions => (
+        Icons.flash_on,
+        l.permissionChipBypass,
+        cs.error,
+      ),
     };
 
     return Material(
@@ -597,13 +615,14 @@ class SandboxModeChip extends StatelessWidget {
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final isClaude = provider != Provider.codex;
+    final l = AppLocalizations.of(context);
 
     final (IconData icon, String label, Color fg) = switch (currentMode) {
-      SandboxMode.on => (Icons.shield_outlined, 'Sandbox', cs.tertiary),
+      SandboxMode.on => (Icons.shield_outlined, l.sandbox, cs.tertiary),
       SandboxMode.off =>
         isClaude
-            ? (Icons.code, 'Standard', cs.onSurfaceVariant)
-            : (Icons.warning_amber, 'No SB', cs.error),
+            ? (Icons.code, l.sandboxStandard, cs.onSurfaceVariant)
+            : (Icons.warning_amber, l.sandboxChipOff, cs.error),
     };
 
     return Material(
@@ -638,4 +657,13 @@ class SandboxModeChip extends StatelessWidget {
       ),
     );
   }
+}
+
+String _permissionModeLabel(AppLocalizations l, PermissionMode mode) {
+  return switch (mode) {
+    PermissionMode.defaultMode => l.permissionDefaultMode,
+    PermissionMode.acceptEdits => l.permissionAcceptEditsMode,
+    PermissionMode.plan => l.permissionPlanMode,
+    PermissionMode.bypassPermissions => l.permissionBypassMode,
+  };
 }

--- a/apps/mobile/lib/features/chat_session/widgets/status_indicator.dart
+++ b/apps/mobile/lib/features/chat_session/widgets/status_indicator.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 
+import '../../../l10n/app_localizations.dart';
 import '../../../models/messages.dart';
 import '../../../theme/app_theme.dart';
 
@@ -22,6 +23,7 @@ class StatusIndicator extends HookWidget {
   @override
   Widget build(BuildContext context) {
     final appColors = Theme.of(context).extension<AppColors>()!;
+    final l = AppLocalizations.of(context);
 
     // Track elapsed time when running/starting
     final isActive =
@@ -58,17 +60,23 @@ class StatusIndicator extends HookWidget {
     }, [isActive, startTime.value]);
 
     final (color, label) = switch (status) {
-      ProcessStatus.starting => (appColors.statusStarting, 'Starting'),
+      ProcessStatus.starting => (appColors.statusStarting, l.statusStarting),
       ProcessStatus.idle =>
         inPlanMode
-            ? (appColors.statusPlan, 'Plan')
-            : (appColors.statusIdle, 'Idle'),
+            ? (appColors.statusPlan, l.permissionPlanMode)
+            : (appColors.statusIdle, l.statusIdle),
       ProcessStatus.running =>
         inPlanMode
-            ? (appColors.statusPlan, 'Plan')
-            : (appColors.statusOnline, 'Running'),
-      ProcessStatus.waitingApproval => (appColors.statusApproval, 'Approval'),
-      ProcessStatus.compacting => (appColors.statusCompacting, 'Compacting'),
+            ? (appColors.statusPlan, l.permissionPlanMode)
+            : (appColors.statusOnline, l.statusRunning),
+      ProcessStatus.waitingApproval => (
+        appColors.statusApproval,
+        l.statusApproval,
+      ),
+      ProcessStatus.compacting => (
+        appColors.statusCompacting,
+        l.statusCompacting,
+      ),
     };
 
     // Format elapsed time

--- a/apps/mobile/lib/features/claude_session/claude_session_screen.dart
+++ b/apps/mobile/lib/features/claude_session/claude_session_screen.dart
@@ -376,6 +376,7 @@ class _ChatScreenBody extends HookWidget {
       final sub = context.read<ChatSessionCubit>().sideEffects.listen(
         (effects) => _executeSideEffects(
           effects,
+          l: l,
           sessionId: sessionId,
           isBackground: isBackground,
           collapseToolResults: collapseToolResults,
@@ -875,6 +876,7 @@ Future<void> _openDiffScreen(
 
 void _executeSideEffects(
   Set<ChatSideEffect> effects, {
+  required AppLocalizations l,
   required String sessionId,
   required bool isBackground,
   required ValueNotifier<int> collapseToolResults,
@@ -896,8 +898,8 @@ void _executeSideEffects(
       case ChatSideEffect.notifyApprovalRequired:
         if (isBackground) {
           NotificationService.instance.show(
-            title: 'Approval Required',
-            body: 'Tool approval needed',
+            title: l.approvalRequired,
+            body: l.toolApprovalNeeded,
             id: 1,
             payload: sessionId,
           );
@@ -905,8 +907,8 @@ void _executeSideEffects(
       case ChatSideEffect.notifyAskQuestion:
         if (isBackground) {
           NotificationService.instance.show(
-            title: 'Claude is asking',
-            body: 'Question needs your answer',
+            title: l.claudeIsAsking,
+            body: l.questionNeedsYourAnswer,
             id: 2,
             payload: sessionId,
           );
@@ -914,8 +916,8 @@ void _executeSideEffects(
       case ChatSideEffect.notifySessionComplete:
         if (isBackground) {
           NotificationService.instance.show(
-            title: 'Session Complete',
-            body: 'Session done',
+            title: l.sessionCompleteTitle,
+            body: l.sessionDone,
             id: 3,
             payload: sessionId,
           );

--- a/apps/mobile/lib/features/claude_session/widgets/rewind_message_list_sheet.dart
+++ b/apps/mobile/lib/features/claude_session/widgets/rewind_message_list_sheet.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../../l10n/app_localizations.dart';
 import '../../../models/messages.dart';
 import '../../../theme/app_theme.dart';
 
@@ -24,6 +25,7 @@ class UserMessageHistorySheet extends StatelessWidget {
   Widget build(BuildContext context) {
     final appColors = Theme.of(context).extension<AppColors>()!;
     final colorScheme = Theme.of(context).colorScheme;
+    final l = AppLocalizations.of(context);
 
     return DraggableScrollableSheet(
       initialChildSize: 0.6,
@@ -56,14 +58,14 @@ class UserMessageHistorySheet extends StatelessWidget {
                   Icon(Icons.history, size: 20, color: colorScheme.primary),
                   const SizedBox(width: 8),
                   Text(
-                    'Message History',
+                    l.messageHistory,
                     style: Theme.of(context).textTheme.titleMedium?.copyWith(
                       fontWeight: FontWeight.w600,
                     ),
                   ),
                   const Spacer(),
                   Text(
-                    '${messages.length} message${messages.length == 1 ? '' : 's'}',
+                    l.messageHistoryCount(messages.length),
                     style: Theme.of(context).textTheme.bodySmall?.copyWith(
                       color: appColors.subtleText,
                     ),
@@ -88,14 +90,14 @@ class UserMessageHistorySheet extends StatelessWidget {
                       ),
                       const SizedBox(height: 12),
                       Text(
-                        'No messages yet',
+                        l.noMessagesYet,
                         style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                           color: appColors.subtleText,
                         ),
                       ),
                       const SizedBox(height: 4),
                       Text(
-                        'Messages will appear here after Claude processes them',
+                        l.messagesAppearAfterProcessing,
                         style: Theme.of(context).textTheme.bodySmall?.copyWith(
                           color: appColors.subtleText,
                         ),

--- a/apps/mobile/lib/features/codex_session/codex_session_screen.dart
+++ b/apps/mobile/lib/features/codex_session/codex_session_screen.dart
@@ -301,6 +301,7 @@ class _CodexChatBody extends HookWidget {
   @override
   Widget build(BuildContext context) {
     final appColors = Theme.of(context).extension<AppColors>()!;
+    final l = AppLocalizations.of(context);
     // Mutable branch state (refreshed from Bridge)
     final currentBranch = useState(gitBranch);
 
@@ -367,6 +368,7 @@ class _CodexChatBody extends HookWidget {
       final sub = context.read<ChatSessionCubit>().sideEffects.listen(
         (effects) => _executeSideEffects(
           effects,
+          l: l,
           sessionId: sessionId,
           isBackground: isBackground,
           collapseToolResults: collapseToolResults,
@@ -614,43 +616,43 @@ class _CodexChatBody extends HookWidget {
                         .terminalApp;
                     final l = AppLocalizations.of(context);
                     return [
-                      const PopupMenuItem(
+                      PopupMenuItem(
                         key: ValueKey('menu_rename'),
                         value: 'rename',
                         child: ListTile(
                           leading: Icon(Icons.edit_outlined, size: 20),
-                          title: Text('Rename'),
+                          title: Text(l.rename),
                           dense: true,
                           contentPadding: EdgeInsets.zero,
                         ),
                       ),
-                      const PopupMenuItem(
+                      PopupMenuItem(
                         key: ValueKey('menu_message_history'),
                         value: 'history',
                         child: ListTile(
                           leading: Icon(Icons.chat_outlined, size: 20),
-                          title: Text('Message History'),
+                          title: Text(l.messageHistory),
                           dense: true,
                           contentPadding: EdgeInsets.zero,
                         ),
                       ),
                       if (projectPath != null)
-                        const PopupMenuItem(
+                        PopupMenuItem(
                           key: ValueKey('menu_screenshot'),
                           value: 'screenshot',
                           child: ListTile(
                             leading: Icon(Icons.screenshot_monitor, size: 20),
-                            title: Text('Screenshot'),
+                            title: Text(l.screenshot),
                             dense: true,
                             contentPadding: EdgeInsets.zero,
                           ),
                         ),
-                      const PopupMenuItem(
+                      PopupMenuItem(
                         key: ValueKey('menu_gallery'),
                         value: 'gallery',
                         child: ListTile(
                           leading: Icon(Icons.collections, size: 20),
-                          title: Text('Gallery'),
+                          title: Text(l.gallery),
                           dense: true,
                           contentPadding: EdgeInsets.zero,
                         ),
@@ -826,7 +828,9 @@ class _CodexChatBody extends HookWidget {
                     status: status,
                     onScrollToBottom: scroll.scrollToBottom,
                     inputController: chatInputController,
-                    hintText: 'Message Codex...',
+                    hintText: AppLocalizations.of(
+                      context,
+                    ).messageProviderPlaceholder('Codex'),
                     initialDiffSelection: diffSelectionFromNav.value,
                     onDiffSelectionConsumed: () {},
                     onDiffSelectionCleared: () =>
@@ -874,6 +878,7 @@ Future<void> _openDiffScreen(
 
 void _executeSideEffects(
   Set<ChatSideEffect> effects, {
+  required AppLocalizations l,
   required String sessionId,
   required bool isBackground,
   required TextEditingController planFeedbackController,
@@ -895,8 +900,8 @@ void _executeSideEffects(
       case ChatSideEffect.notifyApprovalRequired:
         if (isBackground) {
           NotificationService.instance.show(
-            title: 'Approval Required',
-            body: 'Codex tool approval needed',
+            title: l.approvalRequired,
+            body: l.codexToolApprovalNeeded,
             id: 1,
             payload: sessionId,
           );
@@ -904,8 +909,8 @@ void _executeSideEffects(
       case ChatSideEffect.notifyAskQuestion:
         if (isBackground) {
           NotificationService.instance.show(
-            title: 'Codex is asking',
-            body: 'Question needs your answer',
+            title: l.codexIsAsking,
+            body: l.questionNeedsYourAnswer,
             id: 2,
             payload: sessionId,
           );
@@ -913,8 +918,8 @@ void _executeSideEffects(
       case ChatSideEffect.notifySessionComplete:
         if (isBackground) {
           NotificationService.instance.show(
-            title: 'Session Complete',
-            body: 'Codex session done',
+            title: l.sessionCompleteTitle,
+            body: l.codexSessionDone,
             id: 3,
             payload: sessionId,
           );

--- a/apps/mobile/lib/features/session_list/session_list_screen.dart
+++ b/apps/mobile/lib/features/session_list/session_list_screen.dart
@@ -1225,7 +1225,7 @@ class _SessionListScreenState extends State<SessionListScreen>
                               key: const ValueKey('new_session_fab'),
                               onPressed: _showNewSessionDialog,
                               icon: const Icon(Icons.add),
-                              label: const Text('New'),
+                              label: Text(l.newShort),
                             ),
                           )
                         : null,

--- a/apps/mobile/lib/features/session_list/widgets/home_content.dart
+++ b/apps/mobile/lib/features/session_list/widgets/home_content.dart
@@ -262,7 +262,7 @@ class HomeContentState extends State<HomeContent> {
             ?appUpdateBanner,
             SectionHeader(
               icon: Icons.history,
-              label: 'Recent Sessions',
+              label: l.recentSessions,
               color: appColors.subtleText,
             ),
             const SizedBox(height: 8),
@@ -294,7 +294,7 @@ class HomeContentState extends State<HomeContent> {
         if (hasRunningSessions) ...[
           SectionHeader(
             icon: Icons.play_circle_filled,
-            label: 'Running',
+            label: l.runningSessions,
             color: appColors.statusOnline,
           ),
           const SizedBox(height: 4),
@@ -370,7 +370,7 @@ class HomeContentState extends State<HomeContent> {
             hasActiveFilter) ...[
           SectionHeader(
             icon: Icons.history,
-            label: 'Recent Sessions',
+            label: l.recentSessions,
             color: appColors.subtleText,
             trailing: IconButton(
               key: const ValueKey('search_button'),
@@ -380,7 +380,7 @@ class HomeContentState extends State<HomeContent> {
                 color: appColors.subtleText,
               ),
               onPressed: _toggleSearch,
-              tooltip: 'Search',
+              tooltip: l.searchHint,
               padding: EdgeInsets.zero,
               constraints: const BoxConstraints(minWidth: 32, minHeight: 32),
               visualDensity: VisualDensity.compact,
@@ -394,7 +394,7 @@ class HomeContentState extends State<HomeContent> {
               autofocus: true,
               onTapOutside: (_) => FocusScope.of(context).unfocus(),
               decoration: InputDecoration(
-                hintText: 'Search sessions...',
+                hintText: l.searchSessionsHint,
                 prefixIcon: Icon(
                   Icons.search,
                   size: 18,
@@ -505,7 +505,7 @@ class HomeContentState extends State<HomeContent> {
                         key: const ValueKey('load_more_button'),
                         onPressed: widget.onLoadMore,
                         icon: const Icon(Icons.expand_more, size: 18),
-                        label: const Text('Load More'),
+                        label: Text(l.showMore),
                       ),
               ),
               const SizedBox(height: 8),

--- a/apps/mobile/lib/features/session_list/widgets/machine_edit_sheet.dart
+++ b/apps/mobile/lib/features/session_list/widgets/machine_edit_sheet.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../../l10n/app_localizations.dart';
 import '../../../models/machine.dart';
 import '../../../services/ssh_startup_service.dart';
 import '../../../theme/app_theme.dart';
@@ -127,9 +128,10 @@ class _MachineEditSheetState extends State<MachineEditSheet> {
   }
 
   Future<void> _testConnection() async {
+    final l = AppLocalizations.of(context);
     if (!_sshConfigValid) {
       setState(() {
-        _testResult = 'Please fill in SSH credentials';
+        _testResult = l.sshCredentialsRequired;
         _testSuccess = false;
       });
       return;
@@ -155,7 +157,7 @@ class _MachineEditSheetState extends State<MachineEditSheet> {
       );
 
       setState(() {
-        _testResult = result.success ? 'Connection successful!' : result.error;
+        _testResult = result.success ? l.connectionSuccessful : result.error;
         _testSuccess = result.success;
       });
     } catch (e) {
@@ -218,6 +220,7 @@ class _MachineEditSheetState extends State<MachineEditSheet> {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
     final appColors = theme.extension<AppColors>()!;
+    final l = AppLocalizations.of(context);
 
     return DraggableScrollableSheet(
       initialChildSize: 0.85,
@@ -251,7 +254,7 @@ class _MachineEditSheetState extends State<MachineEditSheet> {
                 child: Row(
                   children: [
                     Text(
-                      isEditing ? 'Edit Machine' : 'Add Machine',
+                      isEditing ? l.editMachine : l.addMachine,
                       style: theme.textTheme.titleLarge,
                     ),
                     const Spacer(),
@@ -272,14 +275,14 @@ class _MachineEditSheetState extends State<MachineEditSheet> {
                   padding: const EdgeInsets.all(16),
                   children: [
                     // Basic Info
-                    _SectionHeader(title: 'Basic Info'),
+                    _SectionHeader(title: l.machineBasicInfo),
                     const SizedBox(height: 12),
 
                     TextField(
                       controller: _nameController,
-                      decoration: const InputDecoration(
-                        labelText: 'Name',
-                        hintText: 'Home Mac',
+                      decoration: InputDecoration(
+                        labelText: l.machineNameLabel,
+                        hintText: l.machineNameHint,
                         prefixIcon: Icon(Icons.label),
                         border: OutlineInputBorder(),
                       ),
@@ -288,8 +291,8 @@ class _MachineEditSheetState extends State<MachineEditSheet> {
 
                     TextField(
                       controller: _hostController,
-                      decoration: const InputDecoration(
-                        labelText: 'Host (IP or hostname)',
+                      decoration: InputDecoration(
+                        labelText: l.machineHostLabel,
                         hintText: '100.64.1.2',
                         prefixIcon: Icon(Icons.computer),
                         border: OutlineInputBorder(),
@@ -302,8 +305,8 @@ class _MachineEditSheetState extends State<MachineEditSheet> {
                         Expanded(
                           child: TextField(
                             controller: _portController,
-                            decoration: const InputDecoration(
-                              labelText: 'Port',
+                            decoration: InputDecoration(
+                              labelText: l.portLabel,
                               hintText: '8765',
                               prefixIcon: Icon(Icons.numbers),
                               border: OutlineInputBorder(),
@@ -315,9 +318,9 @@ class _MachineEditSheetState extends State<MachineEditSheet> {
                         Expanded(
                           child: TextField(
                             controller: _apiKeyController,
-                            decoration: const InputDecoration(
-                              labelText: 'API Key',
-                              hintText: 'Optional',
+                            decoration: InputDecoration(
+                              labelText: l.apiKeyOptional,
+                              hintText: l.apiKeyHint,
                               prefixIcon: Icon(Icons.key),
                               border: OutlineInputBorder(),
                             ),
@@ -330,7 +333,7 @@ class _MachineEditSheetState extends State<MachineEditSheet> {
                     const SizedBox(height: 24),
 
                     // SSH Configuration
-                    _SectionHeader(title: 'SSH Configuration'),
+                    _SectionHeader(title: l.sshConfiguration),
                     const SizedBox(height: 12),
 
                     Container(
@@ -347,12 +350,12 @@ class _MachineEditSheetState extends State<MachineEditSheet> {
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
                           SwitchListTile(
-                            title: const Text(
-                              'Enable SSH remote startup',
+                            title: Text(
+                              l.sshEnableRemoteStartup,
                               style: TextStyle(fontWeight: FontWeight.w500),
                             ),
                             subtitle: Text(
-                              'Remotely start Bridge Server when offline',
+                              l.sshRemoteStartupSubtitle,
                               style: theme.textTheme.bodySmall?.copyWith(
                                 color: colorScheme.onSurfaceVariant,
                               ),
@@ -376,8 +379,8 @@ class _MachineEditSheetState extends State<MachineEditSheet> {
                             flex: 2,
                             child: TextField(
                               controller: _sshUsernameController,
-                              decoration: const InputDecoration(
-                                labelText: 'SSH Username',
+                              decoration: InputDecoration(
+                                labelText: l.sshUsernameLabel,
                                 hintText: 'myuser',
                                 prefixIcon: Icon(Icons.person),
                                 border: OutlineInputBorder(),
@@ -388,8 +391,8 @@ class _MachineEditSheetState extends State<MachineEditSheet> {
                           Expanded(
                             child: TextField(
                               controller: _sshPortController,
-                              decoration: const InputDecoration(
-                                labelText: 'SSH Port',
+                              decoration: InputDecoration(
+                                labelText: l.sshPortLabel,
                                 hintText: '22',
                                 border: OutlineInputBorder(),
                               ),
@@ -402,16 +405,16 @@ class _MachineEditSheetState extends State<MachineEditSheet> {
 
                       // Auth type selector
                       SegmentedButton<SshAuthType>(
-                        segments: const [
+                        segments: [
                           ButtonSegment(
                             value: SshAuthType.password,
-                            label: Text('Password'),
-                            icon: Icon(Icons.password),
+                            label: Text(l.password),
+                            icon: const Icon(Icons.password),
                           ),
                           ButtonSegment(
                             value: SshAuthType.privateKey,
-                            label: Text('Private Key'),
-                            icon: Icon(Icons.vpn_key),
+                            label: Text(l.sshPrivateKeyLabel),
+                            icon: const Icon(Icons.vpn_key),
                           ),
                         ],
                         selected: {_sshAuthType},
@@ -424,8 +427,8 @@ class _MachineEditSheetState extends State<MachineEditSheet> {
                       if (_sshAuthType == SshAuthType.password)
                         TextField(
                           controller: _sshPasswordController,
-                          decoration: const InputDecoration(
-                            labelText: 'SSH Password',
+                          decoration: InputDecoration(
+                            labelText: l.sshPassword,
                             prefixIcon: Icon(Icons.lock),
                             border: OutlineInputBorder(),
                           ),
@@ -434,9 +437,9 @@ class _MachineEditSheetState extends State<MachineEditSheet> {
                       else
                         TextField(
                           controller: _sshPrivateKeyController,
-                          decoration: const InputDecoration(
-                            labelText: 'SSH Private Key (PEM)',
-                            hintText: '-----BEGIN OPENSSH PRIVATE KEY-----',
+                          decoration: InputDecoration(
+                            labelText: l.sshPrivateKeyLabel,
+                            hintText: l.sshPrivateKeyHint,
                             prefixIcon: Icon(Icons.vpn_key),
                             border: OutlineInputBorder(),
                           ),
@@ -460,7 +463,7 @@ class _MachineEditSheetState extends State<MachineEditSheet> {
                                 )
                               : const Icon(Icons.wifi_find),
                           label: Text(
-                            _isTesting ? 'Testing...' : 'Test Connection',
+                            _isTesting ? l.testingConnection : l.testConnection,
                           ),
                         ),
                       ),
@@ -532,7 +535,7 @@ class _MachineEditSheetState extends State<MachineEditSheet> {
                         style: TextButton.styleFrom(
                           foregroundColor: colorScheme.onSurfaceVariant,
                         ),
-                        child: const Text('Cancel'),
+                        child: Text(l.cancel),
                       ),
                     ),
                     const SizedBox(width: 16),
@@ -552,10 +555,10 @@ class _MachineEditSheetState extends State<MachineEditSheet> {
                               )
                             : Text(
                                 isEditing
-                                    ? 'Save'
+                                    ? l.save
                                     : widget.onSaveAndConnect != null
-                                    ? 'Add & Connect'
-                                    : 'Add',
+                                    ? l.addAndConnect
+                                    : l.addMachine,
                               ),
                       ),
                     ),

--- a/apps/mobile/lib/features/session_list/widgets/machine_list.dart
+++ b/apps/mobile/lib/features/session_list/widgets/machine_list.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../../l10n/app_localizations.dart';
 import '../../../models/machine.dart';
 import 'machine_card.dart';
 
@@ -38,6 +39,7 @@ class MachineList extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
+    final l = AppLocalizations.of(context);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -48,7 +50,7 @@ class MachineList extends StatelessWidget {
             Icon(Icons.dns, size: 18, color: colorScheme.primary),
             const SizedBox(width: 8),
             Text(
-              'Machines',
+              l.machineSectionTitle,
               style: theme.textTheme.titleSmall?.copyWith(
                 fontWeight: FontWeight.w600,
                 color: colorScheme.primary,
@@ -59,13 +61,13 @@ class MachineList extends StatelessWidget {
               IconButton(
                 onPressed: onRefresh,
                 icon: const Icon(Icons.refresh, size: 20),
-                tooltip: 'Refresh status',
+                tooltip: l.machineRefreshStatus,
                 visualDensity: VisualDensity.compact,
               ),
             TextButton.icon(
               onPressed: onAddMachine,
               icon: const Icon(Icons.add, size: 18),
-              label: const Text('Add'),
+              label: Text(l.addMachine),
               style: TextButton.styleFrom(
                 padding: const EdgeInsets.symmetric(
                   horizontal: 12,
@@ -107,7 +109,7 @@ class MachineList extends StatelessWidget {
                     const SizedBox(width: 16),
                     Expanded(
                       child: Text(
-                        'No saved machines.\nAdd one to quickly connect or remotely start the Bridge Server.',
+                        l.machineNoSavedDescription,
                         style: theme.textTheme.bodySmall?.copyWith(
                           color: colorScheme.onSurfaceVariant,
                           height: 1.5,
@@ -122,7 +124,7 @@ class MachineList extends StatelessWidget {
                   child: FilledButton.icon(
                     onPressed: onAddMachine,
                     icon: const Icon(Icons.add, size: 18),
-                    label: const Text('Add Machine'),
+                    label: Text(l.addMachine),
                     style: FilledButton.styleFrom(
                       backgroundColor: colorScheme.primary,
                       foregroundColor: colorScheme.onPrimary,

--- a/apps/mobile/lib/features/session_list/widgets/session_filter_bar.dart
+++ b/apps/mobile/lib/features/session_list/widgets/session_filter_bar.dart
@@ -54,9 +54,9 @@ class SessionFilterBar extends StatelessWidget {
   Widget _buildDisplayModeDropdown(BuildContext context) {
     final l = AppLocalizations.of(context);
     final label = switch (displayMode) {
-      SessionDisplayMode.first => 'First',
-      SessionDisplayMode.last => 'Last',
-      SessionDisplayMode.summary => 'Summary',
+      SessionDisplayMode.first => l.displayFirst,
+      SessionDisplayMode.last => l.displayLast,
+      SessionDisplayMode.summary => l.displaySummary,
     };
 
     return _ActionChip(
@@ -70,7 +70,7 @@ class SessionFilterBar extends StatelessWidget {
   Widget _buildProviderDropdown(BuildContext context) {
     final l = AppLocalizations.of(context);
     final label = switch (providerFilter) {
-      ProviderFilter.all => 'All AI Tools',
+      ProviderFilter.all => l.filterAllAiTools,
       ProviderFilter.claude => 'Claude',
       ProviderFilter.codex => 'Codex',
     };
@@ -92,10 +92,10 @@ class SessionFilterBar extends StatelessWidget {
 
     return _DropdownChip<String?>(
       icon: Icons.folder_outlined,
-      label: currentProject != null ? currentProject.name : 'All Projects',
+      label: currentProject != null ? currentProject.name : l.filterAllProjects,
       tooltip: l.tooltipProjectFilter,
       items: [
-        (value: null, label: 'All Projects'),
+        (value: null, label: l.filterAllProjects),
         ...projects.map((p) => (value: p.path, label: p.name)),
       ],
       onSelected: onProjectFilterChanged,
@@ -139,7 +139,7 @@ class SessionFilterBar extends StatelessWidget {
                 ),
                 const SizedBox(width: 6),
                 Text(
-                  'Named',
+                  l.filterNamed,
                   style: TextStyle(
                     fontSize: 12,
                     fontWeight: FontWeight.w500,

--- a/apps/mobile/lib/features/session_list/widgets/session_reconnect_banner.dart
+++ b/apps/mobile/lib/features/session_list/widgets/session_reconnect_banner.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../../l10n/app_localizations.dart';
 import '../../../theme/app_theme.dart';
 
 class SessionReconnectBanner extends StatelessWidget {
@@ -8,6 +9,7 @@ class SessionReconnectBanner extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final appColors = Theme.of(context).extension<AppColors>()!;
+    final l = AppLocalizations.of(context);
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       color: appColors.approvalBar,
@@ -23,7 +25,7 @@ class SessionReconnectBanner extends StatelessWidget {
           ),
           const SizedBox(width: 8),
           Text(
-            'Reconnecting...',
+            l.reconnecting,
             style: TextStyle(fontSize: 13, color: appColors.statusApproval),
           ),
         ],

--- a/apps/mobile/lib/features/settings/auth_help_screen.dart
+++ b/apps/mobile/lib/features/settings/auth_help_screen.dart
@@ -6,13 +6,14 @@ import 'package:flutter_markdown/flutter_markdown.dart';
 import '../../l10n/app_localizations.dart';
 import '../../theme/markdown_style.dart';
 
-enum _AuthHelpLanguage { ja, en }
+enum _AuthHelpLanguage { ja, en, zhHans }
 
 extension on _AuthHelpLanguage {
   String get assetPath {
     return switch (this) {
       _AuthHelpLanguage.ja => 'assets/docs/auth-troubleshooting.ja.md',
       _AuthHelpLanguage.en => 'assets/docs/auth-troubleshooting.en.md',
+      _AuthHelpLanguage.zhHans => 'assets/docs/auth-troubleshooting.zh-CN.md',
     };
   }
 }
@@ -40,9 +41,11 @@ class _AuthHelpScreenState extends State<AuthHelpScreen> {
   }
 
   _AuthHelpLanguage _preferredLanguage(Locale locale) {
-    return locale.languageCode == 'ja'
-        ? _AuthHelpLanguage.ja
-        : _AuthHelpLanguage.en;
+    return switch (locale.languageCode) {
+      'ja' => _AuthHelpLanguage.ja,
+      'zh' => _AuthHelpLanguage.zhHans,
+      _ => _AuthHelpLanguage.en,
+    };
   }
 
   Future<void> _loadMarkdown() async {
@@ -54,11 +57,15 @@ class _AuthHelpScreenState extends State<AuthHelpScreen> {
     try {
       final ja = await rootBundle.loadString(_AuthHelpLanguage.ja.assetPath);
       final en = await rootBundle.loadString(_AuthHelpLanguage.en.assetPath);
+      final zhHans = await rootBundle.loadString(
+        _AuthHelpLanguage.zhHans.assetPath,
+      );
       if (!mounted) return;
       setState(() {
         _markdownByLanguage = {
           _AuthHelpLanguage.ja: ja,
           _AuthHelpLanguage.en: en,
+          _AuthHelpLanguage.zhHans: zhHans,
         };
         _loading = false;
       });
@@ -173,6 +180,10 @@ class _AuthHelpLanguageSwitcher extends StatelessWidget {
             ButtonSegment<_AuthHelpLanguage>(
               value: _AuthHelpLanguage.en,
               label: Text(l.authHelpLanguageEn),
+            ),
+            ButtonSegment<_AuthHelpLanguage>(
+              value: _AuthHelpLanguage.zhHans,
+              label: Text(l.authHelpLanguageZhHans),
             ),
           ],
           selected: {selectedLanguage},

--- a/apps/mobile/lib/features/settings/state/settings_cubit.dart
+++ b/apps/mobile/lib/features/settings/state/settings_cubit.dart
@@ -316,13 +316,14 @@ class SettingsCubit extends Cubit<SettingsState> {
   }
 
   /// Resolve the push notification locale from app settings or system locale.
-  /// Returns a BCP-47 language subtag (e.g. "en", "ja").
+  /// Returns a BCP-47 language subtag (e.g. "en", "ja", "zh").
   String _resolvePushLocale() {
     // Use explicit app locale if set
     final appLocale = state.appLocaleId;
     if (appLocale.isNotEmpty) {
       final lang = appLocale.split(RegExp(r'[-_]')).first.toLowerCase();
       if (lang == 'ja') return 'ja';
+      if (lang == 'zh') return 'zh';
       return 'en';
     }
     // Fall back to system locale
@@ -330,6 +331,7 @@ class SettingsCubit extends Cubit<SettingsState> {
       try {
         final systemLocale = Platform.localeName;
         if (systemLocale.startsWith('ja')) return 'ja';
+        if (systemLocale.startsWith('zh')) return 'zh';
       } catch (_) {
         // Platform.localeName may throw on some platforms
       }

--- a/apps/mobile/lib/features/settings/widgets/app_locale_bottom_sheet.dart
+++ b/apps/mobile/lib/features/settings/widgets/app_locale_bottom_sheet.dart
@@ -4,11 +4,12 @@ import '../../../l10n/app_localizations.dart';
 import '../../../theme/app_theme.dart';
 
 /// Available app display locales.
-/// id is empty string for system default, otherwise a language code (e.g. 'ja', 'en').
+/// id is empty string for system default, otherwise a language code (e.g. 'ja', 'en', 'zh').
 const appLocales = <(String id, String label, String? subtitle)>[
   ('', '', null), // System default — label resolved via l10n
   ('ja', '日本語', 'Japanese'),
   ('en', 'English', null),
+  ('zh', '简体中文', 'Simplified Chinese'),
 ];
 
 /// Shows a bottom sheet for selecting the app display locale.

--- a/apps/mobile/lib/l10n/app_en.arb
+++ b/apps/mobile/lib/l10n/app_en.arb
@@ -96,6 +96,8 @@
   "stopServer": "Stop Server",
   "update": "Update",
   "offline": "Offline",
+  "disconnected": "Disconnected",
+  "reconnecting": "Reconnecting...",
   "unreachable": "Unreachable",
   "checking": "Checking...",
 
@@ -106,7 +108,27 @@
   "permission": "Permission",
   "approval": "Approval",
   "worktree": "Worktree",
+  "worktreeTooltip": "Creates an isolated git working tree for this session.",
   "advanced": "Advanced",
+  "environmentSection": "Environment",
+  "permissionDefaultMode": "Default",
+  "permissionAcceptEditsMode": "Accept Edits",
+  "permissionPlanMode": "Plan",
+  "permissionBypassMode": "Bypass All",
+  "permissionDefaultDescription": "Standard permission prompts",
+  "permissionAcceptEditsDescription": "Auto-approve file edits",
+  "permissionPlanDescription": "Analyze and plan without executing",
+  "permissionBypassDescription": "Skip all permission prompts",
+  "permissionModeTitle": "Permission Mode",
+  "changePermissionModeTitle": "Change Permission Mode",
+  "changePermissionModeBody": "Switching to {mode} will restart the session. Your conversation will be preserved.",
+  "@changePermissionModeBody": {
+    "placeholders": {
+      "mode": { "type": "String" }
+    }
+  },
+  "permissionChipAcceptEdits": "Edits",
+  "permissionChipBypass": "Bypass",
   "modelOptional": "Model (optional)",
   "effort": "Effort",
   "defaultLabel": "Default",
@@ -121,6 +143,22 @@
   "persistSessionHistory": "Persist Session History",
   "model": "Model",
   "sandbox": "Sandbox",
+  "sandboxModeTitle": "Sandbox Mode",
+  "sandboxSafeMode": "Sandbox (Safe Mode)",
+  "sandboxStandard": "Standard",
+  "sandboxOnLabel": "Sandbox On",
+  "sandboxOffLabel": "Sandbox Off",
+  "sandboxRestrictedDescription": "Run commands in restricted environment",
+  "sandboxNativeDescription": "Run commands natively",
+  "sandboxNativeCautionDescription": "Run commands natively (CAUTION)",
+  "changeSandboxModeTitle": "Change Sandbox Mode",
+  "changeSandboxModeBody": "Switching to {mode} will restart the session. Your conversation will be preserved.",
+  "@changeSandboxModeBody": {
+    "placeholders": {
+      "mode": { "type": "String" }
+    }
+  },
+  "sandboxChipOff": "No SB",
   "reasoning": "Reasoning",
   "webSearch": "Web Search",
   "networkAccess": "Network Access",
@@ -144,8 +182,15 @@
   "reject": "Reject",
   "approve": "Approve",
   "always": "Always",
+  "restart": "Restart",
 
   "messagePlaceholder": "Message Claude...",
+  "messageProviderPlaceholder": "Message {provider}...",
+  "@messageProviderPlaceholder": {
+    "placeholders": {
+      "provider": { "type": "String" }
+    }
+  },
   "filesMentioned": "{count} file(s) @mentioned",
   "diffLines": "{count} diff lines",
   "tapInterruptHoldStop": "Tap: interrupt, Hold: stop",
@@ -159,6 +204,13 @@
 
   "answered": "Answered",
   "claudeIsAsking": "Claude is asking",
+  "codexIsAsking": "Codex is asking",
+  "questionNeedsYourAnswer": "Question needs your answer",
+  "toolApprovalNeeded": "Tool approval needed",
+  "codexToolApprovalNeeded": "Codex tool approval needed",
+  "sessionCompleteTitle": "Session Complete",
+  "sessionDone": "Session done",
+  "codexSessionDone": "Codex session done",
   "submitAllAnswers": "Submit All Answers",
   "submitWithCount": "Submit ({count} selected)",
   "selectOptionsToSubmit": "Select options to submit",
@@ -251,10 +303,21 @@
   "guideReadyHint": "You can revisit this guide anytime from Settings",
 
   "creatingSession": "Creating session...",
+  "startWithProvider": "Start with {provider}",
+  "@startWithProvider": {
+    "placeholders": {
+      "provider": { "type": "String" }
+    }
+  },
   "copyForAgent": "Copy for Agent",
   "messageHistory": "Message History",
   "viewChanges": "View Changes",
   "screenshot": "Screenshot",
+  "screenshotSaved": "Screenshot saved",
+  "screenshotFailed": "Screenshot failed",
+  "fullScreen": "Full Screen",
+  "captureEntireDesktop": "Capture entire desktop",
+  "noWindowsFound": "No windows found",
 
   "debug": "Debug",
   "logs": "Logs",
@@ -270,7 +333,9 @@
   "promptHistory": "Prompt History",
   "frequent": "Frequent",
   "recent": "Recent",
+  "newShort": "New",
   "searchHint": "Search...",
+  "searchSessionsHint": "Search sessions...",
   "noMatchingPrompts": "No matching prompts",
   "noPromptHistoryYet": "No prompt history yet",
 
@@ -289,6 +354,32 @@
   "agentReadyForPrompt": "The agent is ready for your next prompt.",
   "backToSessions": "Back to Sessions",
   "working": "Working...",
+  "runningSessions": "Running",
+  "recentSessions": "Recent Sessions",
+  "displayFirst": "First",
+  "displayLast": "Last",
+  "displaySummary": "Summary",
+  "filterAllAiTools": "All AI Tools",
+  "filterAllProjects": "All Projects",
+  "filterNamed": "Named",
+  "statusStarting": "Starting",
+  "statusIdle": "Idle",
+  "statusRunning": "Running",
+  "statusApproval": "Approval",
+  "statusCompacting": "Compacting",
+  "statusWorking": "Working",
+  "statusNeedsYou": "Needs You",
+  "statusReady": "Ready",
+  "statusCleaningContext": "Cleaning up context",
+  "statusReviewPlan": "Review plan",
+  "statusApproveToolCall": "Approve tool call",
+  "statusAnswerQuestion": "Answer question",
+  "statusApproveTool": "Approve {toolName}",
+  "@statusApproveTool": {
+    "placeholders": {
+      "toolName": { "type": "String" }
+    }
+  },
   "waitingForApprovalRequests": "Waiting for approval requests from the agent.",
   "noActiveSessions": "No active sessions",
   "startSessionToBegin": "Start a session to begin receiving approval requests.",
@@ -312,6 +403,28 @@
   "version": "Version",
   "loading": "Loading...",
   "setupGuideSubtitle": "New here? Start with this",
+  "machineSectionTitle": "Machines",
+  "machineRefreshStatus": "Refresh status",
+  "machineNoSavedDescription": "No saved machines.\nAdd one to quickly connect or remotely start the Bridge Server.",
+  "addMachine": "Add Machine",
+  "editMachine": "Edit Machine",
+  "machineBasicInfo": "Basic Info",
+  "machineNameLabel": "Name",
+  "machineNameHint": "Home Mac",
+  "machineHostLabel": "Host (IP or hostname)",
+  "portLabel": "Port",
+  "sshConfiguration": "SSH Configuration",
+  "sshEnableRemoteStartup": "Enable SSH remote startup",
+  "sshRemoteStartupSubtitle": "Remotely start Bridge Server when offline",
+  "sshUsernameLabel": "SSH Username",
+  "sshPortLabel": "SSH Port",
+  "sshPrivateKeyLabel": "SSH Private Key (PEM)",
+  "sshPrivateKeyHint": "-----BEGIN OPENSSH PRIVATE KEY-----",
+  "testConnection": "Test Connection",
+  "testingConnection": "Testing...",
+  "sshCredentialsRequired": "Please fill in SSH credentials",
+  "connectionSuccessful": "Connection successful!",
+  "addAndConnect": "Add & Connect",
   "openSourceLicenses": "Open Source Licenses",
   "githubRepository": "GitHub Repository",
   "changelog": "Changelog",
@@ -454,9 +567,29 @@
   "tooltipSendMessage": "Send message",
   "tooltipRemoveImage": "Remove image",
   "tooltipClearDiff": "Clear diff selection",
+  "messageHistoryCount": "{count} messages",
+  "@messageHistoryCount": {
+    "placeholders": {
+      "count": { "type": "int" }
+    }
+  },
+  "noMessagesYet": "No messages yet",
+  "messagesAppearAfterProcessing": "Messages will appear here after the agent processes them",
 
   "showMore": "Show more",
   "showLess": "Show less",
+  "sessionStarted": "Session started ({model})",
+  "@sessionStarted": {
+    "placeholders": {
+      "model": { "type": "String" }
+    }
+  },
+  "systemSubtypeLabel": "System: {subtype}",
+  "@systemSubtypeLabel": {
+    "placeholders": {
+      "subtype": { "type": "String" }
+    }
+  },
 
   "authErrorTitle": "Claude login required",
   "authErrorBody": "Claude Code needs to sign in again on the Bridge machine.",
@@ -468,6 +601,7 @@
   "authHelpButton": "View steps",
   "authHelpLanguageJa": "日本語",
   "authHelpLanguageEn": "English",
+  "authHelpLanguageZhHans": "简体中文",
 
   "terminalApp": "Terminal App",
   "terminalAppSubtitle": "Open projects in an external terminal app",

--- a/apps/mobile/lib/l10n/app_ja.arb
+++ b/apps/mobile/lib/l10n/app_ja.arb
@@ -119,6 +119,8 @@
   "stopServer": "サーバーを停止",
   "update": "更新",
   "offline": "オフライン",
+  "disconnected": "切断されました",
+  "reconnecting": "再接続中...",
   "unreachable": "接続不可",
   "checking": "確認中...",
 
@@ -128,8 +130,28 @@
   "projectPathHint": "/path/to/your/project",
   "permission": "パーミッション",
   "approval": "承認",
-  "worktree": "Worktree",
+  "worktree": "ワークツリー",
+  "worktreeTooltip": "このセッション用に独立した git worktree を作成します。",
   "advanced": "詳細設定",
+  "environmentSection": "環境",
+  "permissionDefaultMode": "デフォルト",
+  "permissionAcceptEditsMode": "編集を自動承認",
+  "permissionPlanMode": "計画",
+  "permissionBypassMode": "すべてバイパス",
+  "permissionDefaultDescription": "標準の権限確認",
+  "permissionAcceptEditsDescription": "ファイル編集を自動承認",
+  "permissionPlanDescription": "実行せずに分析と計画を行う",
+  "permissionBypassDescription": "すべての権限確認をスキップ",
+  "permissionModeTitle": "権限モード",
+  "changePermissionModeTitle": "権限モードを変更",
+  "changePermissionModeBody": "{mode} に切り替えるとセッションが再起動します。会話は保持されます。",
+  "@changePermissionModeBody": {
+    "placeholders": {
+      "mode": { "type": "String" }
+    }
+  },
+  "permissionChipAcceptEdits": "編集",
+  "permissionChipBypass": "バイパス",
   "modelOptional": "モデル（任意）",
   "effort": "Effort",
   "defaultLabel": "デフォルト",
@@ -143,7 +165,23 @@
   "forkSessionOnResume": "再開時にセッションを分岐",
   "persistSessionHistory": "セッション履歴を保持",
   "model": "モデル",
-  "sandbox": "Sandbox",
+  "sandbox": "サンドボックス",
+  "sandboxModeTitle": "サンドボックスモード",
+  "sandboxSafeMode": "Sandbox（セーフモード）",
+  "sandboxStandard": "標準",
+  "sandboxOnLabel": "サンドボックス ON",
+  "sandboxOffLabel": "サンドボックス OFF",
+  "sandboxRestrictedDescription": "制限された環境でコマンドを実行",
+  "sandboxNativeDescription": "ネイティブ環境でコマンドを実行",
+  "sandboxNativeCautionDescription": "ネイティブ環境でコマンドを実行（注意）",
+  "changeSandboxModeTitle": "サンドボックスモードを変更",
+  "changeSandboxModeBody": "{mode} に切り替えるとセッションが再起動します。会話は保持されます。",
+  "@changeSandboxModeBody": {
+    "placeholders": {
+      "mode": { "type": "String" }
+    }
+  },
+  "sandboxChipOff": "No SB",
   "reasoning": "Reasoning",
   "webSearch": "Web Search",
   "networkAccess": "ネットワークアクセス",
@@ -172,8 +210,15 @@
   "reject": "拒否",
   "approve": "承認",
   "always": "常に許可",
+  "restart": "再起動",
 
   "messagePlaceholder": "Claude にメッセージ...",
+  "messageProviderPlaceholder": "{provider} にメッセージ...",
+  "@messageProviderPlaceholder": {
+    "placeholders": {
+      "provider": { "type": "String" }
+    }
+  },
   "filesMentioned": "{count} ファイルを @メンション中",
   "@filesMentioned": {
     "placeholders": {
@@ -208,6 +253,13 @@
 
   "answered": "回答済み",
   "claudeIsAsking": "Claude が質問しています",
+  "codexIsAsking": "Codex が質問しています",
+  "questionNeedsYourAnswer": "質問への回答が必要です",
+  "toolApprovalNeeded": "ツール承認が必要です",
+  "codexToolApprovalNeeded": "Codex のツール承認が必要です",
+  "sessionCompleteTitle": "セッション完了",
+  "sessionDone": "セッションが完了しました",
+  "codexSessionDone": "Codex セッションが完了しました",
   "submitAllAnswers": "すべての回答を送信",
   "submitWithCount": "送信 ({count} 件選択)",
   "@submitWithCount": {
@@ -316,10 +368,21 @@
   "guideReadyHint": "このガイドは設定画面からいつでも確認できます",
 
   "creatingSession": "セッション作成中...",
+  "startWithProvider": "{provider} で開始",
+  "@startWithProvider": {
+    "placeholders": {
+      "provider": { "type": "String" }
+    }
+  },
   "copyForAgent": "エージェント用にコピー",
   "messageHistory": "メッセージ履歴",
   "viewChanges": "変更を確認",
   "screenshot": "スクリーンショット",
+  "screenshotSaved": "スクリーンショットを保存しました",
+  "screenshotFailed": "スクリーンショットに失敗しました",
+  "fullScreen": "フルスクリーン",
+  "captureEntireDesktop": "デスクトップ全体をキャプチャ",
+  "noWindowsFound": "ウィンドウが見つかりません",
 
   "debug": "デバッグ",
   "logs": "ログ",
@@ -335,7 +398,9 @@
   "promptHistory": "プロンプト履歴",
   "frequent": "頻度順",
   "recent": "新しい順",
+  "newShort": "新規",
   "searchHint": "検索...",
+  "searchSessionsHint": "セッションを検索...",
   "noMatchingPrompts": "一致するプロンプトがありません",
   "noPromptHistoryYet": "プロンプト履歴はまだありません",
 
@@ -364,6 +429,32 @@
   "agentReadyForPrompt": "エージェントは次のプロンプトを待っています。",
   "backToSessions": "セッション一覧に戻る",
   "working": "処理中...",
+  "runningSessions": "実行中",
+  "recentSessions": "最近のセッション",
+  "displayFirst": "先頭",
+  "displayLast": "最新",
+  "displaySummary": "要約",
+  "filterAllAiTools": "すべてのAIツール",
+  "filterAllProjects": "すべてのプロジェクト",
+  "filterNamed": "名前付き",
+  "statusStarting": "起動中",
+  "statusIdle": "待機中",
+  "statusRunning": "実行中",
+  "statusApproval": "承認待ち",
+  "statusCompacting": "圧縮中",
+  "statusWorking": "作業中",
+  "statusNeedsYou": "対応待ち",
+  "statusReady": "準備完了",
+  "statusCleaningContext": "コンテキスト整理中",
+  "statusReviewPlan": "プランを確認",
+  "statusApproveToolCall": "ツール呼び出しを承認",
+  "statusAnswerQuestion": "質問に回答",
+  "statusApproveTool": "{toolName} を承認",
+  "@statusApproveTool": {
+    "placeholders": {
+      "toolName": { "type": "String" }
+    }
+  },
   "waitingForApprovalRequests": "エージェントからの承認リクエストを待っています。",
   "noActiveSessions": "アクティブなセッションがありません",
   "startSessionToBegin": "セッションを開始して承認リクエストの受信を始めましょう。",
@@ -387,6 +478,28 @@
   "version": "バージョン",
   "loading": "読み込み中...",
   "setupGuideSubtitle": "初めての方はこちら",
+  "machineSectionTitle": "マシン",
+  "machineRefreshStatus": "状態を更新",
+  "machineNoSavedDescription": "保存済みのマシンはありません。\nマシンを追加すると、すばやく接続したり、オフライン時に Bridge Server をリモート起動できます。",
+  "addMachine": "マシンを追加",
+  "editMachine": "マシンを編集",
+  "machineBasicInfo": "基本情報",
+  "machineNameLabel": "名前",
+  "machineNameHint": "自宅の Mac",
+  "machineHostLabel": "ホスト（IP またはホスト名）",
+  "portLabel": "ポート",
+  "sshConfiguration": "SSH 設定",
+  "sshEnableRemoteStartup": "SSH リモート起動を有効化",
+  "sshRemoteStartupSubtitle": "オフライン時に Bridge Server をリモート起動",
+  "sshUsernameLabel": "SSH ユーザー名",
+  "sshPortLabel": "SSH ポート",
+  "sshPrivateKeyLabel": "SSH 秘密鍵（PEM）",
+  "sshPrivateKeyHint": "-----BEGIN OPENSSH PRIVATE KEY-----",
+  "testConnection": "接続テスト",
+  "testingConnection": "テスト中...",
+  "sshCredentialsRequired": "SSH 認証情報を入力してください",
+  "connectionSuccessful": "接続に成功しました！",
+  "addAndConnect": "追加して接続",
   "openSourceLicenses": "オープンソースライセンス",
   "githubRepository": "GitHub リポジトリ",
   "changelog": "変更履歴",
@@ -529,9 +642,29 @@
   "tooltipSendMessage": "メッセージを送信",
   "tooltipRemoveImage": "画像を削除",
   "tooltipClearDiff": "Diff選択を解除",
+  "messageHistoryCount": "{count} 件のメッセージ",
+  "@messageHistoryCount": {
+    "placeholders": {
+      "count": { "type": "int" }
+    }
+  },
+  "noMessagesYet": "まだメッセージはありません",
+  "messagesAppearAfterProcessing": "メッセージはエージェントが処理した後にここに表示されます",
 
   "showMore": "もっと見る",
   "showLess": "閉じる",
+  "sessionStarted": "セッション開始 ({model})",
+  "@sessionStarted": {
+    "placeholders": {
+      "model": { "type": "String" }
+    }
+  },
+  "systemSubtypeLabel": "System: {subtype}",
+  "@systemSubtypeLabel": {
+    "placeholders": {
+      "subtype": { "type": "String" }
+    }
+  },
 
   "authErrorTitle": "Claude Codeの再ログインが必要です",
   "authErrorBody": "BridgeマシンでClaude Codeを起動し、再ログインしてください。",
@@ -543,6 +676,7 @@
   "authHelpButton": "手順を見る",
   "authHelpLanguageJa": "日本語",
   "authHelpLanguageEn": "English",
+  "authHelpLanguageZhHans": "简体中文",
 
   "terminalApp": "ターミナルアプリ",
   "terminalAppSubtitle": "外部ターミナルアプリでプロジェクトを開く",

--- a/apps/mobile/lib/l10n/app_localizations.dart
+++ b/apps/mobile/lib/l10n/app_localizations.dart
@@ -7,6 +7,7 @@ import 'package:intl/intl.dart' as intl;
 
 import 'app_localizations_en.dart';
 import 'app_localizations_ja.dart';
+import 'app_localizations_zh.dart';
 
 // ignore_for_file: type=lint
 
@@ -96,6 +97,7 @@ abstract class AppLocalizations {
   static const List<Locale> supportedLocales = <Locale>[
     Locale('ja'),
     Locale('en'),
+    Locale('zh'),
   ];
 
   /// No description provided for @appTitle.
@@ -566,6 +568,18 @@ abstract class AppLocalizations {
   /// **'オフライン'**
   String get offline;
 
+  /// No description provided for @disconnected.
+  ///
+  /// In ja, this message translates to:
+  /// **'切断されました'**
+  String get disconnected;
+
+  /// No description provided for @reconnecting.
+  ///
+  /// In ja, this message translates to:
+  /// **'再接続中...'**
+  String get reconnecting;
+
   /// No description provided for @unreachable.
   ///
   /// In ja, this message translates to:
@@ -617,14 +631,104 @@ abstract class AppLocalizations {
   /// No description provided for @worktree.
   ///
   /// In ja, this message translates to:
-  /// **'Worktree'**
+  /// **'ワークツリー'**
   String get worktree;
+
+  /// No description provided for @worktreeTooltip.
+  ///
+  /// In ja, this message translates to:
+  /// **'このセッション用に独立した git worktree を作成します。'**
+  String get worktreeTooltip;
 
   /// No description provided for @advanced.
   ///
   /// In ja, this message translates to:
   /// **'詳細設定'**
   String get advanced;
+
+  /// No description provided for @environmentSection.
+  ///
+  /// In ja, this message translates to:
+  /// **'環境'**
+  String get environmentSection;
+
+  /// No description provided for @permissionDefaultMode.
+  ///
+  /// In ja, this message translates to:
+  /// **'デフォルト'**
+  String get permissionDefaultMode;
+
+  /// No description provided for @permissionAcceptEditsMode.
+  ///
+  /// In ja, this message translates to:
+  /// **'編集を自動承認'**
+  String get permissionAcceptEditsMode;
+
+  /// No description provided for @permissionPlanMode.
+  ///
+  /// In ja, this message translates to:
+  /// **'計画'**
+  String get permissionPlanMode;
+
+  /// No description provided for @permissionBypassMode.
+  ///
+  /// In ja, this message translates to:
+  /// **'すべてバイパス'**
+  String get permissionBypassMode;
+
+  /// No description provided for @permissionDefaultDescription.
+  ///
+  /// In ja, this message translates to:
+  /// **'標準の権限確認'**
+  String get permissionDefaultDescription;
+
+  /// No description provided for @permissionAcceptEditsDescription.
+  ///
+  /// In ja, this message translates to:
+  /// **'ファイル編集を自動承認'**
+  String get permissionAcceptEditsDescription;
+
+  /// No description provided for @permissionPlanDescription.
+  ///
+  /// In ja, this message translates to:
+  /// **'実行せずに分析と計画を行う'**
+  String get permissionPlanDescription;
+
+  /// No description provided for @permissionBypassDescription.
+  ///
+  /// In ja, this message translates to:
+  /// **'すべての権限確認をスキップ'**
+  String get permissionBypassDescription;
+
+  /// No description provided for @permissionModeTitle.
+  ///
+  /// In ja, this message translates to:
+  /// **'権限モード'**
+  String get permissionModeTitle;
+
+  /// No description provided for @changePermissionModeTitle.
+  ///
+  /// In ja, this message translates to:
+  /// **'権限モードを変更'**
+  String get changePermissionModeTitle;
+
+  /// No description provided for @changePermissionModeBody.
+  ///
+  /// In ja, this message translates to:
+  /// **'{mode} に切り替えるとセッションが再起動します。会話は保持されます。'**
+  String changePermissionModeBody(String mode);
+
+  /// No description provided for @permissionChipAcceptEdits.
+  ///
+  /// In ja, this message translates to:
+  /// **'編集'**
+  String get permissionChipAcceptEdits;
+
+  /// No description provided for @permissionChipBypass.
+  ///
+  /// In ja, this message translates to:
+  /// **'バイパス'**
+  String get permissionChipBypass;
 
   /// No description provided for @modelOptional.
   ///
@@ -707,8 +811,74 @@ abstract class AppLocalizations {
   /// No description provided for @sandbox.
   ///
   /// In ja, this message translates to:
-  /// **'Sandbox'**
+  /// **'サンドボックス'**
   String get sandbox;
+
+  /// No description provided for @sandboxModeTitle.
+  ///
+  /// In ja, this message translates to:
+  /// **'サンドボックスモード'**
+  String get sandboxModeTitle;
+
+  /// No description provided for @sandboxSafeMode.
+  ///
+  /// In ja, this message translates to:
+  /// **'Sandbox（セーフモード）'**
+  String get sandboxSafeMode;
+
+  /// No description provided for @sandboxStandard.
+  ///
+  /// In ja, this message translates to:
+  /// **'標準'**
+  String get sandboxStandard;
+
+  /// No description provided for @sandboxOnLabel.
+  ///
+  /// In ja, this message translates to:
+  /// **'サンドボックス ON'**
+  String get sandboxOnLabel;
+
+  /// No description provided for @sandboxOffLabel.
+  ///
+  /// In ja, this message translates to:
+  /// **'サンドボックス OFF'**
+  String get sandboxOffLabel;
+
+  /// No description provided for @sandboxRestrictedDescription.
+  ///
+  /// In ja, this message translates to:
+  /// **'制限された環境でコマンドを実行'**
+  String get sandboxRestrictedDescription;
+
+  /// No description provided for @sandboxNativeDescription.
+  ///
+  /// In ja, this message translates to:
+  /// **'ネイティブ環境でコマンドを実行'**
+  String get sandboxNativeDescription;
+
+  /// No description provided for @sandboxNativeCautionDescription.
+  ///
+  /// In ja, this message translates to:
+  /// **'ネイティブ環境でコマンドを実行（注意）'**
+  String get sandboxNativeCautionDescription;
+
+  /// No description provided for @changeSandboxModeTitle.
+  ///
+  /// In ja, this message translates to:
+  /// **'サンドボックスモードを変更'**
+  String get changeSandboxModeTitle;
+
+  /// No description provided for @changeSandboxModeBody.
+  ///
+  /// In ja, this message translates to:
+  /// **'{mode} に切り替えるとセッションが再起動します。会話は保持されます。'**
+  String changeSandboxModeBody(String mode);
+
+  /// No description provided for @sandboxChipOff.
+  ///
+  /// In ja, this message translates to:
+  /// **'No SB'**
+  String get sandboxChipOff;
 
   /// No description provided for @reasoning.
   ///
@@ -842,11 +1012,23 @@ abstract class AppLocalizations {
   /// **'常に許可'**
   String get always;
 
+  /// No description provided for @restart.
+  ///
+  /// In ja, this message translates to:
+  /// **'再起動'**
+  String get restart;
+
   /// No description provided for @messagePlaceholder.
   ///
   /// In ja, this message translates to:
   /// **'Claude にメッセージ...'**
   String get messagePlaceholder;
+
+  /// No description provided for @messageProviderPlaceholder.
+  ///
+  /// In ja, this message translates to:
+  /// **'{provider} にメッセージ...'**
+  String messageProviderPlaceholder(String provider);
 
   /// No description provided for @filesMentioned.
   ///
@@ -907,6 +1089,48 @@ abstract class AppLocalizations {
   /// In ja, this message translates to:
   /// **'Claude が質問しています'**
   String get claudeIsAsking;
+
+  /// No description provided for @codexIsAsking.
+  ///
+  /// In ja, this message translates to:
+  /// **'Codex が質問しています'**
+  String get codexIsAsking;
+
+  /// No description provided for @questionNeedsYourAnswer.
+  ///
+  /// In ja, this message translates to:
+  /// **'質問への回答が必要です'**
+  String get questionNeedsYourAnswer;
+
+  /// No description provided for @toolApprovalNeeded.
+  ///
+  /// In ja, this message translates to:
+  /// **'ツール承認が必要です'**
+  String get toolApprovalNeeded;
+
+  /// No description provided for @codexToolApprovalNeeded.
+  ///
+  /// In ja, this message translates to:
+  /// **'Codex のツール承認が必要です'**
+  String get codexToolApprovalNeeded;
+
+  /// No description provided for @sessionCompleteTitle.
+  ///
+  /// In ja, this message translates to:
+  /// **'セッション完了'**
+  String get sessionCompleteTitle;
+
+  /// No description provided for @sessionDone.
+  ///
+  /// In ja, this message translates to:
+  /// **'セッションが完了しました'**
+  String get sessionDone;
+
+  /// No description provided for @codexSessionDone.
+  ///
+  /// In ja, this message translates to:
+  /// **'Codex セッションが完了しました'**
+  String get codexSessionDone;
 
   /// No description provided for @submitAllAnswers.
   ///
@@ -1400,6 +1624,12 @@ abstract class AppLocalizations {
   /// **'セッション作成中...'**
   String get creatingSession;
 
+  /// No description provided for @startWithProvider.
+  ///
+  /// In ja, this message translates to:
+  /// **'{provider} で開始'**
+  String startWithProvider(String provider);
+
   /// No description provided for @copyForAgent.
   ///
   /// In ja, this message translates to:
@@ -1423,6 +1653,36 @@ abstract class AppLocalizations {
   /// In ja, this message translates to:
   /// **'スクリーンショット'**
   String get screenshot;
+
+  /// No description provided for @screenshotSaved.
+  ///
+  /// In ja, this message translates to:
+  /// **'スクリーンショットを保存しました'**
+  String get screenshotSaved;
+
+  /// No description provided for @screenshotFailed.
+  ///
+  /// In ja, this message translates to:
+  /// **'スクリーンショットに失敗しました'**
+  String get screenshotFailed;
+
+  /// No description provided for @fullScreen.
+  ///
+  /// In ja, this message translates to:
+  /// **'フルスクリーン'**
+  String get fullScreen;
+
+  /// No description provided for @captureEntireDesktop.
+  ///
+  /// In ja, this message translates to:
+  /// **'デスクトップ全体をキャプチャ'**
+  String get captureEntireDesktop;
+
+  /// No description provided for @noWindowsFound.
+  ///
+  /// In ja, this message translates to:
+  /// **'ウィンドウが見つかりません'**
+  String get noWindowsFound;
 
   /// No description provided for @debug.
   ///
@@ -1502,11 +1762,23 @@ abstract class AppLocalizations {
   /// **'新しい順'**
   String get recent;
 
+  /// No description provided for @newShort.
+  ///
+  /// In ja, this message translates to:
+  /// **'新規'**
+  String get newShort;
+
   /// No description provided for @searchHint.
   ///
   /// In ja, this message translates to:
   /// **'検索...'**
   String get searchHint;
+
+  /// No description provided for @searchSessionsHint.
+  ///
+  /// In ja, this message translates to:
+  /// **'セッションを検索...'**
+  String get searchSessionsHint;
 
   /// No description provided for @noMatchingPrompts.
   ///
@@ -1609,6 +1881,132 @@ abstract class AppLocalizations {
   /// In ja, this message translates to:
   /// **'処理中...'**
   String get working;
+
+  /// No description provided for @runningSessions.
+  ///
+  /// In ja, this message translates to:
+  /// **'実行中'**
+  String get runningSessions;
+
+  /// No description provided for @recentSessions.
+  ///
+  /// In ja, this message translates to:
+  /// **'最近のセッション'**
+  String get recentSessions;
+
+  /// No description provided for @displayFirst.
+  ///
+  /// In ja, this message translates to:
+  /// **'先頭'**
+  String get displayFirst;
+
+  /// No description provided for @displayLast.
+  ///
+  /// In ja, this message translates to:
+  /// **'最新'**
+  String get displayLast;
+
+  /// No description provided for @displaySummary.
+  ///
+  /// In ja, this message translates to:
+  /// **'要約'**
+  String get displaySummary;
+
+  /// No description provided for @filterAllAiTools.
+  ///
+  /// In ja, this message translates to:
+  /// **'すべてのAIツール'**
+  String get filterAllAiTools;
+
+  /// No description provided for @filterAllProjects.
+  ///
+  /// In ja, this message translates to:
+  /// **'すべてのプロジェクト'**
+  String get filterAllProjects;
+
+  /// No description provided for @filterNamed.
+  ///
+  /// In ja, this message translates to:
+  /// **'名前付き'**
+  String get filterNamed;
+
+  /// No description provided for @statusStarting.
+  ///
+  /// In ja, this message translates to:
+  /// **'起動中'**
+  String get statusStarting;
+
+  /// No description provided for @statusIdle.
+  ///
+  /// In ja, this message translates to:
+  /// **'待機中'**
+  String get statusIdle;
+
+  /// No description provided for @statusRunning.
+  ///
+  /// In ja, this message translates to:
+  /// **'実行中'**
+  String get statusRunning;
+
+  /// No description provided for @statusApproval.
+  ///
+  /// In ja, this message translates to:
+  /// **'承認待ち'**
+  String get statusApproval;
+
+  /// No description provided for @statusCompacting.
+  ///
+  /// In ja, this message translates to:
+  /// **'圧縮中'**
+  String get statusCompacting;
+
+  /// No description provided for @statusWorking.
+  ///
+  /// In ja, this message translates to:
+  /// **'作業中'**
+  String get statusWorking;
+
+  /// No description provided for @statusNeedsYou.
+  ///
+  /// In ja, this message translates to:
+  /// **'対応待ち'**
+  String get statusNeedsYou;
+
+  /// No description provided for @statusReady.
+  ///
+  /// In ja, this message translates to:
+  /// **'準備完了'**
+  String get statusReady;
+
+  /// No description provided for @statusCleaningContext.
+  ///
+  /// In ja, this message translates to:
+  /// **'コンテキスト整理中'**
+  String get statusCleaningContext;
+
+  /// No description provided for @statusReviewPlan.
+  ///
+  /// In ja, this message translates to:
+  /// **'プランを確認'**
+  String get statusReviewPlan;
+
+  /// No description provided for @statusApproveToolCall.
+  ///
+  /// In ja, this message translates to:
+  /// **'ツール呼び出しを承認'**
+  String get statusApproveToolCall;
+
+  /// No description provided for @statusAnswerQuestion.
+  ///
+  /// In ja, this message translates to:
+  /// **'質問に回答'**
+  String get statusAnswerQuestion;
+
+  /// No description provided for @statusApproveTool.
+  ///
+  /// In ja, this message translates to:
+  /// **'{toolName} を承認'**
+  String statusApproveTool(String toolName);
 
   /// No description provided for @waitingForApprovalRequests.
   ///
@@ -1741,6 +2139,138 @@ abstract class AppLocalizations {
   /// In ja, this message translates to:
   /// **'初めての方はこちら'**
   String get setupGuideSubtitle;
+
+  /// No description provided for @machineSectionTitle.
+  ///
+  /// In ja, this message translates to:
+  /// **'マシン'**
+  String get machineSectionTitle;
+
+  /// No description provided for @machineRefreshStatus.
+  ///
+  /// In ja, this message translates to:
+  /// **'状態を更新'**
+  String get machineRefreshStatus;
+
+  /// No description provided for @machineNoSavedDescription.
+  ///
+  /// In ja, this message translates to:
+  /// **'保存済みのマシンはありません。\nマシンを追加すると、すばやく接続したり、オフライン時に Bridge Server をリモート起動できます。'**
+  String get machineNoSavedDescription;
+
+  /// No description provided for @addMachine.
+  ///
+  /// In ja, this message translates to:
+  /// **'マシンを追加'**
+  String get addMachine;
+
+  /// No description provided for @editMachine.
+  ///
+  /// In ja, this message translates to:
+  /// **'マシンを編集'**
+  String get editMachine;
+
+  /// No description provided for @machineBasicInfo.
+  ///
+  /// In ja, this message translates to:
+  /// **'基本情報'**
+  String get machineBasicInfo;
+
+  /// No description provided for @machineNameLabel.
+  ///
+  /// In ja, this message translates to:
+  /// **'名前'**
+  String get machineNameLabel;
+
+  /// No description provided for @machineNameHint.
+  ///
+  /// In ja, this message translates to:
+  /// **'自宅の Mac'**
+  String get machineNameHint;
+
+  /// No description provided for @machineHostLabel.
+  ///
+  /// In ja, this message translates to:
+  /// **'ホスト（IP またはホスト名）'**
+  String get machineHostLabel;
+
+  /// No description provided for @portLabel.
+  ///
+  /// In ja, this message translates to:
+  /// **'ポート'**
+  String get portLabel;
+
+  /// No description provided for @sshConfiguration.
+  ///
+  /// In ja, this message translates to:
+  /// **'SSH 設定'**
+  String get sshConfiguration;
+
+  /// No description provided for @sshEnableRemoteStartup.
+  ///
+  /// In ja, this message translates to:
+  /// **'SSH リモート起動を有効化'**
+  String get sshEnableRemoteStartup;
+
+  /// No description provided for @sshRemoteStartupSubtitle.
+  ///
+  /// In ja, this message translates to:
+  /// **'オフライン時に Bridge Server をリモート起動'**
+  String get sshRemoteStartupSubtitle;
+
+  /// No description provided for @sshUsernameLabel.
+  ///
+  /// In ja, this message translates to:
+  /// **'SSH ユーザー名'**
+  String get sshUsernameLabel;
+
+  /// No description provided for @sshPortLabel.
+  ///
+  /// In ja, this message translates to:
+  /// **'SSH ポート'**
+  String get sshPortLabel;
+
+  /// No description provided for @sshPrivateKeyLabel.
+  ///
+  /// In ja, this message translates to:
+  /// **'SSH 秘密鍵（PEM）'**
+  String get sshPrivateKeyLabel;
+
+  /// No description provided for @sshPrivateKeyHint.
+  ///
+  /// In ja, this message translates to:
+  /// **'-----BEGIN OPENSSH PRIVATE KEY-----'**
+  String get sshPrivateKeyHint;
+
+  /// No description provided for @testConnection.
+  ///
+  /// In ja, this message translates to:
+  /// **'接続テスト'**
+  String get testConnection;
+
+  /// No description provided for @testingConnection.
+  ///
+  /// In ja, this message translates to:
+  /// **'テスト中...'**
+  String get testingConnection;
+
+  /// No description provided for @sshCredentialsRequired.
+  ///
+  /// In ja, this message translates to:
+  /// **'SSH 認証情報を入力してください'**
+  String get sshCredentialsRequired;
+
+  /// No description provided for @connectionSuccessful.
+  ///
+  /// In ja, this message translates to:
+  /// **'接続に成功しました！'**
+  String get connectionSuccessful;
+
+  /// No description provided for @addAndConnect.
+  ///
+  /// In ja, this message translates to:
+  /// **'追加して接続'**
+  String get addAndConnect;
 
   /// No description provided for @openSourceLicenses.
   ///
@@ -2222,6 +2752,24 @@ abstract class AppLocalizations {
   /// **'Diff選択を解除'**
   String get tooltipClearDiff;
 
+  /// No description provided for @messageHistoryCount.
+  ///
+  /// In ja, this message translates to:
+  /// **'{count} 件のメッセージ'**
+  String messageHistoryCount(int count);
+
+  /// No description provided for @noMessagesYet.
+  ///
+  /// In ja, this message translates to:
+  /// **'まだメッセージはありません'**
+  String get noMessagesYet;
+
+  /// No description provided for @messagesAppearAfterProcessing.
+  ///
+  /// In ja, this message translates to:
+  /// **'メッセージはエージェントが処理した後にここに表示されます'**
+  String get messagesAppearAfterProcessing;
+
   /// No description provided for @showMore.
   ///
   /// In ja, this message translates to:
@@ -2233,6 +2781,18 @@ abstract class AppLocalizations {
   /// In ja, this message translates to:
   /// **'閉じる'**
   String get showLess;
+
+  /// No description provided for @sessionStarted.
+  ///
+  /// In ja, this message translates to:
+  /// **'セッション開始 ({model})'**
+  String sessionStarted(String model);
+
+  /// No description provided for @systemSubtypeLabel.
+  ///
+  /// In ja, this message translates to:
+  /// **'System: {subtype}'**
+  String systemSubtypeLabel(String subtype);
 
   /// No description provided for @authErrorTitle.
   ///
@@ -2293,6 +2853,12 @@ abstract class AppLocalizations {
   /// In ja, this message translates to:
   /// **'English'**
   String get authHelpLanguageEn;
+
+  /// No description provided for @authHelpLanguageZhHans.
+  ///
+  /// In ja, this message translates to:
+  /// **'简体中文'**
+  String get authHelpLanguageZhHans;
 
   /// No description provided for @terminalApp.
   ///
@@ -2426,7 +2992,7 @@ class _AppLocalizationsDelegate
 
   @override
   bool isSupported(Locale locale) =>
-      <String>['en', 'ja'].contains(locale.languageCode);
+      <String>['en', 'ja', 'zh'].contains(locale.languageCode);
 
   @override
   bool shouldReload(_AppLocalizationsDelegate old) => false;
@@ -2439,6 +3005,8 @@ AppLocalizations lookupAppLocalizations(Locale locale) {
       return AppLocalizationsEn();
     case 'ja':
       return AppLocalizationsJa();
+    case 'zh':
+      return AppLocalizationsZh();
   }
 
   throw FlutterError(

--- a/apps/mobile/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/lib/l10n/app_localizations_en.dart
@@ -260,6 +260,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get offline => 'Offline';
 
   @override
+  String get disconnected => 'Disconnected';
+
+  @override
+  String get reconnecting => 'Reconnecting...';
+
+  @override
   String get unreachable => 'Unreachable';
 
   @override
@@ -287,7 +293,55 @@ class AppLocalizationsEn extends AppLocalizations {
   String get worktree => 'Worktree';
 
   @override
+  String get worktreeTooltip =>
+      'Creates an isolated git working tree for this session.';
+
+  @override
   String get advanced => 'Advanced';
+
+  @override
+  String get environmentSection => 'Environment';
+
+  @override
+  String get permissionDefaultMode => 'Default';
+
+  @override
+  String get permissionAcceptEditsMode => 'Accept Edits';
+
+  @override
+  String get permissionPlanMode => 'Plan';
+
+  @override
+  String get permissionBypassMode => 'Bypass All';
+
+  @override
+  String get permissionDefaultDescription => 'Standard permission prompts';
+
+  @override
+  String get permissionAcceptEditsDescription => 'Auto-approve file edits';
+
+  @override
+  String get permissionPlanDescription => 'Analyze and plan without executing';
+
+  @override
+  String get permissionBypassDescription => 'Skip all permission prompts';
+
+  @override
+  String get permissionModeTitle => 'Permission Mode';
+
+  @override
+  String get changePermissionModeTitle => 'Change Permission Mode';
+
+  @override
+  String changePermissionModeBody(String mode) {
+    return 'Switching to $mode will restart the session. Your conversation will be preserved.';
+  }
+
+  @override
+  String get permissionChipAcceptEdits => 'Edits';
+
+  @override
+  String get permissionChipBypass => 'Bypass';
 
   @override
   String get modelOptional => 'Model (optional)';
@@ -330,6 +384,43 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get sandbox => 'Sandbox';
+
+  @override
+  String get sandboxModeTitle => 'Sandbox Mode';
+
+  @override
+  String get sandboxSafeMode => 'Sandbox (Safe Mode)';
+
+  @override
+  String get sandboxStandard => 'Standard';
+
+  @override
+  String get sandboxOnLabel => 'Sandbox On';
+
+  @override
+  String get sandboxOffLabel => 'Sandbox Off';
+
+  @override
+  String get sandboxRestrictedDescription =>
+      'Run commands in restricted environment';
+
+  @override
+  String get sandboxNativeDescription => 'Run commands natively';
+
+  @override
+  String get sandboxNativeCautionDescription =>
+      'Run commands natively (CAUTION)';
+
+  @override
+  String get changeSandboxModeTitle => 'Change Sandbox Mode';
+
+  @override
+  String changeSandboxModeBody(String mode) {
+    return 'Switching to $mode will restart the session. Your conversation will be preserved.';
+  }
+
+  @override
+  String get sandboxChipOff => 'No SB';
 
   @override
   String get reasoning => 'Reasoning';
@@ -402,7 +493,15 @@ class AppLocalizationsEn extends AppLocalizations {
   String get always => 'Always';
 
   @override
+  String get restart => 'Restart';
+
+  @override
   String get messagePlaceholder => 'Message Claude...';
+
+  @override
+  String messageProviderPlaceholder(String provider) {
+    return 'Message $provider...';
+  }
 
   @override
   String filesMentioned(int count) {
@@ -441,6 +540,27 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get claudeIsAsking => 'Claude is asking';
+
+  @override
+  String get codexIsAsking => 'Codex is asking';
+
+  @override
+  String get questionNeedsYourAnswer => 'Question needs your answer';
+
+  @override
+  String get toolApprovalNeeded => 'Tool approval needed';
+
+  @override
+  String get codexToolApprovalNeeded => 'Codex tool approval needed';
+
+  @override
+  String get sessionCompleteTitle => 'Session Complete';
+
+  @override
+  String get sessionDone => 'Session done';
+
+  @override
+  String get codexSessionDone => 'Codex session done';
 
   @override
   String get submitAllAnswers => 'Submit All Answers';
@@ -716,6 +836,11 @@ class AppLocalizationsEn extends AppLocalizations {
   String get creatingSession => 'Creating session...';
 
   @override
+  String startWithProvider(String provider) {
+    return 'Start with $provider';
+  }
+
+  @override
   String get copyForAgent => 'Copy for Agent';
 
   @override
@@ -726,6 +851,21 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get screenshot => 'Screenshot';
+
+  @override
+  String get screenshotSaved => 'Screenshot saved';
+
+  @override
+  String get screenshotFailed => 'Screenshot failed';
+
+  @override
+  String get fullScreen => 'Full Screen';
+
+  @override
+  String get captureEntireDesktop => 'Capture entire desktop';
+
+  @override
+  String get noWindowsFound => 'No windows found';
 
   @override
   String get debug => 'Debug';
@@ -767,7 +907,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get recent => 'Recent';
 
   @override
+  String get newShort => 'New';
+
+  @override
   String get searchHint => 'Search...';
+
+  @override
+  String get searchSessionsHint => 'Search sessions...';
 
   @override
   String get noMatchingPrompts => 'No matching prompts';
@@ -823,6 +969,71 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get working => 'Working...';
+
+  @override
+  String get runningSessions => 'Running';
+
+  @override
+  String get recentSessions => 'Recent Sessions';
+
+  @override
+  String get displayFirst => 'First';
+
+  @override
+  String get displayLast => 'Last';
+
+  @override
+  String get displaySummary => 'Summary';
+
+  @override
+  String get filterAllAiTools => 'All AI Tools';
+
+  @override
+  String get filterAllProjects => 'All Projects';
+
+  @override
+  String get filterNamed => 'Named';
+
+  @override
+  String get statusStarting => 'Starting';
+
+  @override
+  String get statusIdle => 'Idle';
+
+  @override
+  String get statusRunning => 'Running';
+
+  @override
+  String get statusApproval => 'Approval';
+
+  @override
+  String get statusCompacting => 'Compacting';
+
+  @override
+  String get statusWorking => 'Working';
+
+  @override
+  String get statusNeedsYou => 'Needs You';
+
+  @override
+  String get statusReady => 'Ready';
+
+  @override
+  String get statusCleaningContext => 'Cleaning up context';
+
+  @override
+  String get statusReviewPlan => 'Review plan';
+
+  @override
+  String get statusApproveToolCall => 'Approve tool call';
+
+  @override
+  String get statusAnswerQuestion => 'Answer question';
+
+  @override
+  String statusApproveTool(String toolName) {
+    return 'Approve $toolName';
+  }
 
   @override
   String get waitingForApprovalRequests =>
@@ -892,6 +1103,74 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get setupGuideSubtitle => 'New here? Start with this';
+
+  @override
+  String get machineSectionTitle => 'Machines';
+
+  @override
+  String get machineRefreshStatus => 'Refresh status';
+
+  @override
+  String get machineNoSavedDescription =>
+      'No saved machines.\nAdd one to quickly connect or remotely start the Bridge Server.';
+
+  @override
+  String get addMachine => 'Add Machine';
+
+  @override
+  String get editMachine => 'Edit Machine';
+
+  @override
+  String get machineBasicInfo => 'Basic Info';
+
+  @override
+  String get machineNameLabel => 'Name';
+
+  @override
+  String get machineNameHint => 'Home Mac';
+
+  @override
+  String get machineHostLabel => 'Host (IP or hostname)';
+
+  @override
+  String get portLabel => 'Port';
+
+  @override
+  String get sshConfiguration => 'SSH Configuration';
+
+  @override
+  String get sshEnableRemoteStartup => 'Enable SSH remote startup';
+
+  @override
+  String get sshRemoteStartupSubtitle =>
+      'Remotely start Bridge Server when offline';
+
+  @override
+  String get sshUsernameLabel => 'SSH Username';
+
+  @override
+  String get sshPortLabel => 'SSH Port';
+
+  @override
+  String get sshPrivateKeyLabel => 'SSH Private Key (PEM)';
+
+  @override
+  String get sshPrivateKeyHint => '-----BEGIN OPENSSH PRIVATE KEY-----';
+
+  @override
+  String get testConnection => 'Test Connection';
+
+  @override
+  String get testingConnection => 'Testing...';
+
+  @override
+  String get sshCredentialsRequired => 'Please fill in SSH credentials';
+
+  @override
+  String get connectionSuccessful => 'Connection successful!';
+
+  @override
+  String get addAndConnect => 'Add & Connect';
 
   @override
   String get openSourceLicenses => 'Open Source Licenses';
@@ -1158,10 +1437,32 @@ class AppLocalizationsEn extends AppLocalizations {
   String get tooltipClearDiff => 'Clear diff selection';
 
   @override
+  String messageHistoryCount(int count) {
+    return '$count messages';
+  }
+
+  @override
+  String get noMessagesYet => 'No messages yet';
+
+  @override
+  String get messagesAppearAfterProcessing =>
+      'Messages will appear here after the agent processes them';
+
+  @override
   String get showMore => 'Show more';
 
   @override
   String get showLess => 'Show less';
+
+  @override
+  String sessionStarted(String model) {
+    return 'Session started ($model)';
+  }
+
+  @override
+  String systemSubtypeLabel(String subtype) {
+    return 'System: $subtype';
+  }
 
   @override
   String get authErrorTitle => 'Claude login required';
@@ -1193,6 +1494,9 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get authHelpLanguageEn => 'English';
+
+  @override
+  String get authHelpLanguageZhHans => '简体中文';
 
   @override
   String get terminalApp => 'Terminal App';

--- a/apps/mobile/lib/l10n/app_localizations_ja.dart
+++ b/apps/mobile/lib/l10n/app_localizations_ja.dart
@@ -259,6 +259,12 @@ class AppLocalizationsJa extends AppLocalizations {
   String get offline => 'オフライン';
 
   @override
+  String get disconnected => '切断されました';
+
+  @override
+  String get reconnecting => '再接続中...';
+
+  @override
   String get unreachable => '接続不可';
 
   @override
@@ -283,10 +289,57 @@ class AppLocalizationsJa extends AppLocalizations {
   String get approval => '承認';
 
   @override
-  String get worktree => 'Worktree';
+  String get worktree => 'ワークツリー';
+
+  @override
+  String get worktreeTooltip => 'このセッション用に独立した git worktree を作成します。';
 
   @override
   String get advanced => '詳細設定';
+
+  @override
+  String get environmentSection => '環境';
+
+  @override
+  String get permissionDefaultMode => 'デフォルト';
+
+  @override
+  String get permissionAcceptEditsMode => '編集を自動承認';
+
+  @override
+  String get permissionPlanMode => '計画';
+
+  @override
+  String get permissionBypassMode => 'すべてバイパス';
+
+  @override
+  String get permissionDefaultDescription => '標準の権限確認';
+
+  @override
+  String get permissionAcceptEditsDescription => 'ファイル編集を自動承認';
+
+  @override
+  String get permissionPlanDescription => '実行せずに分析と計画を行う';
+
+  @override
+  String get permissionBypassDescription => 'すべての権限確認をスキップ';
+
+  @override
+  String get permissionModeTitle => '権限モード';
+
+  @override
+  String get changePermissionModeTitle => '権限モードを変更';
+
+  @override
+  String changePermissionModeBody(String mode) {
+    return '$mode に切り替えるとセッションが再起動します。会話は保持されます。';
+  }
+
+  @override
+  String get permissionChipAcceptEdits => '編集';
+
+  @override
+  String get permissionChipBypass => 'バイパス';
 
   @override
   String get modelOptional => 'モデル（任意）';
@@ -328,7 +381,42 @@ class AppLocalizationsJa extends AppLocalizations {
   String get model => 'モデル';
 
   @override
-  String get sandbox => 'Sandbox';
+  String get sandbox => 'サンドボックス';
+
+  @override
+  String get sandboxModeTitle => 'サンドボックスモード';
+
+  @override
+  String get sandboxSafeMode => 'Sandbox（セーフモード）';
+
+  @override
+  String get sandboxStandard => '標準';
+
+  @override
+  String get sandboxOnLabel => 'サンドボックス ON';
+
+  @override
+  String get sandboxOffLabel => 'サンドボックス OFF';
+
+  @override
+  String get sandboxRestrictedDescription => '制限された環境でコマンドを実行';
+
+  @override
+  String get sandboxNativeDescription => 'ネイティブ環境でコマンドを実行';
+
+  @override
+  String get sandboxNativeCautionDescription => 'ネイティブ環境でコマンドを実行（注意）';
+
+  @override
+  String get changeSandboxModeTitle => 'サンドボックスモードを変更';
+
+  @override
+  String changeSandboxModeBody(String mode) {
+    return '$mode に切り替えるとセッションが再起動します。会話は保持されます。';
+  }
+
+  @override
+  String get sandboxChipOff => 'No SB';
 
   @override
   String get reasoning => 'Reasoning';
@@ -399,7 +487,15 @@ class AppLocalizationsJa extends AppLocalizations {
   String get always => '常に許可';
 
   @override
+  String get restart => '再起動';
+
+  @override
   String get messagePlaceholder => 'Claude にメッセージ...';
+
+  @override
+  String messageProviderPlaceholder(String provider) {
+    return '$provider にメッセージ...';
+  }
 
   @override
   String filesMentioned(int count) {
@@ -438,6 +534,27 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get claudeIsAsking => 'Claude が質問しています';
+
+  @override
+  String get codexIsAsking => 'Codex が質問しています';
+
+  @override
+  String get questionNeedsYourAnswer => '質問への回答が必要です';
+
+  @override
+  String get toolApprovalNeeded => 'ツール承認が必要です';
+
+  @override
+  String get codexToolApprovalNeeded => 'Codex のツール承認が必要です';
+
+  @override
+  String get sessionCompleteTitle => 'セッション完了';
+
+  @override
+  String get sessionDone => 'セッションが完了しました';
+
+  @override
+  String get codexSessionDone => 'Codex セッションが完了しました';
 
   @override
   String get submitAllAnswers => 'すべての回答を送信';
@@ -706,6 +823,11 @@ class AppLocalizationsJa extends AppLocalizations {
   String get creatingSession => 'セッション作成中...';
 
   @override
+  String startWithProvider(String provider) {
+    return '$provider で開始';
+  }
+
+  @override
   String get copyForAgent => 'エージェント用にコピー';
 
   @override
@@ -716,6 +838,21 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get screenshot => 'スクリーンショット';
+
+  @override
+  String get screenshotSaved => 'スクリーンショットを保存しました';
+
+  @override
+  String get screenshotFailed => 'スクリーンショットに失敗しました';
+
+  @override
+  String get fullScreen => 'フルスクリーン';
+
+  @override
+  String get captureEntireDesktop => 'デスクトップ全体をキャプチャ';
+
+  @override
+  String get noWindowsFound => 'ウィンドウが見つかりません';
 
   @override
   String get debug => 'デバッグ';
@@ -757,7 +894,13 @@ class AppLocalizationsJa extends AppLocalizations {
   String get recent => '新しい順';
 
   @override
+  String get newShort => '新規';
+
+  @override
   String get searchHint => '検索...';
+
+  @override
+  String get searchSessionsHint => 'セッションを検索...';
 
   @override
   String get noMatchingPrompts => '一致するプロンプトがありません';
@@ -813,6 +956,71 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get working => '処理中...';
+
+  @override
+  String get runningSessions => '実行中';
+
+  @override
+  String get recentSessions => '最近のセッション';
+
+  @override
+  String get displayFirst => '先頭';
+
+  @override
+  String get displayLast => '最新';
+
+  @override
+  String get displaySummary => '要約';
+
+  @override
+  String get filterAllAiTools => 'すべてのAIツール';
+
+  @override
+  String get filterAllProjects => 'すべてのプロジェクト';
+
+  @override
+  String get filterNamed => '名前付き';
+
+  @override
+  String get statusStarting => '起動中';
+
+  @override
+  String get statusIdle => '待機中';
+
+  @override
+  String get statusRunning => '実行中';
+
+  @override
+  String get statusApproval => '承認待ち';
+
+  @override
+  String get statusCompacting => '圧縮中';
+
+  @override
+  String get statusWorking => '作業中';
+
+  @override
+  String get statusNeedsYou => '対応待ち';
+
+  @override
+  String get statusReady => '準備完了';
+
+  @override
+  String get statusCleaningContext => 'コンテキスト整理中';
+
+  @override
+  String get statusReviewPlan => 'プランを確認';
+
+  @override
+  String get statusApproveToolCall => 'ツール呼び出しを承認';
+
+  @override
+  String get statusAnswerQuestion => '質問に回答';
+
+  @override
+  String statusApproveTool(String toolName) {
+    return '$toolName を承認';
+  }
 
   @override
   String get waitingForApprovalRequests => 'エージェントからの承認リクエストを待っています。';
@@ -879,6 +1087,73 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get setupGuideSubtitle => '初めての方はこちら';
+
+  @override
+  String get machineSectionTitle => 'マシン';
+
+  @override
+  String get machineRefreshStatus => '状態を更新';
+
+  @override
+  String get machineNoSavedDescription =>
+      '保存済みのマシンはありません。\nマシンを追加すると、すばやく接続したり、オフライン時に Bridge Server をリモート起動できます。';
+
+  @override
+  String get addMachine => 'マシンを追加';
+
+  @override
+  String get editMachine => 'マシンを編集';
+
+  @override
+  String get machineBasicInfo => '基本情報';
+
+  @override
+  String get machineNameLabel => '名前';
+
+  @override
+  String get machineNameHint => '自宅の Mac';
+
+  @override
+  String get machineHostLabel => 'ホスト（IP またはホスト名）';
+
+  @override
+  String get portLabel => 'ポート';
+
+  @override
+  String get sshConfiguration => 'SSH 設定';
+
+  @override
+  String get sshEnableRemoteStartup => 'SSH リモート起動を有効化';
+
+  @override
+  String get sshRemoteStartupSubtitle => 'オフライン時に Bridge Server をリモート起動';
+
+  @override
+  String get sshUsernameLabel => 'SSH ユーザー名';
+
+  @override
+  String get sshPortLabel => 'SSH ポート';
+
+  @override
+  String get sshPrivateKeyLabel => 'SSH 秘密鍵（PEM）';
+
+  @override
+  String get sshPrivateKeyHint => '-----BEGIN OPENSSH PRIVATE KEY-----';
+
+  @override
+  String get testConnection => '接続テスト';
+
+  @override
+  String get testingConnection => 'テスト中...';
+
+  @override
+  String get sshCredentialsRequired => 'SSH 認証情報を入力してください';
+
+  @override
+  String get connectionSuccessful => '接続に成功しました！';
+
+  @override
+  String get addAndConnect => '追加して接続';
 
   @override
   String get openSourceLicenses => 'オープンソースライセンス';
@@ -1143,10 +1418,31 @@ class AppLocalizationsJa extends AppLocalizations {
   String get tooltipClearDiff => 'Diff選択を解除';
 
   @override
+  String messageHistoryCount(int count) {
+    return '$count 件のメッセージ';
+  }
+
+  @override
+  String get noMessagesYet => 'まだメッセージはありません';
+
+  @override
+  String get messagesAppearAfterProcessing => 'メッセージはエージェントが処理した後にここに表示されます';
+
+  @override
   String get showMore => 'もっと見る';
 
   @override
   String get showLess => '閉じる';
+
+  @override
+  String sessionStarted(String model) {
+    return 'セッション開始 ($model)';
+  }
+
+  @override
+  String systemSubtypeLabel(String subtype) {
+    return 'System: $subtype';
+  }
 
   @override
   String get authErrorTitle => 'Claude Codeの再ログインが必要です';
@@ -1177,6 +1473,9 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get authHelpLanguageEn => 'English';
+
+  @override
+  String get authHelpLanguageZhHans => '简体中文';
 
   @override
   String get terminalApp => 'ターミナルアプリ';

--- a/apps/mobile/lib/l10n/app_localizations_zh.dart
+++ b/apps/mobile/lib/l10n/app_localizations_zh.dart
@@ -1,0 +1,1532 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for Chinese (`zh`).
+class AppLocalizationsZh extends AppLocalizations {
+  AppLocalizationsZh([String locale = 'zh']) : super(locale);
+
+  @override
+  String get appTitle => 'CC Pocket';
+
+  @override
+  String get cancel => '取消';
+
+  @override
+  String get save => '保存';
+
+  @override
+  String get delete => '删除';
+
+  @override
+  String get remove => '移除';
+
+  @override
+  String get removeProjectTitle => '移除项目';
+
+  @override
+  String removeProjectConfirm(Object name) {
+    return '要从最近项目中移除“$name”吗？';
+  }
+
+  @override
+  String get rename => '重命名';
+
+  @override
+  String get renameSession => '重命名会话';
+
+  @override
+  String get sessionNameHint => '会话名称';
+
+  @override
+  String get clearName => '清除名称';
+
+  @override
+  String get connect => '连接';
+
+  @override
+  String get copy => '复制';
+
+  @override
+  String get copied => '已复制';
+
+  @override
+  String get copiedToClipboard => '已复制到剪贴板';
+
+  @override
+  String get lineCopied => '已复制此行';
+
+  @override
+  String get start => '开始';
+
+  @override
+  String get stop => '停止';
+
+  @override
+  String get send => '发送';
+
+  @override
+  String get settings => '设置';
+
+  @override
+  String get gallery => '图库';
+
+  @override
+  String galleryWithCount(int count) {
+    return '图库 ($count)';
+  }
+
+  @override
+  String get disconnect => '断开连接';
+
+  @override
+  String get back => '返回';
+
+  @override
+  String get next => '下一步';
+
+  @override
+  String get done => '完成';
+
+  @override
+  String get skip => '跳过';
+
+  @override
+  String get edit => '编辑';
+
+  @override
+  String get share => '分享';
+
+  @override
+  String get all => '全部';
+
+  @override
+  String get none => '无';
+
+  @override
+  String get serverUnreachable => '无法连接服务器';
+
+  @override
+  String get serverUnreachableBody => '无法访问以下 Bridge 服务器：';
+
+  @override
+  String get setupSteps => '设置步骤：';
+
+  @override
+  String get setupStep1Title => '启动 Bridge 服务器';
+
+  @override
+  String get setupStep1Command => 'npx @ccpocket/bridge@latest';
+
+  @override
+  String get setupStep2Title => '如需常驻运行，请注册为服务';
+
+  @override
+  String get setupStep2Command => 'npx @ccpocket/bridge@latest setup';
+
+  @override
+  String get setupNetworkHint => '请确认两台设备位于同一网络中（或使用 Tailscale）。';
+
+  @override
+  String get connectAnyway => '仍然连接';
+
+  @override
+  String get stopSession => '停止会话';
+
+  @override
+  String get stopSessionConfirm => '要停止此会话吗？Claude 进程将被终止。';
+
+  @override
+  String get startNewWithSameSettings => '使用相同设置新建';
+
+  @override
+  String get editSettingsThenStart => '先修改设置再开始';
+
+  @override
+  String get serverRequiresApiKey => '此服务器需要 API 密钥';
+
+  @override
+  String get bridgeServerUpdated => 'Bridge 服务已更新';
+
+  @override
+  String get failedToUpdateServer => '更新服务器失败';
+
+  @override
+  String get bridgeServerStarted => 'Bridge 服务已启动';
+
+  @override
+  String get failedToStartServer => '启动服务器失败';
+
+  @override
+  String get bridgeServerStopped => 'Bridge 服务已停止';
+
+  @override
+  String get failedToStopServer => '停止服务器失败';
+
+  @override
+  String get sshPassword => 'SSH 密码';
+
+  @override
+  String sshPasswordPrompt(String machineName) {
+    return '请输入 $machineName 的 SSH 密码';
+  }
+
+  @override
+  String get password => '密码';
+
+  @override
+  String get deleteMachine => '删除机器';
+
+  @override
+  String deleteMachineConfirm(String displayName) {
+    return '要删除“$displayName”吗？这会移除所有已保存的凭据。';
+  }
+
+  @override
+  String get connectToBridgeServer => '连接到 Bridge 服务';
+
+  @override
+  String get orConnectManually => '或手动连接';
+
+  @override
+  String get serverUrl => '服务器 URL';
+
+  @override
+  String get serverUrlHint => 'ws://<host-ip>:8765';
+
+  @override
+  String get apiKeyOptional => 'API 密钥（可选）';
+
+  @override
+  String get apiKeyHint => '如果没有认证可留空';
+
+  @override
+  String get scanQrCode => '扫描二维码';
+
+  @override
+  String get setupGuide => '设置指南';
+
+  @override
+  String get readyToStart => '准备就绪';
+
+  @override
+  String get readyToStartDescription => '点击 + 按钮创建新会话，并开始用 Claude 编码。';
+
+  @override
+  String get newSession => '新建会话';
+
+  @override
+  String get neverConnected => '从未连接';
+
+  @override
+  String get justNow => '刚刚';
+
+  @override
+  String minutesAgo(int minutes) {
+    return '$minutes 分钟前';
+  }
+
+  @override
+  String hoursAgo(int hours) {
+    return '$hours 小时前';
+  }
+
+  @override
+  String daysAgo(int days) {
+    return '$days 天前';
+  }
+
+  @override
+  String get unfavorite => '取消收藏';
+
+  @override
+  String get favorite => '收藏';
+
+  @override
+  String get updateBridge => '更新 Bridge';
+
+  @override
+  String get stopServer => '停止服务器';
+
+  @override
+  String get update => '更新';
+
+  @override
+  String get offline => '离线';
+
+  @override
+  String get disconnected => '已断开连接';
+
+  @override
+  String get reconnecting => '正在重新连接...';
+
+  @override
+  String get unreachable => '不可达';
+
+  @override
+  String get checking => '检查中...';
+
+  @override
+  String get recentProjects => '最近项目';
+
+  @override
+  String get orEnterPath => '或输入路径';
+
+  @override
+  String get projectPath => '项目路径';
+
+  @override
+  String get projectPathHint => '/path/to/your/project';
+
+  @override
+  String get permission => '权限';
+
+  @override
+  String get approval => '审批';
+
+  @override
+  String get worktree => '工作树';
+
+  @override
+  String get worktreeTooltip => '为此会话创建独立的 git 工作树。';
+
+  @override
+  String get advanced => '高级';
+
+  @override
+  String get environmentSection => '环境';
+
+  @override
+  String get permissionDefaultMode => '默认';
+
+  @override
+  String get permissionAcceptEditsMode => '自动批准编辑';
+
+  @override
+  String get permissionPlanMode => '规划';
+
+  @override
+  String get permissionBypassMode => '全部绕过';
+
+  @override
+  String get permissionDefaultDescription => '标准权限提示';
+
+  @override
+  String get permissionAcceptEditsDescription => '自动批准文件编辑';
+
+  @override
+  String get permissionPlanDescription => '仅分析和规划，不执行';
+
+  @override
+  String get permissionBypassDescription => '跳过所有权限提示';
+
+  @override
+  String get permissionModeTitle => '权限模式';
+
+  @override
+  String get changePermissionModeTitle => '更改权限模式';
+
+  @override
+  String changePermissionModeBody(String mode) {
+    return '切换到 $mode 会重启当前会话。你的对话会被保留。';
+  }
+
+  @override
+  String get permissionChipAcceptEdits => '编辑';
+
+  @override
+  String get permissionChipBypass => '绕过';
+
+  @override
+  String get modelOptional => '模型（可选）';
+
+  @override
+  String get effort => 'Effort';
+
+  @override
+  String get defaultLabel => '默认';
+
+  @override
+  String get maxTurns => '最大轮数';
+
+  @override
+  String get maxTurnsHint => '例如：8';
+
+  @override
+  String get maxTurnsError => '必须输入大于 0 的整数';
+
+  @override
+  String get maxBudgetUsd => '最大预算（USD）';
+
+  @override
+  String get maxBudgetHint => '例如：1.00';
+
+  @override
+  String get maxBudgetError => '必须输入大于等于 0 的数字';
+
+  @override
+  String get fallbackModel => '回退模型';
+
+  @override
+  String get forkSessionOnResume => '恢复时分叉会话';
+
+  @override
+  String get persistSessionHistory => '保留会话历史';
+
+  @override
+  String get model => '模型';
+
+  @override
+  String get sandbox => '沙箱';
+
+  @override
+  String get sandboxModeTitle => '沙箱模式';
+
+  @override
+  String get sandboxSafeMode => '沙箱（安全模式）';
+
+  @override
+  String get sandboxStandard => '标准';
+
+  @override
+  String get sandboxOnLabel => '沙箱开启';
+
+  @override
+  String get sandboxOffLabel => '沙箱关闭';
+
+  @override
+  String get sandboxRestrictedDescription => '在受限环境中运行命令';
+
+  @override
+  String get sandboxNativeDescription => '在原生环境中运行命令';
+
+  @override
+  String get sandboxNativeCautionDescription => '在原生环境中运行命令（谨慎）';
+
+  @override
+  String get changeSandboxModeTitle => '更改沙箱模式';
+
+  @override
+  String changeSandboxModeBody(String mode) {
+    return '切换到 $mode 会重启当前会话。你的对话会被保留。';
+  }
+
+  @override
+  String get sandboxChipOff => '无沙箱';
+
+  @override
+  String get reasoning => 'Reasoning';
+
+  @override
+  String get webSearch => 'Web Search';
+
+  @override
+  String get networkAccess => '网络访问';
+
+  @override
+  String get worktreeNew => '新建';
+
+  @override
+  String worktreeExisting(int count) {
+    return '已有 ($count)';
+  }
+
+  @override
+  String get branchOptional => '分支（可选）';
+
+  @override
+  String get branchHint => 'ccpocket/<auto>';
+
+  @override
+  String get noExistingWorktrees => '没有现有 worktree';
+
+  @override
+  String get planApprovalSummary => '请查看上方计划，并选择批准或继续规划';
+
+  @override
+  String get planApprovalSummaryCard => '请查看计划，并选择批准或继续规划';
+
+  @override
+  String get toolApprovalSummary => '执行工具需要批准';
+
+  @override
+  String get planApproval => '计划批准';
+
+  @override
+  String get approvalRequired => '需要批准';
+
+  @override
+  String get viewEditPlan => '查看 / 编辑计划';
+
+  @override
+  String get keepPlanning => '继续规划';
+
+  @override
+  String get keepPlanningHint => '需要改什么...';
+
+  @override
+  String get sendFeedbackKeepPlanning => '发送反馈并继续规划';
+
+  @override
+  String get acceptAndClear => '批准并清除';
+
+  @override
+  String get acceptPlan => '批准计划';
+
+  @override
+  String get reject => '拒绝';
+
+  @override
+  String get approve => '批准';
+
+  @override
+  String get always => '始终';
+
+  @override
+  String get restart => '重启';
+
+  @override
+  String get messagePlaceholder => '给 Claude 发消息...';
+
+  @override
+  String messageProviderPlaceholder(String provider) {
+    return '给 $provider 发消息...';
+  }
+
+  @override
+  String filesMentioned(int count) {
+    return '已 @提及 $count 个文件';
+  }
+
+  @override
+  String diffLines(int count) {
+    return '$count 行 diff';
+  }
+
+  @override
+  String get tapInterruptHoldStop => '点按：中断，长按：停止';
+
+  @override
+  String get rewindToHere => '回退到这里';
+
+  @override
+  String get tapToRetry => '点按重试';
+
+  @override
+  String diffSummaryAddedRemoved(int added, int removed) {
+    return '+$added/-$removed 行';
+  }
+
+  @override
+  String lineCountSummary(int count) {
+    return '$count 行';
+  }
+
+  @override
+  String get toolResult => '工具结果';
+
+  @override
+  String get answered => '已回答';
+
+  @override
+  String get claudeIsAsking => 'Claude 正在提问';
+
+  @override
+  String get codexIsAsking => 'Codex 正在提问';
+
+  @override
+  String get questionNeedsYourAnswer => '问题需要你回答';
+
+  @override
+  String get toolApprovalNeeded => '需要你批准工具操作';
+
+  @override
+  String get codexToolApprovalNeeded => '需要你批准 Codex 的工具操作';
+
+  @override
+  String get sessionCompleteTitle => '会话已完成';
+
+  @override
+  String get sessionDone => '会话已结束';
+
+  @override
+  String get codexSessionDone => 'Codex 会话已结束';
+
+  @override
+  String get submitAllAnswers => '提交全部答案';
+
+  @override
+  String submitWithCount(int count) {
+    return '提交（已选择 $count 项）';
+  }
+
+  @override
+  String get selectOptionsToSubmit => '请选择要提交的选项';
+
+  @override
+  String get typeYourAnswer => '输入你的回答...';
+
+  @override
+  String get orTypeCustomAnswer => '或输入自定义回答...';
+
+  @override
+  String get otherAnswer => '其他回答...';
+
+  @override
+  String get selectAllThatApply => '选择所有适用项';
+
+  @override
+  String get noScreenshotsYet => '还没有截图';
+
+  @override
+  String get screenshotButtonHint => '使用聊天工具栏中的截图按钮来捕获截图。';
+
+  @override
+  String get screenshotsWillAppearHere => 'Claude 会话中的截图会显示在这里。';
+
+  @override
+  String allWithCount(int count) {
+    return '全部 ($count)';
+  }
+
+  @override
+  String get noImages => '没有图片';
+
+  @override
+  String get failedToDeleteImage => '删除图片失败';
+
+  @override
+  String get failedToDownloadImage => '下载图片失败';
+
+  @override
+  String get failedToShareImage => '分享图片失败';
+
+  @override
+  String get deleteScreenshot => '要删除截图吗？';
+
+  @override
+  String get cannotBeUndone => '此操作无法撤销。';
+
+  @override
+  String get changes => '变更';
+
+  @override
+  String get cancelSelection => '取消选择';
+
+  @override
+  String get selectAndAttach => '选择并附加';
+
+  @override
+  String get refresh => '刷新';
+
+  @override
+  String get diffCompareSideBySide => '并排';
+
+  @override
+  String get diffCompareSlider => '滑块';
+
+  @override
+  String get diffCompareOverlay => '叠加';
+
+  @override
+  String get diffCompareToggle => '切换';
+
+  @override
+  String get diffBefore => '变更前';
+
+  @override
+  String get diffAfter => '变更后';
+
+  @override
+  String get diffNewFile => '新文件';
+
+  @override
+  String get diffDeleted => '已删除';
+
+  @override
+  String get diffNoImage => '没有图片';
+
+  @override
+  String get filterFiles => '筛选文件';
+
+  @override
+  String attachFilesAndHunks(int files, int hunks) {
+    return '附加 $files 个文件，$hunks 个 hunk';
+  }
+
+  @override
+  String get filterFilesTitle => '筛选文件';
+
+  @override
+  String get noChanges => '没有变更';
+
+  @override
+  String get allFilesFilteredOut => '所有文件都被筛掉了';
+
+  @override
+  String get showAll => '显示全部';
+
+  @override
+  String get setupGuideTitle => '设置指南';
+
+  @override
+  String get guideAboutTitle => '什么是 CC Pocket？';
+
+  @override
+  String get guideAboutDescription =>
+      '一款可让你通过智能手机控制 Claude Code 和 Codex 的移动客户端。';
+
+  @override
+  String get guideAboutDiagramTitle => '工作方式';
+
+  @override
+  String get guideAboutDiagramPhone => 'iPhone';
+
+  @override
+  String get guideAboutDiagramBridge => 'Bridge 服务';
+
+  @override
+  String get guideAboutDiagramClaude => 'Claude CLI\n/ Codex';
+
+  @override
+  String get guideAboutDiagramCaption => '先在你的电脑上启动 Bridge 服务，\n然后从手机连接。';
+
+  @override
+  String get guideBridgeTitle => 'Bridge 服务\n设置';
+
+  @override
+  String get guideBridgeDescription => '先在你的电脑上启动 Bridge 服务。';
+
+  @override
+  String get guideBridgePrerequisites => '前置条件';
+
+  @override
+  String get guideBridgePrereq1 => '已安装 Node.js 的 Mac / PC';
+
+  @override
+  String get guideBridgePrereq2 => 'Claude Code CLI 或 Codex CLI\n（二选一即可）';
+
+  @override
+  String get guideBridgeStep1 => '使用 npx 运行（推荐）';
+
+  @override
+  String get guideBridgeStep1Command => 'npx @ccpocket/bridge@latest';
+
+  @override
+  String get guideBridgeStep2 => '或全局安装';
+
+  @override
+  String get guideBridgeStep2Command =>
+      'npm install -g @ccpocket/bridge\nccpocket-bridge';
+
+  @override
+  String get guideBridgeQrNote => '启动后，终端中会显示二维码';
+
+  @override
+  String get guideConnectionTitle => '连接方式';
+
+  @override
+  String get guideConnectionDescription => '如果处于同一个 Wi-Fi 网络下，你可以立即连接。';
+
+  @override
+  String get guideConnectionQr => '扫描二维码';
+
+  @override
+  String get guideConnectionQrDescription => '只需扫描终端中显示的二维码。最简单的方法。';
+
+  @override
+  String get guideConnectionMdns => '自动发现（mDNS）';
+
+  @override
+  String get guideConnectionMdnsDescription => '自动查找同一局域网中的 Bridge 服务。';
+
+  @override
+  String get guideConnectionManual => '手动输入';
+
+  @override
+  String get guideConnectionManualDescription =>
+      '直接输入 `ws://<IP 地址>:8765` 格式的地址。';
+
+  @override
+  String get guideConnectionRecommended => '推荐';
+
+  @override
+  String get guideTailscaleTitle => '远程访问';
+
+  @override
+  String get guideTailscaleDescription =>
+      '如果要在家外使用，Tailscale（VPN）可以帮助你安全地远程连接。';
+
+  @override
+  String get guideTailscaleStep1 => '在 Mac 和 iPhone 上都安装 Tailscale';
+
+  @override
+  String get guideTailscaleStep2 => '使用同一个账号登录';
+
+  @override
+  String get guideTailscaleStep3 =>
+      '在 Bridge URL 中使用 Tailscale IP\n（例如：ws://100.x.x.x:8765）';
+
+  @override
+  String get guideTailscaleWebsite => 'Tailscale 官网';
+
+  @override
+  String get guideTailscaleWebsiteHint => '访问官网获取更详细的设置说明。';
+
+  @override
+  String get guideLaunchdTitle => '自动启动设置';
+
+  @override
+  String get guideLaunchdDescription =>
+      '如果每次手动启动 Bridge 服务太麻烦，你可以将它配置为设备开机时自动启动。';
+
+  @override
+  String get guideLaunchdCommand => '设置命令';
+
+  @override
+  String get guideLaunchdCommandValue => 'npx @ccpocket/bridge@latest setup';
+
+  @override
+  String get guideLaunchdRecommendation => '建议先通过手动启动验证一切正常，再在稳定后注册为服务。';
+
+  @override
+  String get guideAutostartMacDescription =>
+      '使用 launchd 注册。Shell 环境（nvm、Homebrew 等）会自动继承。';
+
+  @override
+  String get guideAutostartLinuxDescription =>
+      '创建 systemd 用户服务。适用于 Raspberry Pi 及其他 Linux 主机。';
+
+  @override
+  String get guideReadyTitle => '全部就绪！';
+
+  @override
+  String get guideReadyDescription => '启动 Bridge 服务并\n扫描二维码，\n马上开始。';
+
+  @override
+  String get guideReadyStart => '开始使用';
+
+  @override
+  String get guideReadyHint => '你也可以随时在设置中重新打开本指南';
+
+  @override
+  String get creatingSession => '正在创建会话...';
+
+  @override
+  String startWithProvider(String provider) {
+    return '用 $provider 开始';
+  }
+
+  @override
+  String get copyForAgent => '复制给 Agent';
+
+  @override
+  String get messageHistory => '消息历史';
+
+  @override
+  String get viewChanges => '查看变更';
+
+  @override
+  String get screenshot => '截图';
+
+  @override
+  String get screenshotSaved => '截图已保存';
+
+  @override
+  String get screenshotFailed => '截图失败';
+
+  @override
+  String get fullScreen => '全屏';
+
+  @override
+  String get captureEntireDesktop => '截取整个桌面';
+
+  @override
+  String get noWindowsFound => '未找到窗口';
+
+  @override
+  String get debug => '调试';
+
+  @override
+  String get logs => '日志';
+
+  @override
+  String get viewApplicationLogs => '查看应用日志';
+
+  @override
+  String get mockPreview => 'Mock 预览';
+
+  @override
+  String get viewMockChatScenarios => '查看 Mock 聊天场景';
+
+  @override
+  String get updateTrack => '更新轨道';
+
+  @override
+  String get updateTrackDescription => '更改后重启应用以生效';
+
+  @override
+  String get updateTrackStable => '稳定版';
+
+  @override
+  String get updateTrackStaging => '预发布版';
+
+  @override
+  String get updateDownloaded => '更新已下载。请重启应用以生效。';
+
+  @override
+  String get promptHistory => '提示词历史';
+
+  @override
+  String get frequent => '常用';
+
+  @override
+  String get recent => '最近';
+
+  @override
+  String get newShort => '新建';
+
+  @override
+  String get searchHint => '搜索...';
+
+  @override
+  String get searchSessionsHint => '搜索会话...';
+
+  @override
+  String get noMatchingPrompts => '没有匹配的提示词';
+
+  @override
+  String get noPromptHistoryYet => '还没有提示词历史';
+
+  @override
+  String get approvalQueue => '审批队列';
+
+  @override
+  String get resetQueue => '重置队列';
+
+  @override
+  String get swipeSkip => '跳过';
+
+  @override
+  String get swipeSend => '发送';
+
+  @override
+  String get swipeDismiss => '忽略';
+
+  @override
+  String get swipeApprove => '批准';
+
+  @override
+  String get swipeReject => '拒绝';
+
+  @override
+  String get allClear => '全部处理完！';
+
+  @override
+  String itemsProcessed(int count) {
+    return '已处理 $count 项';
+  }
+
+  @override
+  String bestStreak(int count) {
+    return '最佳连击：$count';
+  }
+
+  @override
+  String get tryAgain => '再试一次';
+
+  @override
+  String get waitingForTasks => '正在等待任务';
+
+  @override
+  String get agentReadyForPrompt => 'Agent 已准备好接收你的下一个提示。';
+
+  @override
+  String get backToSessions => '返回会话列表';
+
+  @override
+  String get working => '进行中...';
+
+  @override
+  String get runningSessions => '进行中';
+
+  @override
+  String get recentSessions => '最近会话';
+
+  @override
+  String get displayFirst => '首条';
+
+  @override
+  String get displayLast => '末条';
+
+  @override
+  String get displaySummary => '摘要';
+
+  @override
+  String get filterAllAiTools => '全部 AI 工具';
+
+  @override
+  String get filterAllProjects => '全部项目';
+
+  @override
+  String get filterNamed => '已命名';
+
+  @override
+  String get statusStarting => '启动中';
+
+  @override
+  String get statusIdle => '空闲';
+
+  @override
+  String get statusRunning => '运行中';
+
+  @override
+  String get statusApproval => '待批准';
+
+  @override
+  String get statusCompacting => '压缩中';
+
+  @override
+  String get statusWorking => '处理中';
+
+  @override
+  String get statusNeedsYou => '需要你处理';
+
+  @override
+  String get statusReady => '就绪';
+
+  @override
+  String get statusCleaningContext => '正在整理上下文';
+
+  @override
+  String get statusReviewPlan => '查看计划';
+
+  @override
+  String get statusApproveToolCall => '批准工具调用';
+
+  @override
+  String get statusAnswerQuestion => '回答问题';
+
+  @override
+  String statusApproveTool(String toolName) {
+    return '批准 $toolName';
+  }
+
+  @override
+  String get waitingForApprovalRequests => '正在等待 Agent 发来的审批请求。';
+
+  @override
+  String get noActiveSessions => '没有活动中的会话';
+
+  @override
+  String get startSessionToBegin => '启动一个会话后，即可开始接收审批请求。';
+
+  @override
+  String get settingsTitle => '设置';
+
+  @override
+  String get sectionGeneral => '通用';
+
+  @override
+  String get sectionEditor => '编辑器';
+
+  @override
+  String get indentSize => '缩进大小';
+
+  @override
+  String get indentSizeSubtitle => '列表缩进使用的空格数';
+
+  @override
+  String get sectionAbout => '关于';
+
+  @override
+  String get theme => '主题';
+
+  @override
+  String get themeSystem => '跟随系统';
+
+  @override
+  String get themeLight => '浅色';
+
+  @override
+  String get themeDark => '深色';
+
+  @override
+  String get language => '语言';
+
+  @override
+  String get languageSystem => '跟随系统';
+
+  @override
+  String get voiceInput => '语音输入';
+
+  @override
+  String get pushNotifications => '推送通知';
+
+  @override
+  String get pushNotificationsSubtitle => '通过 Bridge 接收会话通知';
+
+  @override
+  String get pushNotificationsUnavailable => '完成 Firebase 设置后可用';
+
+  @override
+  String get version => '版本';
+
+  @override
+  String get loading => '加载中...';
+
+  @override
+  String get setupGuideSubtitle => '第一次使用？从这里开始';
+
+  @override
+  String get machineSectionTitle => '设备';
+
+  @override
+  String get machineRefreshStatus => '刷新状态';
+
+  @override
+  String get machineNoSavedDescription =>
+      '还没有保存的设备。\n添加后即可快速连接，或在离线时远程启动 Bridge 服务。';
+
+  @override
+  String get addMachine => '添加设备';
+
+  @override
+  String get editMachine => '编辑设备';
+
+  @override
+  String get machineBasicInfo => '基本信息';
+
+  @override
+  String get machineNameLabel => '名称';
+
+  @override
+  String get machineNameHint => '家里的 Mac';
+
+  @override
+  String get machineHostLabel => '主机（IP 或主机名）';
+
+  @override
+  String get portLabel => '端口';
+
+  @override
+  String get sshConfiguration => 'SSH 配置';
+
+  @override
+  String get sshEnableRemoteStartup => '启用 SSH 远程启动';
+
+  @override
+  String get sshRemoteStartupSubtitle => '设备离线时远程启动 Bridge 服务';
+
+  @override
+  String get sshUsernameLabel => 'SSH 用户名';
+
+  @override
+  String get sshPortLabel => 'SSH 端口';
+
+  @override
+  String get sshPrivateKeyLabel => 'SSH 私钥（PEM）';
+
+  @override
+  String get sshPrivateKeyHint => '-----BEGIN OPENSSH PRIVATE KEY-----';
+
+  @override
+  String get testConnection => '测试连接';
+
+  @override
+  String get testingConnection => '测试中...';
+
+  @override
+  String get sshCredentialsRequired => '请填写 SSH 凭据';
+
+  @override
+  String get connectionSuccessful => '连接成功！';
+
+  @override
+  String get addAndConnect => '添加并连接';
+
+  @override
+  String get openSourceLicenses => '开源许可';
+
+  @override
+  String get githubRepository => 'GitHub 仓库';
+
+  @override
+  String get changelog => '更新日志';
+
+  @override
+  String get changelogTitle => '更新日志';
+
+  @override
+  String get showAllMain => '显示全部（main）';
+
+  @override
+  String get changelogFetchError => '加载更新日志失败';
+
+  @override
+  String get fcmBridgeNotInitialized => 'Bridge 尚未初始化';
+
+  @override
+  String get fcmTokenFailed => '获取 FCM Token 失败';
+
+  @override
+  String get fcmEnabled => '通知已启用';
+
+  @override
+  String get fcmEnabledPending => 'Bridge 重新连接后将自动注册';
+
+  @override
+  String get fcmDisabled => '通知已禁用';
+
+  @override
+  String get fcmDisabledPending => 'Bridge 重新连接后将自动取消注册';
+
+  @override
+  String get pushPrivacyMode => '隐私模式';
+
+  @override
+  String get pushPrivacyModeSubtitle => '在通知中隐藏项目名称和内容';
+
+  @override
+  String get updateNotificationLanguage => '更新通知语言';
+
+  @override
+  String get notificationLanguageUpdated => '通知语言已更新';
+
+  @override
+  String get defaultNotRecommended => '默认（不推荐）';
+
+  @override
+  String get imageAttached => '图片已附加';
+
+  @override
+  String get sectionBackup => '备份';
+
+  @override
+  String get backupPromptHistory => '备份提示词历史';
+
+  @override
+  String get restorePromptHistory => '恢复提示词历史';
+
+  @override
+  String get backupSuccess => '备份完成';
+
+  @override
+  String backupFailed(String error) {
+    return '备份失败：$error';
+  }
+
+  @override
+  String get restoreSuccess => '恢复完成';
+
+  @override
+  String restoreFailed(String error) {
+    return '恢复失败：$error';
+  }
+
+  @override
+  String get restoreConfirmTitle => '恢复提示词历史';
+
+  @override
+  String get restoreConfirmMessage => '这将使用备份替换本地所有提示词历史，且无法撤销。';
+
+  @override
+  String get restoreConfirmButton => '恢复';
+
+  @override
+  String get noBackupFound => '未找到备份';
+
+  @override
+  String backupInfo(String date) {
+    return '上次备份：$date';
+  }
+
+  @override
+  String backupVersionInfo(String version, String size) {
+    return 'v$version · $size';
+  }
+
+  @override
+  String get connectToBackup => '连接到 Bridge 后才能使用备份';
+
+  @override
+  String get usageConnectToView => '连接到 Bridge 后查看用量';
+
+  @override
+  String get usageFetchFailed => '获取失败';
+
+  @override
+  String get usageFiveHour => '5 小时';
+
+  @override
+  String get usageSevenDay => '7 天';
+
+  @override
+  String usageResetAt(String time) {
+    return '重置时间：$time';
+  }
+
+  @override
+  String get usageAlreadyReset => '已重置';
+
+  @override
+  String attachedImages(int count) {
+    return '已附加图片 ($count)';
+  }
+
+  @override
+  String get attachedImagesNoCount => '已附加图片';
+
+  @override
+  String get failedToFetchImages => '无法获取图片';
+
+  @override
+  String get responseTimedOut => '响应超时';
+
+  @override
+  String failedToFetchImagesWithError(String error) {
+    return '获取图片失败：$error';
+  }
+
+  @override
+  String get retry => '重试';
+
+  @override
+  String get clipboardNotAvailable => '无法访问剪贴板';
+
+  @override
+  String get failedToLoadImage => '加载图片失败';
+
+  @override
+  String get noImageInClipboard => '剪贴板中没有图片';
+
+  @override
+  String get failedToReadClipboard => '读取剪贴板失败';
+
+  @override
+  String imageLimitReached(int max) {
+    return '最多允许 $max 张图片';
+  }
+
+  @override
+  String imageLimitTruncated(int max, int dropped) {
+    return '仅附加前 $max 张图片（忽略了 $dropped 张）';
+  }
+
+  @override
+  String get selectFromGallery => '从图库选择';
+
+  @override
+  String get pasteFromClipboard => '从剪贴板粘贴';
+
+  @override
+  String get voiceInputLanguage => '语音输入语言';
+
+  @override
+  String get hideVoiceInput => '隐藏语音输入按钮';
+
+  @override
+  String get hideVoiceInputSubtitle => '当你使用第三方语音输入键盘时很有帮助';
+
+  @override
+  String get archive => '归档';
+
+  @override
+  String get archiveConfirm => '要归档此会话吗？';
+
+  @override
+  String get archiveConfirmMessage => '此会话会从列表中隐藏，但你仍然可以在 Claude Code 中访问它。';
+
+  @override
+  String get sessionArchived => '会话已归档';
+
+  @override
+  String get archiveFailed => '归档会话失败';
+
+  @override
+  String archiveFailedWithError(String error) {
+    return '归档会话失败：$error';
+  }
+
+  @override
+  String get noRecentSessions => '没有最近会话';
+
+  @override
+  String get noSessionsMatchFilters => '没有会话匹配当前筛选条件';
+
+  @override
+  String get adjustFiltersAndSearch => '试试修改筛选条件或搜索词';
+
+  @override
+  String get tooltipDisplayMode => '切换卡片上显示的消息';
+
+  @override
+  String get tooltipProviderFilter => '按 AI 工具筛选';
+
+  @override
+  String get tooltipProjectFilter => '按项目筛选';
+
+  @override
+  String get tooltipNamedOnly => '只显示你已命名的会话';
+
+  @override
+  String get tooltipIndent => '增加缩进';
+
+  @override
+  String get tooltipDedent => '减少缩进';
+
+  @override
+  String get tooltipSlashCommand => '斜杠命令';
+
+  @override
+  String get tooltipMention => '提及文件';
+
+  @override
+  String get tooltipPermissionMode => '权限模式';
+
+  @override
+  String get tooltipAttachImage => '附加图片';
+
+  @override
+  String get tooltipPromptHistory => '提示词历史';
+
+  @override
+  String get tooltipVoiceInput => '语音输入';
+
+  @override
+  String get tooltipStopRecording => '停止录音';
+
+  @override
+  String get tooltipSendMessage => '发送消息';
+
+  @override
+  String get tooltipRemoveImage => '移除图片';
+
+  @override
+  String get tooltipClearDiff => '清除 diff 选择';
+
+  @override
+  String messageHistoryCount(int count) {
+    return '$count 条消息';
+  }
+
+  @override
+  String get noMessagesYet => '还没有消息';
+
+  @override
+  String get messagesAppearAfterProcessing => '消息会在代理处理后显示在这里';
+
+  @override
+  String get showMore => '显示更多';
+
+  @override
+  String get showLess => '显示更少';
+
+  @override
+  String sessionStarted(String model) {
+    return '会话已开始（$model）';
+  }
+
+  @override
+  String systemSubtypeLabel(String subtype) {
+    return '系统：$subtype';
+  }
+
+  @override
+  String get authErrorTitle => '需要重新登录 Claude';
+
+  @override
+  String get authErrorBody => 'Bridge 机器上的 Claude Code 需要重新登录。';
+
+  @override
+  String get authErrorPrimaryCommandLabel => '步骤 1';
+
+  @override
+  String get authErrorSecondaryCommandLabel => '步骤 2';
+
+  @override
+  String get authErrorAlternativeLabel => 'Shell 方式';
+
+  @override
+  String get authHelpTitle => '认证故障排查';
+
+  @override
+  String get authHelpFetchError => '加载故障排查指南失败';
+
+  @override
+  String get authHelpButton => '查看步骤';
+
+  @override
+  String get authHelpLanguageJa => '日本語';
+
+  @override
+  String get authHelpLanguageEn => 'English';
+
+  @override
+  String get authHelpLanguageZhHans => '简体中文';
+
+  @override
+  String get terminalApp => '终端应用';
+
+  @override
+  String get terminalAppSubtitle => '在外部终端应用中打开项目';
+
+  @override
+  String get terminalAppNone => '未配置';
+
+  @override
+  String get terminalAppCustom => '自定义';
+
+  @override
+  String get terminalAppName => '应用名称';
+
+  @override
+  String get terminalUrlTemplate => 'URL 模板';
+
+  @override
+  String get terminalUrlTemplateHint => '变量：host、user、port、project_path';
+
+  @override
+  String get terminalSshUser => 'SSH 用户';
+
+  @override
+  String get terminalSshUserHint => '默认使用机器的 SSH 用户';
+
+  @override
+  String get openInTerminal => '在终端中打开';
+
+  @override
+  String get terminalAppNotInstalled => '无法打开终端应用';
+
+  @override
+  String get terminalAppExperimental => '实验性';
+
+  @override
+  String get terminalAppExperimentalNote =>
+      '此功能仍为实验性功能。预设不一定适用于所有应用或配置。欢迎在 GitHub 上贡献新的预设！';
+
+  @override
+  String get sectionSpread => '喜欢 CC POCKET 吗？';
+
+  @override
+  String get shareApp => '分享给朋友';
+
+  @override
+  String get shareAppSubtitle => '告诉你的朋友和同事';
+
+  @override
+  String shareText(String url) {
+    return 'CC Pocket: Claude Code & Codex\n用手机控制你的编程 Agent 📱\n#ccpocket\n$url';
+  }
+
+  @override
+  String get starOnGithub => '在 GitHub 点星';
+
+  @override
+  String get rateOnStore => '在 App Store 评分';
+
+  @override
+  String get rateOnStoreAndroid => '在 Google Play 评分';
+}

--- a/apps/mobile/lib/l10n/app_zh.arb
+++ b/apps/mobile/lib/l10n/app_zh.arb
@@ -1,0 +1,632 @@
+{
+  "@@locale": "zh",
+
+  "appTitle": "CC Pocket",
+
+  "cancel": "取消",
+  "save": "保存",
+  "delete": "删除",
+  "remove": "移除",
+  "removeProjectTitle": "移除项目",
+  "removeProjectConfirm": "要从最近项目中移除“{name}”吗？",
+  "@removeProjectConfirm": {
+    "placeholders": {
+      "name": {
+        "type": "Object"
+      }
+    }
+  },
+  "rename": "重命名",
+  "renameSession": "重命名会话",
+  "sessionNameHint": "会话名称",
+  "clearName": "清除名称",
+  "connect": "连接",
+  "copy": "复制",
+  "copied": "已复制",
+  "copiedToClipboard": "已复制到剪贴板",
+  "lineCopied": "已复制此行",
+  "start": "开始",
+  "stop": "停止",
+  "send": "发送",
+  "settings": "设置",
+  "gallery": "图库",
+  "galleryWithCount": "图库 ({count})",
+  "disconnect": "断开连接",
+  "back": "返回",
+  "next": "下一步",
+  "done": "完成",
+  "skip": "跳过",
+  "edit": "编辑",
+  "share": "分享",
+  "all": "全部",
+  "none": "无",
+
+  "serverUnreachable": "无法连接服务器",
+  "serverUnreachableBody": "无法访问以下 Bridge 服务器：",
+  "setupSteps": "设置步骤：",
+  "setupStep1Title": "启动 Bridge 服务器",
+  "setupStep1Command": "npx @ccpocket/bridge@latest",
+  "setupStep2Title": "如需常驻运行，请注册为服务",
+  "setupStep2Command": "npx @ccpocket/bridge@latest setup",
+  "setupNetworkHint": "请确认两台设备位于同一网络中（或使用 Tailscale）。",
+  "connectAnyway": "仍然连接",
+
+  "stopSession": "停止会话",
+  "stopSessionConfirm": "要停止此会话吗？Claude 进程将被终止。",
+
+  "startNewWithSameSettings": "使用相同设置新建",
+  "editSettingsThenStart": "先修改设置再开始",
+
+  "serverRequiresApiKey": "此服务器需要 API 密钥",
+  "bridgeServerUpdated": "Bridge 服务已更新",
+  "failedToUpdateServer": "更新服务器失败",
+  "bridgeServerStarted": "Bridge 服务已启动",
+  "failedToStartServer": "启动服务器失败",
+  "bridgeServerStopped": "Bridge 服务已停止",
+  "failedToStopServer": "停止服务器失败",
+
+  "sshPassword": "SSH 密码",
+  "sshPasswordPrompt": "请输入 {machineName} 的 SSH 密码",
+  "password": "密码",
+
+  "deleteMachine": "删除机器",
+  "deleteMachineConfirm": "要删除“{displayName}”吗？这会移除所有已保存的凭据。",
+
+  "connectToBridgeServer": "连接到 Bridge 服务",
+  "orConnectManually": "或手动连接",
+  "serverUrl": "服务器 URL",
+  "serverUrlHint": "ws://<host-ip>:8765",
+  "apiKeyOptional": "API 密钥（可选）",
+  "apiKeyHint": "如果没有认证可留空",
+  "scanQrCode": "扫描二维码",
+  "setupGuide": "设置指南",
+
+  "readyToStart": "准备就绪",
+  "readyToStartDescription": "点击 + 按钮创建新会话，并开始用 Claude 编码。",
+  "newSession": "新建会话",
+
+  "neverConnected": "从未连接",
+  "justNow": "刚刚",
+  "minutesAgo": "{minutes} 分钟前",
+  "hoursAgo": "{hours} 小时前",
+  "daysAgo": "{days} 天前",
+  "unfavorite": "取消收藏",
+  "favorite": "收藏",
+  "updateBridge": "更新 Bridge",
+  "stopServer": "停止服务器",
+  "update": "更新",
+  "offline": "离线",
+  "disconnected": "已断开连接",
+  "reconnecting": "正在重新连接...",
+  "unreachable": "不可达",
+  "checking": "检查中...",
+
+  "recentProjects": "最近项目",
+  "orEnterPath": "或输入路径",
+  "projectPath": "项目路径",
+  "projectPathHint": "/path/to/your/project",
+  "permission": "权限",
+  "approval": "审批",
+  "worktree": "工作树",
+  "worktreeTooltip": "为此会话创建独立的 git 工作树。",
+  "advanced": "高级",
+  "environmentSection": "环境",
+  "permissionDefaultMode": "默认",
+  "permissionAcceptEditsMode": "自动批准编辑",
+  "permissionPlanMode": "规划",
+  "permissionBypassMode": "全部绕过",
+  "permissionDefaultDescription": "标准权限提示",
+  "permissionAcceptEditsDescription": "自动批准文件编辑",
+  "permissionPlanDescription": "仅分析和规划，不执行",
+  "permissionBypassDescription": "跳过所有权限提示",
+  "permissionModeTitle": "权限模式",
+  "changePermissionModeTitle": "更改权限模式",
+  "changePermissionModeBody": "切换到 {mode} 会重启当前会话。你的对话会被保留。",
+  "@changePermissionModeBody": {
+    "placeholders": {
+      "mode": { "type": "String" }
+    }
+  },
+  "permissionChipAcceptEdits": "编辑",
+  "permissionChipBypass": "绕过",
+  "modelOptional": "模型（可选）",
+  "effort": "Effort",
+  "defaultLabel": "默认",
+  "maxTurns": "最大轮数",
+  "maxTurnsHint": "例如：8",
+  "maxTurnsError": "必须输入大于 0 的整数",
+  "maxBudgetUsd": "最大预算（USD）",
+  "maxBudgetHint": "例如：1.00",
+  "maxBudgetError": "必须输入大于等于 0 的数字",
+  "fallbackModel": "回退模型",
+  "forkSessionOnResume": "恢复时分叉会话",
+  "persistSessionHistory": "保留会话历史",
+  "model": "模型",
+  "sandbox": "沙箱",
+  "sandboxModeTitle": "沙箱模式",
+  "sandboxSafeMode": "沙箱（安全模式）",
+  "sandboxStandard": "标准",
+  "sandboxOnLabel": "沙箱开启",
+  "sandboxOffLabel": "沙箱关闭",
+  "sandboxRestrictedDescription": "在受限环境中运行命令",
+  "sandboxNativeDescription": "在原生环境中运行命令",
+  "sandboxNativeCautionDescription": "在原生环境中运行命令（谨慎）",
+  "changeSandboxModeTitle": "更改沙箱模式",
+  "changeSandboxModeBody": "切换到 {mode} 会重启当前会话。你的对话会被保留。",
+  "@changeSandboxModeBody": {
+    "placeholders": {
+      "mode": { "type": "String" }
+    }
+  },
+  "sandboxChipOff": "无沙箱",
+  "reasoning": "Reasoning",
+  "webSearch": "Web Search",
+  "networkAccess": "网络访问",
+  "worktreeNew": "新建",
+  "worktreeExisting": "已有 ({count})",
+  "branchOptional": "分支（可选）",
+  "branchHint": "ccpocket/<auto>",
+  "noExistingWorktrees": "没有现有 worktree",
+
+  "planApprovalSummary": "请查看上方计划，并选择批准或继续规划",
+  "planApprovalSummaryCard": "请查看计划，并选择批准或继续规划",
+  "toolApprovalSummary": "执行工具需要批准",
+  "planApproval": "计划批准",
+  "approvalRequired": "需要批准",
+  "viewEditPlan": "查看 / 编辑计划",
+  "keepPlanning": "继续规划",
+  "keepPlanningHint": "需要改什么...",
+  "sendFeedbackKeepPlanning": "发送反馈并继续规划",
+  "acceptAndClear": "批准并清除",
+  "acceptPlan": "批准计划",
+  "reject": "拒绝",
+  "approve": "批准",
+  "always": "始终",
+  "restart": "重启",
+
+  "messagePlaceholder": "给 Claude 发消息...",
+  "messageProviderPlaceholder": "给 {provider} 发消息...",
+  "@messageProviderPlaceholder": {
+    "placeholders": {
+      "provider": { "type": "String" }
+    }
+  },
+  "filesMentioned": "已 @提及 {count} 个文件",
+  "diffLines": "{count} 行 diff",
+  "tapInterruptHoldStop": "点按：中断，长按：停止",
+
+  "rewindToHere": "回退到这里",
+  "tapToRetry": "点按重试",
+
+  "diffSummaryAddedRemoved": "+{added}/-{removed} 行",
+  "lineCountSummary": "{count} 行",
+  "toolResult": "工具结果",
+
+  "answered": "已回答",
+  "claudeIsAsking": "Claude 正在提问",
+  "codexIsAsking": "Codex 正在提问",
+  "questionNeedsYourAnswer": "问题需要你回答",
+  "toolApprovalNeeded": "需要你批准工具操作",
+  "codexToolApprovalNeeded": "需要你批准 Codex 的工具操作",
+  "sessionCompleteTitle": "会话已完成",
+  "sessionDone": "会话已结束",
+  "codexSessionDone": "Codex 会话已结束",
+  "submitAllAnswers": "提交全部答案",
+  "submitWithCount": "提交（已选择 {count} 项）",
+  "selectOptionsToSubmit": "请选择要提交的选项",
+  "typeYourAnswer": "输入你的回答...",
+  "orTypeCustomAnswer": "或输入自定义回答...",
+  "otherAnswer": "其他回答...",
+  "selectAllThatApply": "选择所有适用项",
+
+  "noScreenshotsYet": "还没有截图",
+  "screenshotButtonHint": "使用聊天工具栏中的截图按钮来捕获截图。",
+  "screenshotsWillAppearHere": "Claude 会话中的截图会显示在这里。",
+  "allWithCount": "全部 ({count})",
+  "noImages": "没有图片",
+  "failedToDeleteImage": "删除图片失败",
+  "failedToDownloadImage": "下载图片失败",
+  "failedToShareImage": "分享图片失败",
+  "deleteScreenshot": "要删除截图吗？",
+  "cannotBeUndone": "此操作无法撤销。",
+
+  "changes": "变更",
+  "cancelSelection": "取消选择",
+  "selectAndAttach": "选择并附加",
+  "refresh": "刷新",
+  "diffCompareSideBySide": "并排",
+  "diffCompareSlider": "滑块",
+  "diffCompareOverlay": "叠加",
+  "diffCompareToggle": "切换",
+  "diffBefore": "变更前",
+  "diffAfter": "变更后",
+  "diffNewFile": "新文件",
+  "diffDeleted": "已删除",
+  "diffNoImage": "没有图片",
+  "filterFiles": "筛选文件",
+  "attachFilesAndHunks": "附加 {files} 个文件，{hunks} 个 hunk",
+  "filterFilesTitle": "筛选文件",
+  "noChanges": "没有变更",
+  "allFilesFilteredOut": "所有文件都被筛掉了",
+  "showAll": "显示全部",
+
+  "setupGuideTitle": "设置指南",
+
+  "guideAboutTitle": "什么是 CC Pocket？",
+  "guideAboutDescription": "一款可让你通过智能手机控制 Claude Code 和 Codex 的移动客户端。",
+  "guideAboutDiagramTitle": "工作方式",
+  "guideAboutDiagramPhone": "iPhone",
+  "guideAboutDiagramBridge": "Bridge 服务",
+  "guideAboutDiagramClaude": "Claude CLI\n/ Codex",
+  "guideAboutDiagramCaption": "先在你的电脑上启动 Bridge 服务，\n然后从手机连接。",
+
+  "guideBridgeTitle": "Bridge 服务\n设置",
+  "guideBridgeDescription": "先在你的电脑上启动 Bridge 服务。",
+  "guideBridgePrerequisites": "前置条件",
+  "guideBridgePrereq1": "已安装 Node.js 的 Mac / PC",
+  "guideBridgePrereq2": "Claude Code CLI 或 Codex CLI\n（二选一即可）",
+  "guideBridgeStep1": "使用 npx 运行（推荐）",
+  "guideBridgeStep1Command": "npx @ccpocket/bridge@latest",
+  "guideBridgeStep2": "或全局安装",
+  "guideBridgeStep2Command": "npm install -g @ccpocket/bridge\nccpocket-bridge",
+  "guideBridgeQrNote": "启动后，终端中会显示二维码",
+
+  "guideConnectionTitle": "连接方式",
+  "guideConnectionDescription": "如果处于同一个 Wi-Fi 网络下，你可以立即连接。",
+  "guideConnectionQr": "扫描二维码",
+  "guideConnectionQrDescription": "只需扫描终端中显示的二维码。最简单的方法。",
+  "guideConnectionMdns": "自动发现（mDNS）",
+  "guideConnectionMdnsDescription": "自动查找同一局域网中的 Bridge 服务。",
+  "guideConnectionManual": "手动输入",
+  "guideConnectionManualDescription": "直接输入 `ws://<IP 地址>:8765` 格式的地址。",
+  "guideConnectionRecommended": "推荐",
+
+  "guideTailscaleTitle": "远程访问",
+  "guideTailscaleDescription": "如果要在家外使用，Tailscale（VPN）可以帮助你安全地远程连接。",
+  "guideTailscaleStep1": "在 Mac 和 iPhone 上都安装 Tailscale",
+  "guideTailscaleStep2": "使用同一个账号登录",
+  "guideTailscaleStep3": "在 Bridge URL 中使用 Tailscale IP\n（例如：ws://100.x.x.x:8765）",
+  "guideTailscaleWebsite": "Tailscale 官网",
+  "guideTailscaleWebsiteHint": "访问官网获取更详细的设置说明。",
+
+  "guideLaunchdTitle": "自动启动设置",
+  "guideLaunchdDescription": "如果每次手动启动 Bridge 服务太麻烦，你可以将它配置为设备开机时自动启动。",
+  "guideLaunchdCommand": "设置命令",
+  "guideLaunchdCommandValue": "npx @ccpocket/bridge@latest setup",
+  "guideLaunchdRecommendation": "建议先通过手动启动验证一切正常，再在稳定后注册为服务。",
+  "guideAutostartMacDescription": "使用 launchd 注册。Shell 环境（nvm、Homebrew 等）会自动继承。",
+  "guideAutostartLinuxDescription": "创建 systemd 用户服务。适用于 Raspberry Pi 及其他 Linux 主机。",
+
+  "guideReadyTitle": "全部就绪！",
+  "guideReadyDescription": "启动 Bridge 服务并\n扫描二维码，\n马上开始。",
+  "guideReadyStart": "开始使用",
+  "guideReadyHint": "你也可以随时在设置中重新打开本指南",
+
+  "creatingSession": "正在创建会话...",
+  "startWithProvider": "用 {provider} 开始",
+  "@startWithProvider": {
+    "placeholders": {
+      "provider": { "type": "String" }
+    }
+  },
+  "copyForAgent": "复制给 Agent",
+  "messageHistory": "消息历史",
+  "viewChanges": "查看变更",
+  "screenshot": "截图",
+  "screenshotSaved": "截图已保存",
+  "screenshotFailed": "截图失败",
+  "fullScreen": "全屏",
+  "captureEntireDesktop": "截取整个桌面",
+  "noWindowsFound": "未找到窗口",
+
+  "debug": "调试",
+  "logs": "日志",
+  "viewApplicationLogs": "查看应用日志",
+  "mockPreview": "Mock 预览",
+  "viewMockChatScenarios": "查看 Mock 聊天场景",
+  "updateTrack": "更新轨道",
+  "updateTrackDescription": "更改后重启应用以生效",
+  "updateTrackStable": "稳定版",
+  "updateTrackStaging": "预发布版",
+  "updateDownloaded": "更新已下载。请重启应用以生效。",
+
+  "promptHistory": "提示词历史",
+  "frequent": "常用",
+  "recent": "最近",
+  "newShort": "新建",
+  "searchHint": "搜索...",
+  "searchSessionsHint": "搜索会话...",
+  "noMatchingPrompts": "没有匹配的提示词",
+  "noPromptHistoryYet": "还没有提示词历史",
+
+  "approvalQueue": "审批队列",
+  "resetQueue": "重置队列",
+  "swipeSkip": "跳过",
+  "swipeSend": "发送",
+  "swipeDismiss": "忽略",
+  "swipeApprove": "批准",
+  "swipeReject": "拒绝",
+  "allClear": "全部处理完！",
+  "itemsProcessed": "已处理 {count} 项",
+  "bestStreak": "最佳连击：{count}",
+  "tryAgain": "再试一次",
+  "waitingForTasks": "正在等待任务",
+  "agentReadyForPrompt": "Agent 已准备好接收你的下一个提示。",
+  "backToSessions": "返回会话列表",
+  "working": "进行中...",
+  "runningSessions": "进行中",
+  "recentSessions": "最近会话",
+  "displayFirst": "首条",
+  "displayLast": "末条",
+  "displaySummary": "摘要",
+  "filterAllAiTools": "全部 AI 工具",
+  "filterAllProjects": "全部项目",
+  "filterNamed": "已命名",
+  "statusStarting": "启动中",
+  "statusIdle": "空闲",
+  "statusRunning": "运行中",
+  "statusApproval": "待批准",
+  "statusCompacting": "压缩中",
+  "statusWorking": "处理中",
+  "statusNeedsYou": "需要你处理",
+  "statusReady": "就绪",
+  "statusCleaningContext": "正在整理上下文",
+  "statusReviewPlan": "查看计划",
+  "statusApproveToolCall": "批准工具调用",
+  "statusAnswerQuestion": "回答问题",
+  "statusApproveTool": "批准 {toolName}",
+  "@statusApproveTool": {
+    "placeholders": {
+      "toolName": { "type": "String" }
+    }
+  },
+  "waitingForApprovalRequests": "正在等待 Agent 发来的审批请求。",
+  "noActiveSessions": "没有活动中的会话",
+  "startSessionToBegin": "启动一个会话后，即可开始接收审批请求。",
+
+  "settingsTitle": "设置",
+  "sectionGeneral": "通用",
+  "sectionEditor": "编辑器",
+  "indentSize": "缩进大小",
+  "indentSizeSubtitle": "列表缩进使用的空格数",
+  "sectionAbout": "关于",
+  "theme": "主题",
+  "themeSystem": "跟随系统",
+  "themeLight": "浅色",
+  "themeDark": "深色",
+  "language": "语言",
+  "languageSystem": "跟随系统",
+  "voiceInput": "语音输入",
+  "pushNotifications": "推送通知",
+  "pushNotificationsSubtitle": "通过 Bridge 接收会话通知",
+  "pushNotificationsUnavailable": "完成 Firebase 设置后可用",
+  "version": "版本",
+  "loading": "加载中...",
+  "setupGuideSubtitle": "第一次使用？从这里开始",
+  "machineSectionTitle": "设备",
+  "machineRefreshStatus": "刷新状态",
+  "machineNoSavedDescription": "还没有保存的设备。\n添加后即可快速连接，或在离线时远程启动 Bridge 服务。",
+  "addMachine": "添加设备",
+  "editMachine": "编辑设备",
+  "machineBasicInfo": "基本信息",
+  "machineNameLabel": "名称",
+  "machineNameHint": "家里的 Mac",
+  "machineHostLabel": "主机（IP 或主机名）",
+  "portLabel": "端口",
+  "sshConfiguration": "SSH 配置",
+  "sshEnableRemoteStartup": "启用 SSH 远程启动",
+  "sshRemoteStartupSubtitle": "设备离线时远程启动 Bridge 服务",
+  "sshUsernameLabel": "SSH 用户名",
+  "sshPortLabel": "SSH 端口",
+  "sshPrivateKeyLabel": "SSH 私钥（PEM）",
+  "sshPrivateKeyHint": "-----BEGIN OPENSSH PRIVATE KEY-----",
+  "testConnection": "测试连接",
+  "testingConnection": "测试中...",
+  "sshCredentialsRequired": "请填写 SSH 凭据",
+  "connectionSuccessful": "连接成功！",
+  "addAndConnect": "添加并连接",
+  "openSourceLicenses": "开源许可",
+  "githubRepository": "GitHub 仓库",
+  "changelog": "更新日志",
+  "changelogTitle": "更新日志",
+  "showAllMain": "显示全部（main）",
+  "changelogFetchError": "加载更新日志失败",
+
+  "fcmBridgeNotInitialized": "Bridge 尚未初始化",
+  "fcmTokenFailed": "获取 FCM Token 失败",
+  "fcmEnabled": "通知已启用",
+  "fcmEnabledPending": "Bridge 重新连接后将自动注册",
+  "fcmDisabled": "通知已禁用",
+  "fcmDisabledPending": "Bridge 重新连接后将自动取消注册",
+  "pushPrivacyMode": "隐私模式",
+  "pushPrivacyModeSubtitle": "在通知中隐藏项目名称和内容",
+  "updateNotificationLanguage": "更新通知语言",
+  "notificationLanguageUpdated": "通知语言已更新",
+
+  "defaultNotRecommended": "默认（不推荐）",
+
+  "imageAttached": "图片已附加",
+
+  "sectionBackup": "备份",
+  "backupPromptHistory": "备份提示词历史",
+  "restorePromptHistory": "恢复提示词历史",
+  "backupSuccess": "备份完成",
+  "backupFailed": "备份失败：{error}",
+  "@backupFailed": {
+    "placeholders": {
+      "error": {"type": "String"}
+    }
+  },
+  "restoreSuccess": "恢复完成",
+  "restoreFailed": "恢复失败：{error}",
+  "@restoreFailed": {
+    "placeholders": {
+      "error": {"type": "String"}
+    }
+  },
+  "restoreConfirmTitle": "恢复提示词历史",
+  "restoreConfirmMessage": "这将使用备份替换本地所有提示词历史，且无法撤销。",
+  "restoreConfirmButton": "恢复",
+  "noBackupFound": "未找到备份",
+  "backupInfo": "上次备份：{date}",
+  "@backupInfo": {
+    "placeholders": {
+      "date": {"type": "String"}
+    }
+  },
+  "backupVersionInfo": "v{version} · {size}",
+  "@backupVersionInfo": {
+    "placeholders": {
+      "version": {"type": "String"},
+      "size": {"type": "String"}
+    }
+  },
+  "connectToBackup": "连接到 Bridge 后才能使用备份",
+
+  "usageConnectToView": "连接到 Bridge 后查看用量",
+  "usageFetchFailed": "获取失败",
+  "usageFiveHour": "5 小时",
+  "usageSevenDay": "7 天",
+  "usageResetAt": "重置时间：{time}",
+  "@usageResetAt": {
+    "placeholders": {
+      "time": {"type": "String"}
+    }
+  },
+  "usageAlreadyReset": "已重置",
+
+  "attachedImages": "已附加图片 ({count})",
+  "@attachedImages": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "attachedImagesNoCount": "已附加图片",
+  "failedToFetchImages": "无法获取图片",
+  "responseTimedOut": "响应超时",
+  "failedToFetchImagesWithError": "获取图片失败：{error}",
+  "@failedToFetchImagesWithError": {
+    "placeholders": {
+      "error": {"type": "String"}
+    }
+  },
+  "retry": "重试",
+
+  "clipboardNotAvailable": "无法访问剪贴板",
+  "failedToLoadImage": "加载图片失败",
+  "noImageInClipboard": "剪贴板中没有图片",
+  "failedToReadClipboard": "读取剪贴板失败",
+  "imageLimitReached": "最多允许 {max} 张图片",
+  "@imageLimitReached": {
+    "placeholders": {
+      "max": {"type": "int"}
+    }
+  },
+  "imageLimitTruncated": "仅附加前 {max} 张图片（忽略了 {dropped} 张）",
+  "@imageLimitTruncated": {
+    "placeholders": {
+      "max": {"type": "int"},
+      "dropped": {"type": "int"}
+    }
+  },
+  "selectFromGallery": "从图库选择",
+  "pasteFromClipboard": "从剪贴板粘贴",
+
+  "voiceInputLanguage": "语音输入语言",
+  "hideVoiceInput": "隐藏语音输入按钮",
+  "hideVoiceInputSubtitle": "当你使用第三方语音输入键盘时很有帮助",
+
+  "archive": "归档",
+  "archiveConfirm": "要归档此会话吗？",
+  "archiveConfirmMessage": "此会话会从列表中隐藏，但你仍然可以在 Claude Code 中访问它。",
+  "sessionArchived": "会话已归档",
+  "archiveFailed": "归档会话失败",
+  "archiveFailedWithError": "归档会话失败：{error}",
+  "@archiveFailedWithError": {
+    "placeholders": {
+      "error": {"type": "String"}
+    }
+  },
+  "noRecentSessions": "没有最近会话",
+  "noSessionsMatchFilters": "没有会话匹配当前筛选条件",
+  "adjustFiltersAndSearch": "试试修改筛选条件或搜索词",
+
+  "tooltipDisplayMode": "切换卡片上显示的消息",
+  "tooltipProviderFilter": "按 AI 工具筛选",
+  "tooltipProjectFilter": "按项目筛选",
+  "tooltipNamedOnly": "只显示你已命名的会话",
+  "tooltipIndent": "增加缩进",
+  "tooltipDedent": "减少缩进",
+  "tooltipSlashCommand": "斜杠命令",
+  "tooltipMention": "提及文件",
+  "tooltipPermissionMode": "权限模式",
+  "tooltipAttachImage": "附加图片",
+  "tooltipPromptHistory": "提示词历史",
+  "tooltipVoiceInput": "语音输入",
+  "tooltipStopRecording": "停止录音",
+  "tooltipSendMessage": "发送消息",
+  "tooltipRemoveImage": "移除图片",
+  "tooltipClearDiff": "清除 diff 选择",
+  "messageHistoryCount": "{count} 条消息",
+  "@messageHistoryCount": {
+    "placeholders": {
+      "count": { "type": "int" }
+    }
+  },
+  "noMessagesYet": "还没有消息",
+  "messagesAppearAfterProcessing": "消息会在代理处理后显示在这里",
+
+  "showMore": "显示更多",
+  "showLess": "显示更少",
+  "sessionStarted": "会话已开始（{model}）",
+  "@sessionStarted": {
+    "placeholders": {
+      "model": { "type": "String" }
+    }
+  },
+  "systemSubtypeLabel": "系统：{subtype}",
+  "@systemSubtypeLabel": {
+    "placeholders": {
+      "subtype": { "type": "String" }
+    }
+  },
+
+  "authErrorTitle": "需要重新登录 Claude",
+  "authErrorBody": "Bridge 机器上的 Claude Code 需要重新登录。",
+  "authErrorPrimaryCommandLabel": "步骤 1",
+  "authErrorSecondaryCommandLabel": "步骤 2",
+  "authErrorAlternativeLabel": "Shell 方式",
+  "authHelpTitle": "认证故障排查",
+  "authHelpFetchError": "加载故障排查指南失败",
+  "authHelpButton": "查看步骤",
+  "authHelpLanguageJa": "日本語",
+  "authHelpLanguageEn": "English",
+  "authHelpLanguageZhHans": "简体中文",
+
+  "terminalApp": "终端应用",
+  "terminalAppSubtitle": "在外部终端应用中打开项目",
+  "terminalAppNone": "未配置",
+  "terminalAppCustom": "自定义",
+  "terminalAppName": "应用名称",
+  "terminalUrlTemplate": "URL 模板",
+  "terminalUrlTemplateHint": "变量：host、user、port、project_path",
+  "terminalSshUser": "SSH 用户",
+  "terminalSshUserHint": "默认使用机器的 SSH 用户",
+  "openInTerminal": "在终端中打开",
+  "terminalAppNotInstalled": "无法打开终端应用",
+  "terminalAppExperimental": "实验性",
+  "terminalAppExperimentalNote": "此功能仍为实验性功能。预设不一定适用于所有应用或配置。欢迎在 GitHub 上贡献新的预设！",
+
+  "sectionSpread": "喜欢 CC POCKET 吗？",
+  "shareApp": "分享给朋友",
+  "shareAppSubtitle": "告诉你的朋友和同事",
+  "shareText": "CC Pocket: Claude Code & Codex\n用手机控制你的编程 Agent \ud83d\udcf1\n#ccpocket\n{url}",
+  "@shareText": {
+    "placeholders": {
+      "url": { "type": "String" }
+    }
+  },
+  "starOnGithub": "在 GitHub 点星",
+  "rateOnStore": "在 App Store 评分",
+  "rateOnStoreAndroid": "在 Google Play 评分"
+}

--- a/apps/mobile/lib/widgets/bubbles/system_chip.dart
+++ b/apps/mobile/lib/widgets/bubbles/system_chip.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../l10n/app_localizations.dart';
 import '../../models/messages.dart';
 import '../../theme/app_theme.dart';
 
@@ -10,9 +11,10 @@ class SystemChip extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final appColors = Theme.of(context).extension<AppColors>()!;
+    final l = AppLocalizations.of(context);
     final label = message.model != null
-        ? 'Session started (${message.model})'
-        : 'System: ${message.subtype}';
+        ? l.sessionStarted(message.model!)
+        : l.systemSubtypeLabel(message.subtype);
     return Center(
       child: Padding(
         padding: const EdgeInsets.symmetric(vertical: 6),

--- a/apps/mobile/lib/widgets/new_session_sheet.dart
+++ b/apps/mobile/lib/widgets/new_session_sheet.dart
@@ -1325,7 +1325,7 @@ class _OptionsSection extends StatelessWidget {
           Padding(
             padding: const EdgeInsets.only(bottom: 12),
             child: Text(
-              'Environment',
+              l.environmentSection,
               style: TextStyle(
                 fontSize: 12,
                 fontWeight: FontWeight.w600,
@@ -1354,7 +1354,10 @@ class _OptionsSection extends StatelessWidget {
                           PermissionMode.bypassPermissions => Icons.flash_on,
                         }, size: 16),
                         const SizedBox(width: 8),
-                        Text(m.label, style: const TextStyle(fontSize: 13)),
+                        Text(
+                          _localizedPermissionModeLabel(l, m),
+                          style: const TextStyle(fontSize: 13),
+                        ),
                       ],
                     ),
                   ),
@@ -1384,11 +1387,11 @@ class _OptionsSection extends StatelessWidget {
                       final icon = m == SandboxMode.on
                           ? Icons.shield_outlined
                           : (isClaude ? Icons.code : Icons.warning_amber);
-                      final label = isClaude
-                          ? (m == SandboxMode.on
-                                ? 'Sandbox (Safe Mode)'
-                                : 'Standard')
-                          : m.label;
+                      final label = _localizedSandboxLabel(
+                        l,
+                        m,
+                        isClaude: isClaude,
+                      );
                       return DropdownMenuItem(
                         value: m,
                         child: Row(
@@ -1438,8 +1441,7 @@ class _OptionsSection extends StatelessWidget {
                 ),
                 const SizedBox(width: 8),
                 Tooltip(
-                  message:
-                      'Creates an isolated git working tree for this session.',
+                  message: l.worktreeTooltip,
                   child: Icon(
                     Icons.info_outline,
                     size: 16,
@@ -2217,12 +2219,16 @@ class _SheetActions extends StatelessWidget {
           const SizedBox(width: 12),
           Expanded(
             child: SizedBox(
-              height: 48,
+              height: 54,
               child: FilledButton(
                 key: const ValueKey('dialog_start_button'),
                 style: FilledButton.styleFrom(
                   backgroundColor: canStart ? providerStyle.background : null,
                   foregroundColor: canStart ? providerStyle.foreground : null,
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 18,
+                    vertical: 12,
+                  ),
                   shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(14),
                   ),
@@ -2233,10 +2239,11 @@ class _SheetActions extends StatelessWidget {
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
                     Text(
-                      'Start with ${provider.label}',
+                      l.startWithProvider(provider.label),
                       style: const TextStyle(
                         fontSize: 15,
                         fontWeight: FontWeight.w600,
+                        height: 1.2,
                       ),
                     ),
                   ],
@@ -2301,4 +2308,24 @@ class _ProviderToggleButton extends StatelessWidget {
       ),
     );
   }
+}
+
+String _localizedPermissionModeLabel(AppLocalizations l, PermissionMode mode) {
+  return switch (mode) {
+    PermissionMode.defaultMode => l.permissionDefaultMode,
+    PermissionMode.acceptEdits => l.permissionAcceptEditsMode,
+    PermissionMode.plan => l.permissionPlanMode,
+    PermissionMode.bypassPermissions => l.permissionBypassMode,
+  };
+}
+
+String _localizedSandboxLabel(
+  AppLocalizations l,
+  SandboxMode mode, {
+  required bool isClaude,
+}) {
+  if (isClaude) {
+    return mode == SandboxMode.on ? l.sandboxSafeMode : l.sandboxStandard;
+  }
+  return mode == SandboxMode.on ? l.sandboxOnLabel : l.sandboxOffLabel;
 }

--- a/apps/mobile/lib/widgets/screenshot_sheet.dart
+++ b/apps/mobile/lib/widgets/screenshot_sheet.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
+import '../l10n/app_localizations.dart';
 import '../models/messages.dart';
 import '../services/bridge_service.dart';
 import '../theme/app_theme.dart';
@@ -63,17 +64,18 @@ class _ScreenshotSheetContentState extends State<_ScreenshotSheetContent> {
       setState(() => _capturing = false);
       // Capture references before pop (context may become invalid after pop)
       final messenger = ScaffoldMessenger.of(context);
+      final l = AppLocalizations.of(context);
       if (result.success) {
         Navigator.pop(context);
         messenger.showSnackBar(
-          const SnackBar(
-            content: Text('Screenshot saved'),
-            duration: Duration(seconds: 2),
+          SnackBar(
+            content: Text(l.screenshotSaved),
+            duration: const Duration(seconds: 2),
           ),
         );
       } else {
         messenger.showSnackBar(
-          SnackBar(content: Text(result.error ?? 'Screenshot failed')),
+          SnackBar(content: Text(result.error ?? l.screenshotFailed)),
         );
       }
     });
@@ -101,6 +103,7 @@ class _ScreenshotSheetContentState extends State<_ScreenshotSheetContent> {
   Widget build(BuildContext context) {
     final appColors = Theme.of(context).extension<AppColors>()!;
     final cs = Theme.of(context).colorScheme;
+    final l = AppLocalizations.of(context);
 
     return Padding(
       padding: EdgeInsets.only(
@@ -131,9 +134,9 @@ class _ScreenshotSheetContentState extends State<_ScreenshotSheetContent> {
               children: [
                 const Icon(Icons.screenshot_monitor, size: 20),
                 const SizedBox(width: 8),
-                const Expanded(
+                Expanded(
                   child: Text(
-                    'Screenshot',
+                    l.screenshot,
                     style: TextStyle(fontSize: 18, fontWeight: FontWeight.w600),
                   ),
                 ),
@@ -146,7 +149,7 @@ class _ScreenshotSheetContentState extends State<_ScreenshotSheetContent> {
                           setState(() => _windows = null);
                           widget.bridge.requestWindowList();
                         },
-                  tooltip: 'Refresh',
+                  tooltip: l.refresh,
                   visualDensity: VisualDensity.compact,
                 ),
               ],
@@ -167,12 +170,12 @@ class _ScreenshotSheetContentState extends State<_ScreenshotSheetContent> {
               decoration: BoxDecoration(borderRadius: BorderRadius.circular(8)),
               child: ListTile(
                 leading: Icon(Icons.fullscreen, size: 24, color: cs.primary),
-                title: const Text(
-                  'Full Screen',
+                title: Text(
+                  l.fullScreen,
                   style: TextStyle(fontSize: 14, fontWeight: FontWeight.w600),
                 ),
                 subtitle: Text(
-                  'Capture entire desktop',
+                  l.captureEntireDesktop,
                   style: TextStyle(fontSize: 11, color: appColors.subtleText),
                 ),
                 onTap: () => _capture(mode: 'fullscreen'),
@@ -190,7 +193,7 @@ class _ScreenshotSheetContentState extends State<_ScreenshotSheetContent> {
                 padding: const EdgeInsets.all(32),
                 child: Center(
                   child: Text(
-                    'No windows found',
+                    l.noWindowsFound,
                     style: TextStyle(color: appColors.subtleText),
                   ),
                 ),

--- a/apps/mobile/lib/widgets/session_card.dart
+++ b/apps/mobile/lib/widgets/session_card.dart
@@ -94,7 +94,9 @@ class _RunningSessionCardState extends State<RunningSessionCard> {
   Widget build(BuildContext context) {
     final session = widget.session;
     final appColors = Theme.of(context).extension<AppColors>()!;
+    final l = AppLocalizations.of(context);
     final visualStatus = sessionVisualStatusFor(
+      l: l,
       rawStatus: session.status,
       permissionMode: session.permissionMode,
       pendingPermission: session.pendingPermission,

--- a/apps/mobile/lib/widgets/session_visual_status.dart
+++ b/apps/mobile/lib/widgets/session_visual_status.dart
@@ -1,3 +1,4 @@
+import '../l10n/app_localizations.dart';
 import '../models/messages.dart';
 
 enum SessionPrimaryStatus { working, needsYou, ready }
@@ -19,6 +20,7 @@ class SessionVisualStatus {
 }
 
 SessionVisualStatus sessionVisualStatusFor({
+  required AppLocalizations l,
   required String rawStatus,
   String? permissionMode,
   PermissionRequestMessage? pendingPermission,
@@ -27,16 +29,16 @@ SessionVisualStatus sessionVisualStatusFor({
 
   if (pendingPermission != null) {
     final detail = switch (pendingPermission.toolName) {
-      'ExitPlanMode' => 'Review plan',
+      'ExitPlanMode' => l.statusReviewPlan,
       'AskUserQuestion' =>
         pendingPermission.isRequestUserInputApproval
-            ? 'Approve tool call'
-            : 'Answer question',
-      _ => 'Approve ${pendingPermission.toolName}',
+            ? l.statusApproveToolCall
+            : l.statusAnswerQuestion,
+      _ => l.statusApproveTool(pendingPermission.toolName),
     };
     return SessionVisualStatus(
       primary: SessionPrimaryStatus.needsYou,
-      label: 'Needs You',
+      label: l.statusNeedsYou,
       detail: detail,
       showPlanBadge: showPlanBadge,
       animate: true,
@@ -46,26 +48,26 @@ SessionVisualStatus sessionVisualStatusFor({
   return switch (rawStatus) {
     'starting' || 'running' => SessionVisualStatus(
       primary: SessionPrimaryStatus.working,
-      label: 'Working',
+      label: l.statusWorking,
       showPlanBadge: showPlanBadge,
       animate: true,
     ),
     'compacting' => SessionVisualStatus(
       primary: SessionPrimaryStatus.working,
-      label: 'Working',
-      detail: 'Cleaning up context',
+      label: l.statusWorking,
+      detail: l.statusCleaningContext,
       showPlanBadge: showPlanBadge,
       animate: true,
     ),
     'waiting_approval' => SessionVisualStatus(
       primary: SessionPrimaryStatus.needsYou,
-      label: 'Needs You',
+      label: l.statusNeedsYou,
       showPlanBadge: showPlanBadge,
       animate: true,
     ),
     _ => SessionVisualStatus(
       primary: SessionPrimaryStatus.ready,
-      label: 'Ready',
+      label: l.statusReady,
       showPlanBadge: showPlanBadge,
       animate: false,
     ),

--- a/apps/mobile/test/auth_help_docs_test.dart
+++ b/apps/mobile/test/auth_help_docs_test.dart
@@ -28,5 +28,16 @@ void main() {
       expect(content, contains('`claude`'));
       expect(content, contains('`/login`'));
     });
+
+    test('Simplified Chinese markdown exists with localized guidance', () {
+      final file = File('assets/docs/auth-troubleshooting.zh-CN.md');
+
+      expect(file.existsSync(), isTrue);
+      final content = file.readAsStringSync();
+      expect(content, contains('当你不在 Bridge 机器旁边时'));
+      expect(content, contains('用终端应用连接到 Bridge 机器'));
+      expect(content, contains('`claude`'));
+      expect(content, contains('`/login`'));
+    });
   });
 }

--- a/apps/mobile/test/session_card_test.dart
+++ b/apps/mobile/test/session_card_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:ccpocket/l10n/app_localizations.dart';
+import 'package:ccpocket/l10n/app_localizations_en.dart';
 import 'package:ccpocket/models/messages.dart';
 import 'package:ccpocket/theme/app_theme.dart';
 import 'package:ccpocket/widgets/session_card.dart';
@@ -70,7 +71,9 @@ void main() {
 
   group('RunningSessionCard', () {
     test('maps visual status for running plan session', () {
+      final l = AppLocalizationsEn();
       final visual = sessionVisualStatusFor(
+        l: l,
         rawStatus: 'running',
         permissionMode: PermissionMode.plan.value,
       );
@@ -81,7 +84,9 @@ void main() {
     });
 
     test('maps visual status for plan approval', () {
+      final l = AppLocalizationsEn();
       final visual = sessionVisualStatusFor(
+        l: l,
         rawStatus: 'waiting_approval',
         permissionMode: PermissionMode.plan.value,
         pendingPermission: const PermissionRequestMessage(

--- a/apps/mobile/test/settings_cubit_push_test.dart
+++ b/apps/mobile/test/settings_cubit_push_test.dart
@@ -308,5 +308,38 @@ void main() {
       await fcm.disposeFake();
       bridge.dispose();
     });
+
+    test(
+      'uses zh push locale when app language is simplified Chinese',
+      () async {
+        SharedPreferences.setMockInitialValues({
+          'settings_app_locale': 'zh',
+          'machines_v2':
+              '[{"id":"$_testMachineId","host":"$_testHost","port":$_testPort}]',
+        });
+        final prefs = await SharedPreferences.getInstance();
+        final manager = await _createMachineManager(prefs);
+        await manager.init();
+        final bridge = FakeBridgeService()
+          ..emitConnection(BridgeConnectionState.connected, url: _testUrl);
+        final fcm = FakeFcmService(available: true, token: 'token-zh');
+        final cubit = SettingsCubit(
+          prefs,
+          bridgeService: bridge,
+          machineManager: manager,
+          fcmService: fcm,
+        );
+
+        await _flushAsync();
+        await cubit.toggleFcm(true);
+
+        expect(bridge.registerCalls, isNotEmpty);
+        expect(bridge.registerCalls.last.locale, 'zh');
+
+        await cubit.close();
+        await fcm.disposeFake();
+        bridge.dispose();
+      },
+    );
   });
 }

--- a/docs/auth-troubleshooting.ja.md
+++ b/docs/auth-troubleshooting.ja.md
@@ -1,5 +1,7 @@
 # Claude 認証トラブルシューティング
 
+[English](auth-troubleshooting.md) | [简体中文版](auth-troubleshooting.zh-CN.md)
+
 CC Pocket は Bridge マシン上に保存された Claude Code のログイン状態を使います。
 認証エラーが出たら、そのマシンで Claude Code に再ログインしてください。
 

--- a/docs/auth-troubleshooting.md
+++ b/docs/auth-troubleshooting.md
@@ -1,5 +1,7 @@
 # Claude Authentication Troubleshooting
 
+[日本語版](auth-troubleshooting.ja.md) | [简体中文版](auth-troubleshooting.zh-CN.md)
+
 CC Pocket uses the Claude Code login state stored on your Bridge machine.
 If authentication fails, sign in to Claude Code again on that machine.
 

--- a/docs/auth-troubleshooting.zh-CN.md
+++ b/docs/auth-troubleshooting.zh-CN.md
@@ -1,0 +1,41 @@
+# Claude 认证故障排查
+
+[English](auth-troubleshooting.md) | [日本語版](auth-troubleshooting.ja.md)
+
+CC Pocket 会使用保存在你的 Bridge 机器上的 Claude Code 登录状态。
+如果认证失败，请在那台机器上重新登录 Claude Code。
+
+## 当你不在 Bridge 机器旁边时
+
+在 CC Pocket 的使用场景里，你的 Bridge 机器可能是家里的 Mac mini，或者另一台一直开着的 Mac。
+即使如此，你也可以直接用手机远程重新登录 Claude Code。
+
+1. 用终端应用连接到 Bridge 机器
+   - 可以使用 Moshi、Termius、Blink 或任意 SSH 客户端
+2. 运行 `claude`
+3. 在 Claude Code 中执行 `/login`
+4. 在手机或电脑浏览器中打开显示出来的 URL
+5. 完成登录
+6. 如果终端提示需要粘贴结果，就把结果贴回去
+
+从下一次请求开始，CC Pocket 就会使用更新后的登录状态。
+
+## 当你就在 Bridge 机器旁边时
+
+1. 在 Bridge 机器上运行 `claude`
+2. 执行 `/login`
+3. 在浏览器中完成登录流程
+
+## Shell 方式
+
+如果你愿意，也可以直接运行下面的命令：
+
+```bash
+claude auth login
+```
+
+## 常见原因
+
+- 你的 Claude 登录已过期
+- Claude Code 更新后，旧的登录状态失效了
+- Anthropic 撤销了已保存的令牌

--- a/packages/bridge/src/push-i18n.test.ts
+++ b/packages/bridge/src/push-i18n.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizePushLocale, t } from "./push-i18n.js";
+
+describe("normalizePushLocale", () => {
+  it("returns zh for simplified Chinese locale tags", () => {
+    expect(normalizePushLocale("zh-CN")).toBe("zh");
+    expect(normalizePushLocale("zh_Hans")).toBe("zh");
+  });
+
+  it("falls back to en for unsupported locales", () => {
+    expect(normalizePushLocale("ko-KR")).toBe("en");
+  });
+});
+
+describe("t", () => {
+  it("returns Chinese translations with placeholders resolved", () => {
+    expect(t("zh", "approval_body", { toolName: "apply_patch" })).toBe(
+      "请批准执行 apply_patch",
+    );
+  });
+});

--- a/packages/bridge/src/push-i18n.ts
+++ b/packages/bridge/src/push-i18n.ts
@@ -1,4 +1,4 @@
-export type PushLocale = "en" | "ja";
+export type PushLocale = "en" | "ja" | "zh";
 
 const translations: Record<PushLocale, Record<string, string>> = {
   en: {
@@ -35,9 +35,26 @@ const translations: Record<PushLocale, Record<string, string>> = {
     result_success_body_private: "セッション完了",
     result_error_body_private: "セッションが失敗しました",
   },
+  zh: {
+    approval_title: "需要批准",
+    ask_title: "需要回复",
+    plan_ready_title: "计划已准备好",
+    approval_body: "请批准执行 {toolName}",
+    plan_ready_body: "计划已准备好，请查看",
+    ask_default_body: "Claude 正在提问",
+    task_completed: "任务已完成",
+    error_occurred: "发生错误",
+    session_completed: "会话已完成",
+    session_failed: "会话失败",
+    // Privacy mode
+    approval_body_private: "请批准工具执行",
+    ask_body_private: "请回答一个问题",
+    result_success_body_private: "会话已完成",
+    result_error_body_private: "会话失败",
+  },
 };
 
-const SUPPORTED_LOCALES = new Set<string>(["en", "ja"]);
+const SUPPORTED_LOCALES = new Set<string>(["en", "ja", "zh"]);
 
 export function normalizePushLocale(locale: string | undefined): PushLocale {
   if (!locale) return "en";


### PR DESCRIPTION
## Summary

Add Simplified Chinese support across the mobile app, bridge notifications, and repository docs.

## Changes

- Add `zh` app locale resources and generated localization wiring
- Localize key mobile UI flows found during Android real-device verification
- Add Simplified Chinese auth troubleshooting docs for app assets and repo docs
- Add Simplified Chinese push notification strings on the Bridge side
- Add README and cross-links for Simplified Chinese docs
- Fix Android new-session CTA clipping for Chinese text
- Pin Android NDK version to stabilize local Android builds

## Test plan

- [x] Bridge Server tests pass (`npm run test:bridge`)
- [x] Flutter tests pass (`cd apps/mobile && flutter test`)
- [x] Manual testing done

## Notes

- Verified on Android real device
- PR CI will run Flutter analyze/test on `pull_request`
- Android / iOS / macOS release workflows are not PR-triggered in the current repository setup
