### PR TITLE
feat(settings): add adjustable text size setting

### DIFF
--- a/apps/mobile/lib/features/settings/settings_screen.dart
+++ b/apps/mobile/lib/features/settings/settings_screen.dart
@@ -217,6 +217,18 @@ class _SettingsScreenState extends State<SettingsScreen> {
                             context.read<SettingsCubit>().setThemeMode(mode),
                       ),
                     ),
+                    Divider(
+                      height: 1,
+                      indent: 16,
+                      endIndent: 16,
+                      color: cs.outlineVariant,
+                    ),
+                    // Text size
+                    _TextSizeTile(
+                      value: state.textScale,
+                      onChanged: (value) =>
+                          context.read<SettingsCubit>().setTextScale(value),
+                    ),
                     if (state.appIconSupported) ...[
                       Divider(
                         height: 1,
@@ -1068,6 +1080,61 @@ class _MacOSNativeAppTile extends StatelessWidget {
         Uri.parse(AppConstants.macOSReleasesUrl),
         mode: LaunchMode.externalApplication,
       ),
+    );
+  }
+}
+
+/// A General-section row that lets the user adjust the global text scale
+/// with a slider. Mirrors the visual layout of the surrounding ListTiles
+/// so it sits naturally inside the General card.
+class _TextSizeTile extends StatelessWidget {
+  const _TextSizeTile({required this.value, required this.onChanged});
+
+  final double value;
+  final ValueChanged<double> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final l = AppLocalizations.of(context);
+    final percent = (value * 100).round();
+    final percentLabel = '$percent%';
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
+          child: Row(
+            children: [
+              Icon(Icons.format_size, color: cs.primary),
+              const SizedBox(width: 32),
+              Expanded(
+                child: Text(
+                  l.textSize,
+                  style: Theme.of(context).textTheme.bodyLarge,
+                ),
+              ),
+              Text(
+                percentLabel,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: cs.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(56, 0, 16, 8),
+          child: Slider(
+            min: textScaleMin,
+            max: textScaleMax,
+            divisions: 10,
+            label: percentLabel,
+            value: value,
+            onChanged: onChanged,
+          ),
+        ),
+      ],
     );
   }
 }

--- a/apps/mobile/lib/features/settings/state/settings_cubit.dart
+++ b/apps/mobile/lib/features/settings/state/settings_cubit.dart
@@ -46,6 +46,7 @@ class SettingsCubit extends Cubit<SettingsState> {
   static const _keyTerminalApp = 'settings_terminal_app';
   static const _keyNewSessionTabs = 'settings_new_session_tabs';
   static const _keyUsageDisplayMode = 'settings_usage_display_mode';
+  static const _keyTextScale = 'settings_text_scale';
   // Legacy key for migration
   static const _keyIndentSize = 'settings_indent_size';
   // Legacy key for migration
@@ -165,6 +166,8 @@ class SettingsCubit extends Cubit<SettingsState> {
 
     final shorebirdTrack = prefs.getString(keyShorebirdTrack) ?? 'stable';
     final indentSize = prefs.getInt(_keyIndentSize) ?? 2;
+    final textScale = (prefs.getDouble(_keyTextScale) ?? textScaleDefault)
+        .clamp(textScaleMin, textScaleMax);
     final hideVoiceInput = prefs.getBool(_keyHideVoiceInput) ?? false;
     final selectedAppIcon = appIconVariantFromId(
       prefs.getString(_keySelectedAppIcon),
@@ -205,6 +208,7 @@ class SettingsCubit extends Cubit<SettingsState> {
       fcmPrivacyMachines: fcmPrivacyMachines,
       shorebirdTrack: shorebirdTrack,
       indentSize: indentSize.clamp(1, 4),
+      textScale: textScale,
       hideVoiceInput: hideVoiceInput,
       selectedAppIcon: selectedAppIcon,
       terminalApp: terminalApp,
@@ -282,6 +286,14 @@ class SettingsCubit extends Cubit<SettingsState> {
     final clamped = size.clamp(1, 4);
     _prefs.setInt(_keyIndentSize, clamped);
     emit(state.copyWith(indentSize: clamped));
+  }
+
+  /// Updates the global text scale used to render text throughout the app.
+  /// Values outside the supported range are clamped before being persisted.
+  void setTextScale(double scale) {
+    final clamped = scale.clamp(textScaleMin, textScaleMax);
+    _prefs.setDouble(_keyTextScale, clamped);
+    emit(state.copyWith(textScale: clamped));
   }
 
   void setShorebirdTrack(String track) {

--- a/apps/mobile/lib/features/settings/state/settings_state.dart
+++ b/apps/mobile/lib/features/settings/state/settings_state.dart
@@ -20,6 +20,15 @@ enum FcmStatusKey {
 
 enum UsageDisplayMode { remaining, used }
 
+/// Minimum allowed value for [SettingsState.textScale].
+const double textScaleMin = 0.5;
+
+/// Maximum allowed value for [SettingsState.textScale].
+const double textScaleMax = 1.5;
+
+/// Default text scale (1.0 = follow the system default with no extra scaling).
+const double textScaleDefault = 1.0;
+
 /// Application-wide user settings.
 @freezed
 abstract class SettingsState with _$SettingsState {
@@ -60,6 +69,11 @@ abstract class SettingsState with _$SettingsState {
 
     /// Indent size for list formatting (1-4 spaces).
     @Default(2) int indentSize,
+
+    /// Global text scale factor applied to the whole app.
+    /// Range: [textScaleMin] - [textScaleMax]. 1.0 means no extra scaling
+    /// on top of the system default font size.
+    @Default(textScaleDefault) double textScale,
 
     /// Whether to hide the voice input button in the chat input bar.
     @Default(false) bool hideVoiceInput,

--- a/apps/mobile/lib/l10n/app_en.arb
+++ b/apps/mobile/lib/l10n/app_en.arb
@@ -462,6 +462,7 @@
   "themeSystem": "System",
   "themeLight": "Light",
   "themeDark": "Dark",
+  "textSize": "Text size",
   "appIconTitle": "App Icon",
   "appIconMonthlySupporterPerk": "This is a Monthly Supporter perk.",
   "appIconSupporterDialogTitle": "Monthly Supporter Perk",

--- a/apps/mobile/lib/l10n/app_ja.arb
+++ b/apps/mobile/lib/l10n/app_ja.arb
@@ -520,6 +520,7 @@
   "themeSystem": "システム",
   "themeLight": "ライト",
   "themeDark": "ダーク",
+  "textSize": "文字サイズ",
   "appIconTitle": "アプリアイコン",
   "appIconMonthlySupporterPerk": "月額サポーター特典です。",
   "appIconSupporterDialogTitle": "月額サポーター特典",

--- a/apps/mobile/lib/l10n/app_zh.arb
+++ b/apps/mobile/lib/l10n/app_zh.arb
@@ -538,6 +538,7 @@
   "themeSystem": "跟随系统",
   "themeLight": "浅色",
   "themeDark": "深色",
+  "textSize": "文字大小",
   "appIconTitle": "应用图标",
   "appIconMonthlySupporterPerk": "这是月度 Supporter 特典。",
   "appIconSupporterDialogTitle": "月度 Supporter 特典",

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -436,6 +436,16 @@ class _CcpocketAppState extends State<CcpocketApp> {
             navigatorObservers: () => [SessionRouteObserver()],
           ),
           debugShowCheckedModeBanner: false,
+          builder: (context, child) {
+            if (child == null) return const SizedBox.shrink();
+            final mq = MediaQuery.of(context);
+            return MediaQuery(
+              data: mq.copyWith(
+                textScaler: TextScaler.linear(settings.textScale),
+              ),
+              child: child,
+            );
+          },
         );
       },
     );


### PR DESCRIPTION
## Summary

Closes #61.

設定画面に文字サイズを調整する Slider を追加します。アプリ全体のテキストが 0.5x から 1.5x の範囲で拡大・縮小でき、特に「OS の最小フォント設定でもまだ大きい」と感じるケースでチャット履歴や diff の情報密度を上げられます。

issue #61 で機能要望として相談したうえで、CONTRIBUTING.md の「望ましい PR の形」(1PR 1テーマ / 単一 commit / `main` ベース) に沿って実装しました。

## Changes

- `SettingsState`
  - `textScale` field (`double`, default `1.0`)
  - top-level constants `textScaleMin = 0.5`, `textScaleMax = 1.5`, `textScaleDefault = 1.0`
- `SettingsCubit`
  - SharedPreferences key `settings_text_scale` を追加
  - `_load` で範囲外を `clamp` で吸収
  - `setTextScale(double)` setter
- `main.dart`
  - `MaterialApp.router` に `builder` を追加し、`MediaQuery` を `TextScaler.linear(settings.textScale)` で wrap
- `settings_screen.dart`
  - General セクション (Theme の直下) に `_TextSizeTile` を追加
  - Slider + 現在値の % ラベル、`divisions: 10` で 0.1 刻み (0.5x / 0.6x / ... / 1.5x)
- l10n
  - `app_en.arb` / `app_ja.arb` / `app_zh.arb` に `textSize` (Text size / 文字サイズ / 文字大小)

## レビュアー向けの注意点

ローカル環境に flutter SDK が無い状態で実装したため、以下が **未実施** です。マージ前に走らせていただけると助かります。

```bash
cd apps/mobile
flutter pub get
dart run build_runner build --delete-conflicting-outputs
```

これで `settings_state.freezed.dart` の textScale 関連と `app_localizations*.dart` の textSize 関連が再生成されます。あわせて `dart analyze apps/mobile` も未実行なので、レビュー時に確認をお願いします。

## 設計判断のメモ

- OS の Dynamic Type と合成するか、アプリ独自の倍率で完全置き換えにするかで迷いました。
  今回はシンプルさを優先して `TextScaler.linear(settings.textScale)` で完全置き換えにしています。OS のフォントサイズ設定は無視されます。
- 「OS 設定 × アプリ設定」の合成を希望される場合は、`TextScaler` を継承したカスタム class で `scale(fontSize) => base.scale(fontSize) * factor` する形に follow-up できます。指示があれば対応します。
- CONTRIBUTING.md にあるとおり、メンテナ側で再実装される場合は問題ありません。コードベースの慣習と異なる箇所があればお知らせください。

## Test plan

- [ ] `flutter pub get` + `dart run build_runner build --delete-conflicting-outputs` を実行して生成物を更新
- [ ] アプリを起動 → 設定 → 「文字サイズ」 Slider を動かし、リアルタイムで文字サイズが変わることを確認
- [ ] アプリ再起動後も設定値が保持されることを確認
- [ ] 0.5x / 1.0x / 1.5x の境界でレイアウトが大きく崩れないことを確認 (チャット画面、diff 画面、設定画面)
- [ ] `dart analyze apps/mobile` がクリーンに通ることを確認