### PR TITLE
feat(mobile): SSH Direct接続モード — サブスクでToS準拠のClaude Code操作

### DIFF
--- a/apps/mobile/lib/models/machine.dart
+++ b/apps/mobile/lib/models/machine.dart
@@ -27,6 +27,16 @@ enum SshAuthType {
   privateKey,
 }
 
+/// Connection mode for a machine
+enum ConnectionMode {
+  /// Connect via Bridge Server (WebSocket) — requires Bridge Server running
+  bridge,
+
+  /// Connect directly via SSH — runs Claude CLI on the remote machine
+  /// This mode is ToS-compliant and works with Pro/Max subscriptions
+  sshDirect,
+}
+
 /// Bridge Server version information from /version endpoint
 @freezed
 abstract class BridgeVersionInfo with _$BridgeVersionInfo {
@@ -130,6 +140,10 @@ abstract class Machine with _$Machine {
 
   /// Whether this machine can be started remotely (SSH configured)
   bool get canStartRemotely => sshEnabled && sshUsername != null;
+
+  /// Whether SSH Direct mode can be used (SSH must be configured)
+  bool get canUseSshDirect =>
+      sshEnabled && sshUsername != null && hasCredentials;
 }
 
 /// Runtime state wrapper for Machine with status and version information.

--- a/apps/mobile/lib/services/ssh_direct_service.dart
+++ b/apps/mobile/lib/services/ssh_direct_service.dart
@@ -1,0 +1,674 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:dartssh2/dartssh2.dart';
+
+import '../core/logger.dart';
+import '../models/machine.dart';
+import '../models/messages.dart';
+import 'bridge_service_base.dart';
+import 'machine_manager_service.dart';
+import 'ssh_message_mapper.dart';
+
+/// SSH Direct Service — connects to a remote machine via SSH and runs
+/// Claude Code CLI directly, bypassing the Bridge Server entirely.
+///
+/// This approach is fully compliant with Anthropic's ToS because:
+/// - The `claude` CLI is launched directly by the user (via SSH)
+/// - The app is just an SSH client + viewer — no OAuth tokens are used
+/// - From Anthropic's perspective, it's identical to using a terminal
+///
+/// Architecture:
+/// ```
+/// [CC Pocket App] → SSH → [User's Mac] → claude --output-format stream-json
+///                   ↕ stdin/stdout (JSON Lines)
+/// ```
+class SshDirectService implements BridgeServiceBase {
+  final MachineManagerService _machineManager;
+
+  /// SSH connection
+  SSHClient? _sshClient;
+  SSHSession? _sshSession;
+
+  /// Stream controllers for BridgeServiceBase interface
+  final _messageController = StreamController<ServerMessage>.broadcast();
+  final _taggedMessageController =
+      StreamController<(ServerMessage, String?)>.broadcast();
+  final _connectionController =
+      StreamController<BridgeConnectionState>.broadcast();
+  final _sessionListController =
+      StreamController<List<SessionInfo>>.broadcast();
+  final _fileListController = StreamController<List<String>>.broadcast();
+
+  /// Internal state
+  BridgeConnectionState _connectionState = BridgeConnectionState.disconnected;
+  String? _currentSessionId;
+  String? _currentProjectPath;
+  String? _connectedMachineId;
+  final List<SessionInfo> _sessions = [];
+  final List<ServerMessage> _sessionHistory = [];
+
+  /// Pending control requests (request_id → completer for approval)
+  final _pendingControlRequests = <String, Completer<bool>>{};
+
+  /// Stdout line buffer for JSON parsing
+  final _lineBuffer = StringBuffer();
+
+  /// Timeout for SSH connection
+  static const _connectionTimeout = Duration(seconds: 15);
+
+  SshDirectService(this._machineManager);
+
+  // ---- BridgeServiceBase implementation ----
+
+  @override
+  Stream<ServerMessage> get messages => _messageController.stream;
+
+  @override
+  Stream<BridgeConnectionState> get connectionStatus =>
+      _connectionController.stream;
+
+  @override
+  Stream<List<SessionInfo>> get sessionList => _sessionListController.stream;
+
+  @override
+  Stream<List<String>> get fileList => _fileListController.stream;
+
+  @override
+  String? get httpBaseUrl => null; // No HTTP server in SSH mode
+
+  @override
+  bool get isConnected => _connectionState == BridgeConnectionState.connected;
+
+  @override
+  Stream<ServerMessage> messagesForSession(String sessionId) {
+    return _taggedMessageController.stream
+        .where((tagged) {
+          final (_, taggedSessionId) = tagged;
+          return taggedSessionId == null || taggedSessionId == sessionId;
+        })
+        .map((tagged) => tagged.$1);
+  }
+
+  @override
+  void send(ClientMessage message) {
+    switch (message.type) {
+      case 'start':
+        _handleStart(message);
+      case 'input':
+        _handleInput(message);
+      case 'approve':
+        _handleApprove(message);
+      case 'approve_always':
+        _handleApprove(message);
+      case 'reject':
+        _handleReject(message);
+      case 'stop_session':
+        _handleStopSession(message);
+      case 'interrupt':
+        _handleInterrupt(message);
+      case 'list_sessions':
+        _emitSessionList();
+      case 'get_history':
+        _handleGetHistory(message);
+      case 'set_permission_mode':
+        // Permission mode changes require restarting the claude process
+        // with different flags. For now, log a warning.
+        logger.w('SshDirect: permission mode changes require session restart');
+      default:
+        logger.d('SshDirect: unsupported message type: ${message.type}');
+    }
+  }
+
+  @override
+  void requestSessionHistory(String sessionId) {
+    // Emit cached history
+    if (_sessionHistory.isNotEmpty) {
+      _emit(HistoryMessage(messages: List.of(_sessionHistory)));
+    }
+  }
+
+  @override
+  void stopSession(String sessionId) {
+    send(ClientMessage.stopSession(sessionId));
+  }
+
+  @override
+  void requestFileList(String projectPath) {
+    // File listing via SSH: run `find` or `ls` command
+    _runSshCommand('ls -1 "$projectPath" 2>/dev/null | head -100').then((
+      output,
+    ) {
+      if (output != null) {
+        final files =
+            output
+                .split('\n')
+                .where((f) => f.isNotEmpty)
+                .map((f) => '$projectPath/$f')
+                .toList();
+        _fileListController.add(files);
+      }
+    });
+  }
+
+  @override
+  void requestSessionList() {
+    _emitSessionList();
+  }
+
+  @override
+  void interrupt(String sessionId) {
+    send(ClientMessage.interrupt(sessionId));
+  }
+
+  // ---- Public API (beyond BridgeServiceBase) ----
+
+  /// Connect to a machine via SSH.
+  Future<bool> connect(String machineId) async {
+    final machine = _machineManager.getMachine(machineId);
+    if (machine == null) {
+      logger.e('SshDirect: Machine not found: $machineId');
+      return false;
+    }
+
+    if (machine.sshUsername == null) {
+      logger.e('SshDirect: SSH username not configured');
+      return false;
+    }
+
+    _setConnectionState(BridgeConnectionState.connecting);
+
+    try {
+      final socket = await SSHSocket.connect(
+        machine.host,
+        machine.sshPort,
+        timeout: _connectionTimeout,
+      );
+
+      // Authenticate
+      String? password;
+      String? privateKey;
+
+      if (machine.sshAuthType == SshAuthType.password) {
+        password = await _machineManager.getSshPassword(machineId);
+        if (password == null || password.isEmpty) {
+          _setConnectionState(BridgeConnectionState.disconnected);
+          return false;
+        }
+        _sshClient = SSHClient(
+          socket,
+          username: machine.sshUsername!,
+          onPasswordRequest: () => password!,
+        );
+      } else {
+        privateKey = await _machineManager.getSshPrivateKey(machineId);
+        if (privateKey == null || privateKey.isEmpty) {
+          _setConnectionState(BridgeConnectionState.disconnected);
+          return false;
+        }
+        _sshClient = SSHClient(
+          socket,
+          username: machine.sshUsername!,
+          identities: [...SSHKeyPair.fromPem(privateKey)],
+        );
+      }
+
+      _connectedMachineId = machineId;
+      _setConnectionState(BridgeConnectionState.connected);
+
+      // Emit initial session list (empty)
+      _emitSessionList();
+
+      logger.i('SshDirect: Connected to ${machine.host}:${machine.sshPort}');
+      return true;
+    } on SSHAuthFailError {
+      logger.e('SshDirect: Authentication failed');
+      _setConnectionState(BridgeConnectionState.disconnected);
+      return false;
+    } on TimeoutException {
+      logger.e('SshDirect: Connection timeout');
+      _setConnectionState(BridgeConnectionState.disconnected);
+      return false;
+    } catch (e) {
+      logger.e('SshDirect: Connection failed: $e');
+      _setConnectionState(BridgeConnectionState.disconnected);
+      return false;
+    }
+  }
+
+  /// Disconnect from the remote machine.
+  void disconnect() {
+    _stopClaudeProcess();
+    _sshClient?.close();
+    _sshClient = null;
+    _connectedMachineId = null;
+    _sessions.clear();
+    _sessionHistory.clear();
+    _setConnectionState(BridgeConnectionState.disconnected);
+  }
+
+  /// Dispose all resources.
+  void dispose() {
+    disconnect();
+    _messageController.close();
+    _taggedMessageController.close();
+    _connectionController.close();
+    _sessionListController.close();
+    _fileListController.close();
+  }
+
+  // ---- Message handlers ----
+
+  void _handleStart(ClientMessage message) {
+    final json = jsonDecode(message.toJson()) as Map<String, dynamic>;
+    final projectPath = json['projectPath'] as String? ?? '';
+    final permissionMode = json['permissionMode'] as String?;
+    final executionMode = json['executionMode'] as String?;
+    final planMode = json['planMode'] as bool?;
+    final sessionId = json['sessionId'] as String?;
+    final model = json['model'] as String?;
+
+    _startClaudeSession(
+      projectPath: projectPath,
+      sessionId: sessionId,
+      permissionMode: permissionMode,
+      executionMode: executionMode,
+      planMode: planMode,
+      model: model,
+    );
+  }
+
+  void _handleInput(ClientMessage message) {
+    final json = jsonDecode(message.toJson()) as Map<String, dynamic>;
+    final text = json['text'] as String? ?? '';
+    final images = json['images'] as List?;
+
+    final imageList = images
+        ?.map((i) => i as Map<String, dynamic>)
+        .toList();
+
+    _sendToClaudeProcess(
+      SshMessageMapper.buildUserInput(text, images: imageList),
+    );
+
+    // Emit input ack
+    _emit(InputAckMessage(sessionId: _currentSessionId));
+
+    // Emit status change to running
+    _emit(StatusMessage(status: ProcessStatus.running));
+    _updateSessionStatus('running');
+  }
+
+  void _handleApprove(ClientMessage message) {
+    final json = jsonDecode(message.toJson()) as Map<String, dynamic>;
+    final id = json['id'] as String? ?? '';
+
+    final completer = _pendingControlRequests.remove(id);
+    if (completer != null && !completer.isCompleted) {
+      completer.complete(true);
+    }
+
+    // Send control_response to CLI
+    _sendToClaudeProcess(SshMessageMapper.buildApproveResponse(id));
+
+    // Emit permission resolved
+    _emit(PermissionResolvedMessage(toolUseId: id));
+    _emit(StatusMessage(status: ProcessStatus.running));
+    _updateSessionStatus('running');
+  }
+
+  void _handleReject(ClientMessage message) {
+    final json = jsonDecode(message.toJson()) as Map<String, dynamic>;
+    final id = json['id'] as String? ?? '';
+    final rejectMessage = json['message'] as String?;
+
+    final completer = _pendingControlRequests.remove(id);
+    if (completer != null && !completer.isCompleted) {
+      completer.complete(false);
+    }
+
+    _sendToClaudeProcess(
+      SshMessageMapper.buildDenyResponse(id, message: rejectMessage),
+    );
+
+    _emit(PermissionResolvedMessage(toolUseId: id));
+    _emit(StatusMessage(status: ProcessStatus.running));
+    _updateSessionStatus('running');
+  }
+
+  void _handleStopSession(ClientMessage message) {
+    _stopClaudeProcess();
+    _updateSessionStatus('idle');
+  }
+
+  void _handleInterrupt(ClientMessage message) {
+    // Send SIGINT-equivalent: close the current session's stdin
+    // The CLI should handle this gracefully
+    _stopClaudeProcess();
+    _emit(
+      ResultMessage(
+        subtype: 'error_during_execution',
+        error: 'Session interrupted by user',
+      ),
+    );
+    _updateSessionStatus('idle');
+  }
+
+  void _handleGetHistory(ClientMessage message) {
+    if (_sessionHistory.isNotEmpty) {
+      _emit(HistoryMessage(messages: List.of(_sessionHistory)));
+    }
+  }
+
+  // ---- Claude CLI process management ----
+
+  Future<void> _startClaudeSession({
+    required String projectPath,
+    String? sessionId,
+    String? permissionMode,
+    String? executionMode,
+    bool? planMode,
+    String? model,
+  }) async {
+    if (_sshClient == null) {
+      _emit(ErrorMessage(message: 'Not connected via SSH'));
+      return;
+    }
+
+    // Stop any existing session
+    _stopClaudeProcess();
+
+    // Generate session ID
+    _currentSessionId = sessionId ?? _generateSessionId();
+    _currentProjectPath = projectPath;
+    _sessionHistory.clear();
+
+    // Build CLI command
+    final command = _buildClaudeCommand(
+      projectPath: projectPath,
+      sessionId: _currentSessionId,
+      permissionMode: permissionMode,
+      executionMode: executionMode,
+      planMode: planMode,
+      model: model,
+    );
+
+    logger.i('SshDirect: Starting claude session: $command');
+
+    try {
+      // Start SSH session with the claude command
+      _sshSession = await _sshClient!.execute(command);
+
+      // Update session list
+      final session = SessionInfo(
+        id: _currentSessionId!,
+        provider: 'claude',
+        projectPath: projectPath,
+        claudeSessionId: _currentSessionId,
+        status: 'starting',
+        createdAt: DateTime.now().toIso8601String(),
+        lastActivityAt: DateTime.now().toIso8601String(),
+        permissionMode: permissionMode,
+        executionMode: executionMode,
+        planMode: planMode ?? false,
+        model: model,
+      );
+      _sessions.clear();
+      _sessions.add(session);
+      _emitSessionList();
+
+      // Emit status
+      _emit(StatusMessage(status: ProcessStatus.starting));
+
+      // Listen to stdout (JSON Lines)
+      _sshSession!.stdout
+          .cast<List<int>>()
+          .transform(utf8.decoder)
+          .listen(
+            _onStdoutData,
+            onDone: _onProcessDone,
+            onError: (error) {
+              logger.e('SshDirect: stdout error: $error');
+              _emit(ErrorMessage(message: 'SSH stdout error: $error'));
+            },
+          );
+
+      // Listen to stderr for error messages
+      _sshSession!.stderr
+          .cast<List<int>>()
+          .transform(utf8.decoder)
+          .listen((data) {
+            logger.w('SshDirect: stderr: $data');
+            // Don't emit all stderr as errors — claude CLI outputs info to stderr
+          });
+    } catch (e) {
+      logger.e('SshDirect: Failed to start claude session: $e');
+      _emit(ErrorMessage(message: 'Failed to start Claude session: $e'));
+      _updateSessionStatus('idle');
+    }
+  }
+
+  /// Build the `claude` CLI command with appropriate flags.
+  String _buildClaudeCommand({
+    required String projectPath,
+    String? sessionId,
+    String? permissionMode,
+    String? executionMode,
+    bool? planMode,
+    String? model,
+  }) {
+    final args = <String>[
+      'claude',
+      '-p', // Print/headless mode
+      '--output-format', 'stream-json',
+      '--input-format', 'stream-json',
+      '--verbose',
+    ];
+
+    // Session resumption
+    if (sessionId != null) {
+      args.addAll(['--session-id', sessionId]);
+    }
+
+    // Model selection
+    if (model != null && model.isNotEmpty) {
+      args.addAll(['--model', model]);
+    }
+
+    // Permission handling based on mode
+    final effectiveMode = executionMode ?? permissionMode;
+    switch (effectiveMode) {
+      case 'bypassPermissions':
+      case 'fullAccess':
+        args.add('--dangerously-skip-permissions');
+      case 'acceptEdits':
+        args.addAll([
+          '--allowedTools',
+          'Bash(read_only:true),Read,Glob,Grep,Edit,Write,WebSearch',
+        ]);
+      case 'plan':
+        // Plan mode: no tool execution, just planning
+        // Use minimal permissions
+        args.addAll(['--allowedTools', 'Read,Glob,Grep,WebSearch']);
+      default:
+        // Default mode: only safe read-only tools
+        args.addAll(['--allowedTools', 'Read,Glob,Grep,WebSearch']);
+    }
+
+    // Working directory
+    final command = 'cd ${_shellEscape(projectPath)} && ${args.join(' ')}';
+
+    // Wrap in login shell to pick up user's env (nvm, etc.)
+    return 'zsh -li -c ${_shellEscape(command)}';
+  }
+
+  void _onStdoutData(String data) {
+    // Buffer incoming data and process complete lines
+    _lineBuffer.write(data);
+    final buffered = _lineBuffer.toString();
+    final lines = buffered.split('\n');
+
+    // Keep the last (potentially incomplete) line in the buffer
+    _lineBuffer.clear();
+    if (lines.isNotEmpty && !buffered.endsWith('\n')) {
+      _lineBuffer.write(lines.removeLast());
+    } else if (lines.isNotEmpty && lines.last.isEmpty) {
+      lines.removeLast();
+    }
+
+    for (final line in lines) {
+      final trimmed = line.trim();
+      if (trimmed.isEmpty) continue;
+
+      try {
+        final json = jsonDecode(trimmed) as Map<String, dynamic>;
+        _processCliMessage(json);
+      } catch (e) {
+        // Not JSON — could be startup messages or warnings
+        logger.d('SshDirect: non-JSON stdout: $trimmed');
+      }
+    }
+  }
+
+  void _processCliMessage(Map<String, dynamic> json) {
+    final type = json['type'] as String?;
+
+    // Handle control_request (permission) messages
+    if (type == 'control_request') {
+      final mapped = SshMessageMapper.mapControlRequest(json);
+      if (mapped != null) {
+        final (requestId, permMessage) = mapped;
+        _pendingControlRequests[requestId] = Completer<bool>();
+        _emit(permMessage);
+        _emit(StatusMessage(status: ProcessStatus.waitingApproval));
+        _updateSessionStatus('waiting_approval');
+      }
+      return;
+    }
+
+    // Map SDK message to ServerMessage
+    final serverMessage = SshMessageMapper.mapSdkMessage(json);
+    if (serverMessage == null) return;
+
+    // Track history for non-streaming messages
+    if (serverMessage is! StreamDeltaMessage &&
+        serverMessage is! ThinkingDeltaMessage &&
+        serverMessage is! StatusMessage) {
+      _sessionHistory.add(serverMessage);
+    }
+
+    // Update status on specific message types
+    if (serverMessage is SystemMessage &&
+        serverMessage.subtype == 'session_created') {
+      _emit(StatusMessage(status: ProcessStatus.idle));
+      _updateSessionStatus('idle');
+    }
+
+    if (serverMessage is ResultMessage) {
+      _emit(StatusMessage(status: ProcessStatus.idle));
+      _updateSessionStatus('idle');
+    }
+
+    _emit(serverMessage);
+  }
+
+  void _onProcessDone() {
+    logger.i('SshDirect: Claude process finished');
+
+    // If there's still buffered data, try to process it
+    final remaining = _lineBuffer.toString().trim();
+    if (remaining.isNotEmpty) {
+      try {
+        final json = jsonDecode(remaining) as Map<String, dynamic>;
+        _processCliMessage(json);
+      } catch (_) {
+        // Ignore
+      }
+    }
+    _lineBuffer.clear();
+
+    // Emit idle status if we didn't get a result message
+    _updateSessionStatus('idle');
+    _sshSession = null;
+  }
+
+  void _sendToClaudeProcess(String jsonLine) {
+    if (_sshSession == null) {
+      logger.w('SshDirect: No active SSH session to send to');
+      return;
+    }
+
+    try {
+      _sshSession!.stdin.add(utf8.encode('$jsonLine\n'));
+    } catch (e) {
+      logger.e('SshDirect: Failed to write to stdin: $e');
+      _emit(ErrorMessage(message: 'Failed to send message: $e'));
+    }
+  }
+
+  void _stopClaudeProcess() {
+    if (_sshSession != null) {
+      try {
+        _sshSession!.close();
+      } catch (_) {
+        // Ignore close errors
+      }
+      _sshSession = null;
+    }
+    _lineBuffer.clear();
+    _pendingControlRequests.clear();
+  }
+
+  /// Run a one-off SSH command (for file listing, etc.)
+  Future<String?> _runSshCommand(String command) async {
+    if (_sshClient == null) return null;
+
+    try {
+      final result = await _sshClient!.run(command);
+      return utf8.decode(result);
+    } catch (e) {
+      logger.e('SshDirect: Command failed: $e');
+      return null;
+    }
+  }
+
+  // ---- Helpers ----
+
+  void _emit(ServerMessage message) {
+    _messageController.add(message);
+    _taggedMessageController.add((message, _currentSessionId));
+  }
+
+  void _setConnectionState(BridgeConnectionState state) {
+    _connectionState = state;
+    _connectionController.add(state);
+  }
+
+  void _emitSessionList() {
+    _sessionListController.add(List.unmodifiable(_sessions));
+  }
+
+  void _updateSessionStatus(String status) {
+    if (_currentSessionId == null) return;
+
+    final idx = _sessions.indexWhere((s) => s.id == _currentSessionId);
+    if (idx >= 0) {
+      _sessions[idx] = _sessions[idx].copyWith(
+        status: status,
+        lastMessage: '',
+      );
+      _emitSessionList();
+    }
+  }
+
+  String _generateSessionId() {
+    // Simple UUID-like ID
+    final now = DateTime.now().millisecondsSinceEpoch;
+    return 'ssh-${now.toRadixString(36)}';
+  }
+
+  /// Shell-escape a string for safe use in a command.
+  static String _shellEscape(String s) {
+    return "'${s.replaceAll("'", "'\\''")}'";
+  }
+}

--- a/apps/mobile/lib/services/ssh_message_mapper.dart
+++ b/apps/mobile/lib/services/ssh_message_mapper.dart
@@ -1,0 +1,330 @@
+import 'dart:convert';
+
+import '../models/messages.dart';
+
+/// Maps Claude Code CLI `--output-format stream-json` output (SDKMessage)
+/// to the existing [ServerMessage] types used by the Flutter app.
+///
+/// The CLI outputs Newline-Delimited JSON (NDJSON) where each line is an
+/// SDKMessage. This mapper translates those into the same ServerMessage types
+/// that the Bridge Server would emit, allowing the rest of the app to work
+/// unchanged.
+///
+/// Reference: https://code.claude.com/docs/en/headless
+class SshMessageMapper {
+  /// Parse a single JSON line from CLI stdout and convert to [ServerMessage].
+  ///
+  /// Returns `null` for messages that should be silently ignored
+  /// (e.g. internal control messages that are handled separately).
+  static ServerMessage? mapSdkMessage(Map<String, dynamic> json) {
+    final type = json['type'] as String?;
+    if (type == null) return null;
+
+    return switch (type) {
+      'system' => _mapSystemMessage(json),
+      'stream_event' => _mapStreamEvent(json),
+      'assistant' => _mapAssistantMessage(json),
+      'user' => _mapUserMessage(json),
+      'result' => _mapResultMessage(json),
+      'tool_use_summary' => _mapToolUseSummary(json),
+      'tool_progress' => null, // Silently ignore progress updates for now
+      'auth_status' => null, // Auth is handled at SSH level
+      'rate_limit_event' => _mapRateLimitEvent(json),
+      'prompt_suggestion' => null, // Not used in current UI
+      _ => null, // Unknown types are silently ignored
+    };
+  }
+
+  /// Map `control_request` messages to [PermissionRequestMessage].
+  ///
+  /// The control protocol is used by the Claude Agent SDK internally.
+  /// When running in SDK mode, the CLI sends `control_request` for
+  /// permission checks, and expects `control_response` via stdin.
+  ///
+  /// Returns the request_id along with the mapped message so the caller
+  /// can respond with the appropriate `control_response`.
+  static (String requestId, PermissionRequestMessage message)?
+      mapControlRequest(Map<String, dynamic> json) {
+    final type = json['type'] as String?;
+    if (type != 'control_request') return null;
+
+    final requestId = json['request_id'] as String? ?? '';
+    final request = json['request'] as Map<String, dynamic>?;
+    if (request == null) return null;
+
+    final subtype = request['subtype'] as String?;
+    if (subtype != 'can_use_tool') return null;
+
+    final toolName = request['tool_name'] as String? ?? '';
+    final input = request['input'] as Map<String, dynamic>? ?? {};
+
+    // Use request_id as toolUseId since it serves the same purpose
+    return (
+      requestId,
+      PermissionRequestMessage(
+        toolUseId: requestId,
+        toolName: toolName,
+        input: input,
+      ),
+    );
+  }
+
+  /// Build a `control_response` JSON string for approving a tool use.
+  static String buildApproveResponse(String requestId) {
+    return jsonEncode({
+      'type': 'control_response',
+      'request_id': requestId,
+      'response': {
+        'subtype': 'success',
+        'response': {'behavior': 'allow'},
+      },
+    });
+  }
+
+  /// Build a `control_response` JSON string for denying a tool use.
+  static String buildDenyResponse(String requestId, {String? message}) {
+    return jsonEncode({
+      'type': 'control_response',
+      'request_id': requestId,
+      'response': {
+        'subtype': 'success',
+        'response': {
+          'behavior': 'deny',
+          if (message != null) 'message': message,
+        },
+      },
+    });
+  }
+
+  /// Build a user input message for sending via stdin.
+  static String buildUserInput(String text, {List<Map<String, dynamic>>? images}) {
+    final content = <Map<String, dynamic>>[];
+    content.add({'type': 'text', 'text': text});
+
+    if (images != null) {
+      for (final img in images) {
+        content.add({
+          'type': 'image',
+          'source': {
+            'type': 'base64',
+            'media_type': img['mimeType'] ?? 'image/png',
+            'data': img['data'] ?? '',
+          },
+        });
+      }
+    }
+
+    return jsonEncode({
+      'type': 'user',
+      'message': {
+        'role': 'user',
+        'content': content.length == 1 ? text : content,
+      },
+    });
+  }
+
+  // ---- Private mapping methods ----
+
+  static ServerMessage? _mapSystemMessage(Map<String, dynamic> json) {
+    final subtype = json['subtype'] as String? ?? '';
+
+    switch (subtype) {
+      case 'init':
+        return SystemMessage(
+          subtype: 'session_created',
+          sessionId: json['session_id'] as String?,
+          claudeSessionId: json['session_id'] as String?,
+          model: json['model'] as String?,
+          provider: 'claude',
+          projectPath: json['cwd'] as String?,
+          permissionMode: json['permissionMode'] as String?,
+          slashCommands:
+              (json['slash_commands'] as List?)
+                  ?.map((e) => e.toString())
+                  .toList() ??
+              const [],
+          skills:
+              (json['skills'] as List?)
+                  ?.map((e) => e.toString())
+                  .toList() ??
+              const [],
+        );
+
+      case 'status':
+        // Map status subtypes to ProcessStatus
+        final statusText = json['status'] as String? ?? '';
+        return StatusMessage(status: ProcessStatus.fromString(statusText));
+
+      case 'compact_boundary':
+        return StatusMessage(status: ProcessStatus.compacting);
+
+      case 'api_retry':
+        final attempt = json['attempt'] as int? ?? 0;
+        final maxRetries = json['max_retries'] as int? ?? 0;
+        final error = json['error'] as String? ?? 'unknown';
+        return ErrorMessage(
+          message: 'API retry ($attempt/$maxRetries): $error',
+          errorCode: 'api_retry',
+        );
+
+      default:
+        return null; // Ignore unknown system subtypes
+    }
+  }
+
+  static ServerMessage? _mapStreamEvent(Map<String, dynamic> json) {
+    final event = json['event'] as Map<String, dynamic>?;
+    if (event == null) return null;
+
+    final eventType = event['type'] as String?;
+
+    switch (eventType) {
+      case 'content_block_delta':
+        final delta = event['delta'] as Map<String, dynamic>?;
+        if (delta == null) return null;
+
+        final deltaType = delta['type'] as String?;
+        switch (deltaType) {
+          case 'text_delta':
+            final text = delta['text'] as String? ?? '';
+            return StreamDeltaMessage(text: text);
+          case 'thinking_delta':
+            final thinking = delta['thinking'] as String? ?? '';
+            return ThinkingDeltaMessage(text: thinking);
+          case 'input_json_delta':
+            // Tool input streaming - ignore for now, we get the full input
+            // in the assistant message
+            return null;
+          default:
+            return null;
+        }
+
+      case 'message_start':
+      case 'content_block_start':
+      case 'content_block_stop':
+      case 'message_delta':
+      case 'message_stop':
+        // These are structural events, not content. Ignore.
+        return null;
+
+      default:
+        return null;
+    }
+  }
+
+  static ServerMessage _mapAssistantMessage(Map<String, dynamic> json) {
+    final message = json['message'] as Map<String, dynamic>? ?? {};
+    final uuid = json['uuid'] as String?;
+
+    return AssistantServerMessage(
+      message: AssistantMessage.fromJson(message),
+      messageUuid: uuid,
+    );
+  }
+
+  static ServerMessage? _mapUserMessage(Map<String, dynamic> json) {
+    final isSynthetic = json['isSynthetic'] as bool? ?? false;
+    final message = json['message'] as Map<String, dynamic>? ?? {};
+    final content = message['content'];
+    final uuid = json['uuid'] as String?;
+
+    // Check if this is a tool_result message
+    if (content is List) {
+      for (final block in content) {
+        if (block is Map<String, dynamic> && block['type'] == 'tool_result') {
+          final toolUseId = block['tool_use_id'] as String? ?? '';
+          final resultContent = block['content'];
+          final normalizedContent = _normalizeContent(resultContent);
+
+          return ToolResultMessage(
+            toolUseId: toolUseId,
+            content: normalizedContent,
+            userMessageUuid: uuid,
+          );
+        }
+      }
+    }
+
+    // Regular user message (not tool_result) - emit as UserInputMessage
+    if (!isSynthetic) {
+      final textContent = _extractTextFromContent(content);
+      return UserInputMessage(
+        text: textContent,
+        userMessageUuid: uuid,
+        isSynthetic: false,
+      );
+    }
+
+    return null; // Ignore synthetic user messages that aren't tool results
+  }
+
+  static ServerMessage _mapResultMessage(Map<String, dynamic> json) {
+    final subtype = json['subtype'] as String? ?? '';
+    final usage = json['usage'] as Map<String, dynamic>?;
+
+    return ResultMessage(
+      subtype: subtype,
+      result: json['result'] as String?,
+      error: _extractErrors(json),
+      cost: (json['total_cost_usd'] as num?)?.toDouble(),
+      duration: (json['duration_ms'] as num?)?.toDouble(),
+      sessionId: json['session_id'] as String?,
+      stopReason: json['stop_reason'] as String?,
+      inputTokens: usage?['input_tokens'] as int?,
+      cachedInputTokens: usage?['cache_read_input_tokens'] as int?,
+      outputTokens: usage?['output_tokens'] as int?,
+    );
+  }
+
+  static ServerMessage _mapToolUseSummary(Map<String, dynamic> json) {
+    return ToolUseSummaryMessage(
+      summary: json['summary'] as String? ?? '',
+      precedingToolUseIds:
+          (json['preceding_tool_use_ids'] as List?)?.cast<String>() ??
+          const [],
+    );
+  }
+
+  static ServerMessage _mapRateLimitEvent(Map<String, dynamic> json) {
+    return ErrorMessage(
+      message: 'Rate limit reached. Please wait before retrying.',
+      errorCode: 'rate_limit',
+    );
+  }
+
+  // ---- Helpers ----
+
+  static String _normalizeContent(dynamic content) {
+    if (content is String) return content;
+    if (content is List) {
+      return content
+          .whereType<Map<String, dynamic>>()
+          .where((c) => c['type'] == 'text')
+          .map((c) => c['text']?.toString() ?? '')
+          .join('\n');
+    }
+    return content?.toString() ?? '';
+  }
+
+  static String _extractTextFromContent(dynamic content) {
+    if (content is String) return content;
+    if (content is List) {
+      return content
+          .whereType<Map<String, dynamic>>()
+          .where((c) => c['type'] == 'text')
+          .map((c) => c['text']?.toString() ?? '')
+          .join('\n');
+    }
+    return '';
+  }
+
+  static String? _extractErrors(Map<String, dynamic> json) {
+    final errors = json['errors'];
+    if (errors is List && errors.isNotEmpty) {
+      return errors.map((e) => e.toString()).join('\n');
+    }
+    final error = json['error'];
+    if (error is String) return error;
+    return null;
+  }
+}


### PR DESCRIPTION
## 概要

v1.25.0 以降、AnthropicのポリシーによりOAuth認証が無効化されましたが、この問題を根本的に解決する **SSH Direct 接続モード** を提案・実装しました。

Bridge Server を経由せず、SSH経由でユーザーのマシン上の `claude` CLI を直接起動し、`--output-format stream-json` の出力をパースして既存UIで表示します。

## なぜ ToS に準拠するか

```
現行: App → WebSocket → Bridge Server → Claude Agent SDK → API
                         ^^^^^^^^^^^ サードパーティ扱い ❌

提案: App → SSH → claude CLI (ユーザー自身が起動) → API
       ^^^ ただのSSHクライアント ✅
```

- `claude` CLI を起動するのは **ユーザー自身**（SSH経由）
- アプリは **SSHクライアント＋ビューワー** に過ぎず、OAuth トークンや API キーに一切触れない
- Anthropic から見ると、ユーザーがターミナルで操作しているのと区別がつかない

## 変更内容

### 新規ファイル

| ファイル | 内容 |
|---------|------|
| `ssh_message_mapper.dart` | Claude CLI の stream-json 出力（SDKMessage）を既存の `ServerMessage` 型にマッピング |
| `ssh_direct_service.dart` | SSH接続 + Claude CLIプロセス管理。`BridgeServiceBase` を実装 |

### 変更ファイル

| ファイル | 内容 |
|---------|------|
| `machine.dart` | `ConnectionMode` enum 追加、`canUseSshDirect` ヘルパー追加 |

### アーキテクチャ

```
┌──────────────┐         ┌─────────────────────────┐
│  CC Pocket   │   SSH   │  ユーザーの Mac/サーバー   │
│  (モバイル)   │ ──────→ │                         │
│              │         │  claude --output-format  │
│  - ビューワー │ ←stdout │         stream-json      │
│  - 入力      │  stdin→ │                         │
│  - 承認      │         │  (ユーザー自身のサブスクで │
│              │         │   動作)                  │
└──────────────┘         └─────────────────────────┘
```

### メッセージマッピング

| CLI出力 (SDKMessage) | → ServerMessage |
|---|---|
| `system` (init) | `SystemMessage` |
| `stream_event` (text_delta) | `StreamDeltaMessage` |
| `stream_event` (thinking_delta) | `ThinkingDeltaMessage` |
| `assistant` | `AssistantServerMessage` |
| `user` (tool_result) | `ToolResultMessage` |
| `result` | `ResultMessage` |
| `control_request` (can_use_tool) | `PermissionRequestMessage` |
| `tool_use_summary` | `ToolUseSummaryMessage` |

### 権限モードのマッピング

| ExecutionMode | CLI フラグ |
|---|---|
| `fullAccess` | `--dangerously-skip-permissions` |
| `acceptEdits` | `--allowedTools "Bash(read_only:true),Read,Glob,Grep,Edit,Write,WebSearch"` |
| `default` | `--allowedTools "Read,Glob,Grep,WebSearch"` |

## 現行方式との比較

| | 現行（Bridge + API Key） | SSH Direct |
|---|---|---|
| サブスク（Pro/Max） | ❌ 利用不可 | ✅ 利用可能 |
| ToS 準拠 | ⚠️ API キー必須 | ✅ 完全準拠 |
| 追加サーバー | Bridge Server 必要 | 不要（sshd のみ） |
| Anthropic 側の変更で壊れるリスク | 中（SDK依存） | 低（公式CLI） |

## 共存設計

既存の Bridge モードに影響を与えません。`ConnectionMode` enum で `bridge` / `sshDirect` を切り替える設計です。

## TODO（この PR のスコープ外）

- [ ] 接続モード選択 UI の追加（Machine 設定画面）
- [ ] `ConnectionMode` を `Machine` の freezed フィールドに追加（`build_runner build` 実行が必要）
- [ ] `main.dart` の DI 統合（`BridgeService` と `SshDirectService` の切り替え）
- [ ] tmux/screen 内での起動によるセッション永続化
- [ ] `control_request`/`control_response` プロトコルのインタラクティブ承認テスト
- [ ] 複数セッション管理の改善
- [ ] SSH鍵管理のセキュリティ強化（Secure Enclave活用）

## ビルド時の注意

`machine.dart` に `ConnectionMode` enum を追加しています。freezed フィールドとしての `connectionMode` 追加は `build_runner build` が必要なため、このPRでは enum 定義のみに留めています。

```bash
cd apps/mobile && dart run build_runner build --delete-conflicting-outputs
```

## テストプラン

- [ ] SSH接続が正常に確立されることを確認
- [ ] `claude --output-format stream-json` の出力が正しくパースされることを確認
- [ ] ストリーミングテキスト（stream_delta）が既存UIで表示されることを確認
- [ ] 権限承認フロー（control_request → control_response）が動作することを確認
- [ ] セッション開始/停止/再開が正しく動作することを確認
- [ ] Pro/Max サブスクリプションで API キーなしで動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)