### PR TITLE
fix(mobile): adjust chat scroll when keyboard appears on Android

### DIFF
--- a/apps/mobile/lib/features/claude_session/claude_session_screen.dart
+++ b/apps/mobile/lib/features/claude_session/claude_session_screen.dart
@@ -313,6 +313,24 @@ class _ChatScreenBody extends HookWidget {
         lifecycleState != null && lifecycleState != AppLifecycleState.resumed;
     final scroll = useScrollTracking(sessionId);
 
+    // --- Keep chat content visible when keyboard appears ---
+    final keyboardHeight = MediaQuery.viewInsetsOf(context).bottom;
+    final prevKeyboardRef = useRef(0.0);
+    useEffect(() {
+      final prevKb = prevKeyboardRef.value;
+      prevKeyboardRef.value = keyboardHeight;
+      final delta = keyboardHeight - prevKb;
+      if (delta != 0) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (!scroll.controller.hasClients) return;
+          final pos = scroll.controller.position;
+          final target = (pos.pixels + delta).clamp(0.0, pos.maxScrollExtent);
+          scroll.controller.jumpTo(target);
+        });
+      }
+      return null;
+    }, [keyboardHeight]);
+
     // Plan feedback controller (for plan approval rejection message)
     final planFeedbackController = useTextEditingController();
 
@@ -810,7 +828,7 @@ class _ChatScreenBody extends HookWidget {
                       pendingPlanToolUseId: pendingPlanToolUseId,
                       onScrollToBottom: scroll.scrollToBottom,
                       scrollToUserEntry: scrollToUserEntry,
-                      bottomPadding: 8,
+                      bottomPadding: overlayHeight + 8,
                     ),
                   ),
                 ),

--- a/apps/mobile/lib/features/codex_session/codex_session_screen.dart
+++ b/apps/mobile/lib/features/codex_session/codex_session_screen.dart
@@ -310,6 +310,24 @@ class _CodexChatBody extends HookWidget {
         lifecycleState != null && lifecycleState != AppLifecycleState.resumed;
     final scroll = useScrollTracking(sessionId);
 
+    // --- Keep chat content visible when keyboard appears ---
+    final keyboardHeight = MediaQuery.viewInsetsOf(context).bottom;
+    final prevKeyboardRef = useRef(0.0);
+    useEffect(() {
+      final prevKb = prevKeyboardRef.value;
+      prevKeyboardRef.value = keyboardHeight;
+      final delta = keyboardHeight - prevKb;
+      if (delta != 0) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (!scroll.controller.hasClients) return;
+          final pos = scroll.controller.position;
+          final target = (pos.pixels + delta).clamp(0.0, pos.maxScrollExtent);
+          scroll.controller.jumpTo(target);
+        });
+      }
+      return null;
+    }, [keyboardHeight]);
+
     // Chat input controller
     final chatInputController = useTextEditingController();
     final planFeedbackController = useTextEditingController();
@@ -816,7 +834,7 @@ class _CodexChatBody extends HookWidget {
                       scrollToUserEntry: scrollToUserEntry,
                       collapseToolResults: collapseToolResults,
                       onScrollToBottom: scroll.scrollToBottom,
-                      bottomPadding: 8,
+                      bottomPadding: overlayHeight + 8,
                     ),
                   ),
                 ),


### PR DESCRIPTION
## Problem

On Android, when the soft keyboard opens in a chat session, the message list stays at the same scroll position. The keyboard covers the bottom portion of visible messages, forcing the user to manually scroll to see recent content. This affects both Claude and Codex session screens.

Every major chat app (Telegram, WhatsApp, iMessage, Slack, Discord, ChatGPT) shifts the content up when the keyboard appears — without it, the app feels broken.

## Solution

Added a `useEffect` hook in both session screens that watches `MediaQuery.viewInsetsOf(context).bottom`. When the keyboard height changes:

- **Keyboard opens:** scroll position shifts up by the keyboard height delta
- **Keyboard closes:** scroll position shifts back down by the same delta
- Works at **any scroll position** (bottom, middle, or top of the conversation)
- Uses `clamp(0.0, maxScrollExtent)` to prevent over-scrolling

Also restored `bottomPadding: overlayHeight + 8` in `contentBuilder` (was `8`), so the message list properly accounts for the approval bar overlay height.

## Changes

- `claude_session_screen.dart` — keyboard scroll adjustment hook + bottomPadding fix
- `codex_session_screen.dart` — same changes

No changes to `BottomOverlayLayout` or other shared widgets.

## Test plan

Tested on a physical Android device (release build):

- [x] Keyboard opens → chat shifts up, same content stays visible
- [x] Keyboard closes without typing → chat shifts back to original position
- [x] Works when scrolled to bottom of conversation
- [x] Works when scrolled to middle of conversation
- [x] Approval bar positions correctly with keyboard open/closed
- [x] No jank or stutter in keyboard animation