### PR TITLE
fix(bridge): codex app-server の CPU 100% フィードバックループを修正

### DIFF
--- a/packages/bridge/src/codex-process.ts
+++ b/packages/bridge/src/codex-process.ts
@@ -9,6 +9,15 @@ import { resolvePlatformPath } from "./path-utils.js";
 
 const DEFAULT_CODEX_MODEL = "gpt-5.5";
 
+/**
+ * After we run skills/list + app/list, codex often re-emits
+ * `app/list/updated` / `skills/changed` notifications as a side effect of our
+ * own RPCs. Reacting to those without a cooldown causes a tight feedback
+ * loop that pegs codex app-server at 100% CPU. Ignore notification-driven
+ * refetches for this many ms after each fetch completes.
+ */
+const COMPLETION_FETCH_COOLDOWN_MS = 1000;
+
 export interface CodexStartOptions {
   threadId?: string;
   profile?: string;
@@ -223,6 +232,12 @@ export class CodexProcess extends EventEmitter<CodexProcessEvents> {
   private _completionFetchInFlight: Promise<void> | null = null;
   private _completionFetchQueued = false;
   private _lastCompletionEntitiesSignature: string | null = null;
+  /**
+   * Cooldown timestamp; ignore notification-driven refetches before this.
+   * Prevents `app/list/updated` / `skills/changed` echoes from our own
+   * `app/list` / `skills/list` calls from causing a 100% CPU storm in codex.
+   */
+  private _completionFetchCooldownUntil = 0;
 
   /** Expose skill metadata so session/websocket can access it. */
   get skills(): CodexSkillMetadata[] {
@@ -1145,11 +1160,21 @@ export class CodexProcess extends EventEmitter<CodexProcessEvents> {
       await this._completionFetchInFlight;
     } finally {
       this._completionFetchInFlight = null;
-      if (this._completionFetchQueued && !this.stopped && this._projectPath) {
-        this._completionFetchQueued = false;
-        void this.fetchCompletionEntities(this._projectPath);
-      }
+      this._completionFetchCooldownUntil =
+        Date.now() + COMPLETION_FETCH_COOLDOWN_MS;
+      // Drop queued: any notification that fired during the in-flight fetch
+      // is almost certainly a self-echo from our own `app/list` /
+      // `skills/list` RPCs. Honoring it here re-arms an infinite refetch
+      // loop. Real future changes will arrive as fresh notifications after
+      // the cooldown window and be picked up via the notification path.
+      this._completionFetchQueued = false;
     }
+  }
+
+  private scheduleCompletionFetchFromNotification(): void {
+    if (!this._projectPath || this.stopped) return;
+    if (Date.now() < this._completionFetchCooldownUntil) return;
+    void this.fetchCompletionEntities(this._projectPath);
   }
 
   private async _fetchCompletionEntitiesInternal(
@@ -1727,16 +1752,12 @@ export class CodexProcess extends EventEmitter<CodexProcessEvents> {
 
       case "skills/changed": {
         // Re-fetch skills/apps when Codex notifies us of changes
-        if (this._projectPath) {
-          void this.fetchCompletionEntities(this._projectPath);
-        }
+        this.scheduleCompletionFetchFromNotification();
         break;
       }
 
       case "app/list/updated": {
-        if (this._projectPath) {
-          void this.fetchCompletionEntities(this._projectPath);
-        }
+        this.scheduleCompletionFetchFromNotification();
         break;
       }
 


### PR DESCRIPTION
## 概要

ccpocket-bridge 経由で `codex app-server --listen stdio://` を起動すると、セッション開始直後から **codex の CPU 使用率が 100% に張り付く**バグを修正します。

## 症状

- bridge がアイドル状態（クライアント切断中・ユーザー入力なし）でも codex が CPU 100% を継続
- Linux ではファンが最大回転、Package 温度 85°C 超まで上昇
- 数バージョンの codex-cli (0.123.0 / 0.124.0 / 0.125.0-alpha.3) すべてで再現
- どの sandbox / approval ポリシーの組み合わせ (workspace-write / read-only / danger-full-access × never / on-request) でも再現

## 原因

`app/list` RPC を呼ぶと codex は応答に加えて `app/list/updated` 通知を **複数回エコー** します。bridge はその通知に反応して `fetchCompletionEntities()` を再実行し、その中でまた `app/list` を呼ぶ、という **自己反響型の無限ループ** になっていました。

```
bridge ──app/list──▶ codex
       ◀app/list/updated × N ──
       ──app/list──▶ codex
       ◀app/list/updated × N ──
       ... (約 25 fetch/sec で永久継続)
```

既存の `_lastCompletionEntitiesSignature` による重複排除は **emit (= bridge → app への通知) を抑止するだけ**で、RPC 自体は毎回走るためログ上は気づきにくく、ループを抑え込めていませんでした。

### なぜ macOS ユーザーは気づきにくかったか

ループ自体は全プラットフォームで起きていますが、1 周あたりに codex が spawn する probe (`lsb_release` / `getconf` 等) のコストが OS により異なります。

| OS | probe コスト | 観測される CPU |
|---|---|---|
| Linux | `lsb_release` が Python スクリプトで起動 30〜50ms | **100% に張り付き** |
| macOS | `lsb_release` が ENOENT で即時失敗、軽量なフォールバック | 数 % で見過ごされる |

そのため Linux ユーザーから問題が顕在化しましたが、修正は全プラットフォームで電力 / CPU 改善に寄与します。

## 修正内容

`packages/bridge/src/codex-process.ts` (+31 / -10 行)

1. **クールダウン定数追加** (`COMPLETION_FETCH_COOLDOWN_MS = 1000`)
2. **`_completionFetchCooldownUntil` フィールド** で fetch 完了後 1 秒間の cooldown を管理
3. **`scheduleCompletionFetchFromNotification()` 新メソッド**: cooldown 内なら通知を無視
4. **`skills/changed` / `app/list/updated` 通知ハンドラ** を上記メソッド経由に変更
5. **`fetchCompletionEntities` の queued 再帰を削除**
   - in-flight 中に来た通知はほぼ確実に自己エコーなので honor すると loop が再武装
   - 本物の更新は cooldown 明けの新規通知として正常に拾われる

## 検証

### Before / After (60 秒間の計測)

| 項目 | 修正前 | 修正後 |
|---|---|---|
| `fetchCompletionEntities()` 実行回数 | 247+ (継続増加) | **1** (初回のみ) |
| `app/list/updated` 通知受信数 | 数百〜 | **2** (初回エコーのみ) |
| codex CPU @ 60s | **95%** | **2.4%** |
| codex Package 温度 | 87°C | 通常のアイドル温度 |

### 再現スクリプト

bridge の振る舞いを最小再現する Node スクリプトで検証しました（コメントアウト/環境変数でクールダウンの有無を切替可能）。
- `app/list` を 1 回呼ぶだけで `app/list/updated` が 2 回返る挙動を確認
- 修正前ロジック → 14 秒で fetchCount 247 / CPU 95%
- 修正後ロジック → fetchCount 1 / CPU 2.4% で定常

### テスト

- `npx tsc --noEmit -p packages/bridge/tsconfig.json` クリーン
- `npm run test:bridge` → **516 / 516 tests pass**

## 互換性 / リスク

- 通知ハンドラの仕様変更ですが、既存テストは全て通過
- 本物の skills/apps 変更検知は cooldown (1 秒) 分だけ遅延しますが、ユーザー体感への影響は無視できる範囲
- public API・WebSocket プロトコルの変更なし

## 関連

- Codex 側にも `app/list` RPC の応答として `app/list/updated` を発火する挙動の見直しを別途報告する価値はありますが、本 PR は bridge 側で完結する防御的修正です

🤖 Generated with [Claude Code](https://claude.com/claude-code)