### PR TITLE
fix(chat): scroll long option lists in AskUserQuestion bubble

### DIFF
--- a/apps/mobile/lib/widgets/bubbles/ask_user_question_widget.dart
+++ b/apps/mobile/lib/widgets/bubbles/ask_user_question_widget.dart
@@ -447,25 +447,35 @@ class _AskUserQuestionWidgetState extends State<AskUserQuestionWidget> {
                 ),
               ),
             ] else ...[
-              _AskQuestionLayout(
-                question: questions.first as Map<String, dynamic>,
-                questionIndex: 0,
-                isMultiQuestion: false,
-                scrollable: widget.scrollable,
-                allowsCustomInput: _singleQuestionAllowsCustomInput,
-                singleAnswers: _singleAnswers,
-                multiAnswers: _multiAnswers,
-                customInputs: _customInputs,
-                getOrCreateController: _getOrCreateController,
-                onAnswerSingle: _onAnswerSingle,
-                onToggleMultiSelectLabel: _toggleMultiSelectLabel,
-                onConfirmMultiSelect: _confirmMultiSelect,
-                onSubmitCustomText: _submitCustomText,
-                onCustomTextChanged: _onCustomTextChanged,
-                onShowCustomInput: _showCustomInput,
-                alwaysShowTextInput:
-                    !_singleQuestionIsMultiSelect &&
-                    _singleQuestionAllowsCustomInput,
+              // Mirror the multi-question layout so that long option lists
+              // remain scrollable inside the bubble even when the surrounding
+              // container is mounted as a non-scrolling overlay.
+              ConstrainedBox(
+                constraints: BoxConstraints(
+                  maxHeight: (availableHeight - keyboardHeight) * 0.42,
+                ),
+                child: SingleChildScrollView(
+                  child: _AskQuestionLayout(
+                    question: questions.first as Map<String, dynamic>,
+                    questionIndex: 0,
+                    isMultiQuestion: false,
+                    scrollable: false,
+                    allowsCustomInput: _singleQuestionAllowsCustomInput,
+                    singleAnswers: _singleAnswers,
+                    multiAnswers: _multiAnswers,
+                    customInputs: _customInputs,
+                    getOrCreateController: _getOrCreateController,
+                    onAnswerSingle: _onAnswerSingle,
+                    onToggleMultiSelectLabel: _toggleMultiSelectLabel,
+                    onConfirmMultiSelect: _confirmMultiSelect,
+                    onSubmitCustomText: _submitCustomText,
+                    onCustomTextChanged: _onCustomTextChanged,
+                    onShowCustomInput: _showCustomInput,
+                    alwaysShowTextInput:
+                        !_singleQuestionIsMultiSelect &&
+                        _singleQuestionAllowsCustomInput,
+                  ),
+                ),
               ),
             ],
             if (_singleQuestionIsMultiSelect) ...[


### PR DESCRIPTION
## Summary

Closes #63.

単一質問の AskUserQuestion で選択肢が多いと、 バブルが画面に収まりきらず後ろの方の選択肢が画面外に出て選べなくなる問題を修正します。

## Problem

`apps/mobile/lib/widgets/bubbles/ask_user_question_widget.dart` の build メソッドで、複数質問パスと単一質問パスで作りが非対称でした。

- 複数質問パス (line 410 付近): `ConstrainedBox(maxHeight: (availableHeight - keyboardHeight) * 0.42)` で高さ制限し、 `ExpandablePageView` 経由で `_AskQuestionLayout(scrollable: ...)` を表示
- 単一質問パス (line 449 付近): `ConstrainedBox` なし、 `_AskQuestionLayout` を直接 Column の子として配置。 さらに呼び出し側 (`claude_session_screen.dart` / `codex_session_screen.dart`) が `scrollable: false` を渡しているため `_AskQuestionLayout` 内部の `SingleChildScrollView` も無効化

結果、選択肢が多いとバブル自身が画面いっぱいに伸びて切れ、外側 `BottomOverlayLayout` の `ConstrainedBox(maxHeight: visibleHeight)` で「画面いっぱい」までしか制限がかからず、 ユーザーから見て「下の選択肢が見えない / スクロールできない」状態になります。

## Fix

単一質問パスにも複数質問パスと同等の `ConstrainedBox + SingleChildScrollView` wrap を追加して、選択肢リストが長い場合もバブル内をスクロールできるようにします。

```dart
} else ...[
  ConstrainedBox(
    constraints: BoxConstraints(
      maxHeight: (availableHeight - keyboardHeight) * 0.42,
    ),
    child: SingleChildScrollView(
      child: _AskQuestionLayout(
        // ...
        scrollable: false,
        // ...
      ),
    ),
  ),
],
```

- 高さの上限は複数質問パスと揃えて `* 0.42`
- 内部 `_AskQuestionLayout` は `scrollable: false` のまま (外側で wrap しているため二重スクロールを避ける)
- 既存の呼び出し側 (`scrollable: false`) は変更なし

差分は `+29 / -19` の単一ファイル修正です。

## レビュアー向けの注意点

ローカル環境に flutter SDK が無い状態で実装したため、以下が **未実施** です。

- `flutter pub get`
- `dart analyze apps/mobile`
- 実機 / シミュレータでの目視確認

提案の修正は構文的には自然ですが、 実機での挙動確認はお願いしたく、 マージ前に以下のシナリオで確認していただけると助かります。

## Test plan

- [ ] `dart analyze apps/mobile` がクリーンに通ることを確認
- [ ] iPhone (狭い画面の機種ほど顕著) で AskUserQuestion を表示し、 単一質問で選択肢を 6 個以上 + 各 description 長めにしたとき、 バブル内を縦スクロールしてすべての選択肢にアクセスできることを確認
- [ ] 複数質問 (PageView) パスのレイアウトに副作用がないことを確認 (今回触っていないが念のため)
- [ ] 質問が短い (1-3 個の選択肢) ケースでバブルが必要以上に縦に伸びていないことを確認 (`maxHeight` で 0.42 制限なので問題ないはず)
- [ ] キーボード表示時に下端が見切れず、 余白も適切に保たれることを確認 (`(availableHeight - keyboardHeight) * 0.42` でキーボード分は引いている)