### PR TITLE
fix(bridge): optimize git branch loading

### DIFF
--- a/packages/bridge/src/git-operations.test.ts
+++ b/packages/bridge/src/git-operations.test.ts
@@ -35,6 +35,7 @@ function createTempRepo(): string {
   execFileSync("git", ["init"], { cwd: dir });
   execFileSync("git", ["config", "user.email", "test@test.com"], { cwd: dir });
   execFileSync("git", ["config", "user.name", "Test"], { cwd: dir });
+  execFileSync("git", ["config", "commit.gpgsign", "false"], { cwd: dir });
   writeFileSync(join(dir, "initial.txt"), "initial\n");
   execFileSync("git", ["add", "."], { cwd: dir });
   execFileSync("git", ["commit", "-m", "initial"], { cwd: dir });
@@ -134,8 +135,9 @@ describe("gitStatus", () => {
   it("includes pushable commits when remote status is requested", () => {
     const remote = createBareRemote();
     try {
+      const current = gitCmd(["rev-parse", "--abbrev-ref", "HEAD"], repo);
       gitCmd(["remote", "add", "origin", remote], repo);
-      gitCmd(["push", "-u", "origin", "master"], repo);
+      gitCmd(["push", "-u", "origin", current], repo);
       writeFileSync(join(repo, "ahead.txt"), "ahead\n");
       gitCmd(["add", "ahead.txt"], repo);
       gitCmd(["commit", "-m", "ahead"], repo);
@@ -146,7 +148,7 @@ describe("gitStatus", () => {
         commitsAhead: 1,
         commitsBehind: 0,
         hasUpstream: true,
-        branch: "master",
+        branch: current,
       });
     } finally {
       rmSync(remote, { recursive: true, force: true });
@@ -157,13 +159,15 @@ describe("gitStatus", () => {
     const remote = createBareRemote();
     const clone = join(tmpdir(), `git-ops-clone-${randomUUID().slice(0, 8)}`);
     try {
+      const current = gitCmd(["rev-parse", "--abbrev-ref", "HEAD"], repo);
       gitCmd(["remote", "add", "origin", remote], repo);
-      gitCmd(["push", "-u", "origin", "master"], repo);
-      execFileSync("git", ["clone", remote, clone]);
+      gitCmd(["push", "-u", "origin", current], repo);
+      execFileSync("git", ["clone", "--branch", current, remote, clone]);
       execFileSync("git", ["config", "user.email", "test@test.com"], {
         cwd: clone,
       });
       execFileSync("git", ["config", "user.name", "Test"], { cwd: clone });
+      execFileSync("git", ["config", "commit.gpgsign", "false"], { cwd: clone });
       writeFileSync(join(clone, "behind.txt"), "behind\n");
       gitCmd(["add", "behind.txt"], clone);
       gitCmd(["commit", "-m", "behind"], clone);
@@ -175,7 +179,7 @@ describe("gitStatus", () => {
         commitsAhead: 0,
         commitsBehind: 1,
         hasUpstream: true,
-        branch: "master",
+        branch: current,
       });
     } finally {
       rmSync(remote, { recursive: true, force: true });
@@ -667,6 +671,42 @@ describe("listBranches", () => {
     }
   });
 
+  it("includes diverged ahead and behind status for branches with upstream", () => {
+    const remote = createBareRemote();
+    const clone = join(tmpdir(), `git-ops-clone-${randomUUID().slice(0, 8)}`);
+    try {
+      execFileSync("git", ["remote", "add", "origin", remote], { cwd: repo });
+      execFileSync("git", ["checkout", "feat/login"], { cwd: repo });
+      execFileSync("git", ["push", "-u", "origin", "feat/login"], { cwd: repo });
+
+      writeFileSync(join(repo, "local.txt"), "local\n");
+      execFileSync("git", ["add", "local.txt"], { cwd: repo });
+      execFileSync("git", ["commit", "-m", "local commit"], { cwd: repo });
+
+      execFileSync("git", ["clone", remote, clone]);
+      execFileSync("git", ["config", "user.email", "test@test.com"], { cwd: clone });
+      execFileSync("git", ["config", "user.name", "Test"], { cwd: clone });
+      execFileSync("git", ["config", "commit.gpgsign", "false"], { cwd: clone });
+      execFileSync("git", ["checkout", "feat/login"], { cwd: clone });
+      writeFileSync(join(clone, "remote.txt"), "remote\n");
+      execFileSync("git", ["add", "remote.txt"], { cwd: clone });
+      execFileSync("git", ["commit", "-m", "remote commit"], { cwd: clone });
+      execFileSync("git", ["push", "origin", "feat/login"], { cwd: clone });
+
+      execFileSync("git", ["fetch", "origin"], { cwd: repo });
+
+      const result = listBranches(repo);
+      expect(result.remoteStatusByBranch["feat/login"]).toMatchObject({
+        ahead: 1,
+        behind: 1,
+        hasUpstream: true,
+      });
+    } finally {
+      rmSync(clone, { recursive: true, force: true });
+      rmSync(remote, { recursive: true, force: true });
+    }
+  });
+
   it("reports no upstream for branches without tracking", () => {
     const result = listBranches(repo);
     expect(result.remoteStatusByBranch["feat/login"]).toMatchObject({
@@ -674,6 +714,60 @@ describe("listBranches", () => {
       behind: 0,
       hasUpstream: false,
     });
+  });
+
+  it("does not run per-branch rev-list commands for stale upstream refs", () => {
+    execFileSync("git", ["remote", "add", "origin", repo], { cwd: repo });
+    execFileSync("git", ["config", "branch.feat/login.remote", "origin"], {
+      cwd: repo,
+    });
+    execFileSync(
+      "git",
+      ["config", "branch.feat/login.merge", "refs/heads/deleted-upstream"],
+      { cwd: repo },
+    );
+
+    const originalWrite = process.stderr.write;
+    let stderr = "";
+    process.stderr.write = function write(chunk, ...args) {
+      stderr += String(chunk);
+      return originalWrite.call(this, chunk, ...args);
+    } as typeof process.stderr.write;
+
+    try {
+      const result = listBranches(repo);
+      expect(result.remoteStatusByBranch["feat/login"]).toMatchObject({
+        ahead: 0,
+        behind: 0,
+        hasUpstream: true,
+      });
+    } finally {
+      process.stderr.write = originalWrite;
+    }
+
+    expect(stderr).not.toContain("fatal:");
+    expect(stderr).not.toContain("deleted-upstream");
+  });
+
+  it("includes branches checked out in linked worktrees", () => {
+    const worktree = join(
+      tmpdir(),
+      `git-ops-worktree-${randomUUID().slice(0, 8)}`,
+    );
+    try {
+      execFileSync("git", ["worktree", "add", worktree, "feat/login"], {
+        cwd: repo,
+      });
+
+      const result = listBranches(repo);
+      expect(result.checkedOutBranches).toContain(result.current);
+      expect(result.checkedOutBranches).toContain("feat/login");
+    } finally {
+      execFileSync("git", ["worktree", "remove", "--force", worktree], {
+        cwd: repo,
+      });
+      rmSync(worktree, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/bridge/src/git-operations.ts
+++ b/packages/bridge/src/git-operations.ts
@@ -257,8 +257,21 @@ export function listBranches(projectPath: string): BranchListResult {
   const cwd = resolveProject(projectPath);
   const current = git(["rev-parse", "--abbrev-ref", "HEAD"], cwd);
 
-  const output = git(["branch", "--list", "--format=%(refname:short)"], cwd);
-  const branches = output ? output.split("\n").filter(Boolean) : [];
+  const output = git([
+    "branch",
+    "--list",
+    "--format=%(refname:short)%09%(upstream:short)%09%(upstream:track)",
+  ], cwd);
+  const branchRows = output
+    ? output.split("\n").filter(Boolean).map((line) => {
+        const [branch, upstream = "", track = ""] = line.split("\t");
+        return {
+          branch,
+          remoteStatus: parseBranchRemoteStatus(upstream, track),
+        };
+      })
+    : [];
+  const branches = branchRows.map((row) => row.branch);
 
   // Collect branches checked out by worktrees (+ main repo)
   const checkedOutBranches: string[] = [];
@@ -280,44 +293,29 @@ export function listBranches(projectPath: string): BranchListResult {
   }
 
   const remoteStatusByBranch = Object.fromEntries(
-    branches.map((branch) => [branch, getBranchRemoteStatus(cwd, branch)]),
+    branchRows.map((row) => [row.branch, row.remoteStatus]),
   );
 
   return { current, branches, checkedOutBranches, remoteStatusByBranch };
 }
 
-function getBranchRemoteStatus(
-  cwd: string,
-  branch: string,
+function parseBranchRemoteStatus(
+  upstream: string,
+  track: string,
 ): BranchRemoteStatus {
-  const upstream = execFileSync(
-    "git",
-    ["for-each-ref", "--format=%(upstream:short)", `refs/heads/${branch}`],
-    { cwd, encoding: "utf-8" },
-  ).trim();
-
   if (!upstream) {
     return { ahead: 0, behind: 0, hasUpstream: false };
   }
 
-  let ahead = 0;
-  let behind = 0;
-
-  try {
-    ahead =
-      parseInt(git(["rev-list", "--count", `${upstream}..${branch}`], cwd), 10) || 0;
-  } catch {
-    ahead = 0;
-  }
-
-  try {
-    behind =
-      parseInt(git(["rev-list", "--count", `${branch}..${upstream}`], cwd), 10) || 0;
-  } catch {
-    behind = 0;
-  }
+  const ahead = parseTrackCount(track, /ahead (\d+)/);
+  const behind = parseTrackCount(track, /behind (\d+)/);
 
   return { ahead, behind, hasUpstream: true };
+}
+
+function parseTrackCount(track: string, pattern: RegExp): number {
+  const match = track.match(pattern);
+  return match ? parseInt(match[1], 10) || 0 : 0;
 }
 
 /** Create a new branch, optionally checking it out. */


### PR DESCRIPTION
## Summary

Optimizes Bridge Server Git branch loading by reading upstream tracking information with a single `git branch --format` call instead of running per-branch upstream / rev-list commands.

## Why This Is A PR

- Why PR instead of Issue / Prompt Request first: This follows the scoped Prompt Request and keeps the change limited to the Bridge Server `listBranches()` path.
- Related Issue / Prompt Request: Closes #71
- Base PR (if stacked on another open PR): N/A

## Changes

- Use `git branch --list --format` to collect branch name, upstream, and tracking summary in one command.
- Parse ahead / behind counts from Git's upstream tracking summary.
- Preserve checked-out branch detection through `git worktree list --porcelain`.
- Add regression coverage for diverged branches, stale upstream refs, linked worktree checked-out branch detection, and default-branch-agnostic remote status tests.

## Local Measurements

I tested this against a private repository with many local branches and worktrees. I am omitting the repository name and local paths, but the measured shape was:

```text
local branches: 124
branches with upstream configured: 80
branches without upstream configured: 44
checked-out branches/worktrees reported by worktree list: 18
stale upstream refs: 52
```

Before this change, the branch remote-status path effectively ran hundreds of Git commands per call:

```text
rev-parse current branch: 1
branch --list: 1
worktree list --porcelain: 1
for-each-ref per branch: 124
rev-list ahead/behind per upstream branch: 160
estimated total: 287
```

Local before measurements:

```text
old listBranches-equivalent loop: about 3.00s per call
old path repeated 4 times:        11.88s
```

The single-command approach measured before patching was much faster:

```text
git branch --list --format="%(refname:short)|%(upstream:short)|%(upstream:track)"
private repository worktree: 0.02s for 124 rows
```

After patching `listBranches()`, repeated calls inside the same Node process measured:

```text
run 1: 586.2ms
run 2: 226.2ms
run 3: 195.1ms
run 4: 211.4ms
run 5: 178.3ms
```

Comparison:

```text
old listBranches-equivalent loop: about 3.00s per call
new listBranches in-process:      about 178ms to 226ms per call after warmup
4 old calls:                      11.88s
4 new calls at ~200ms each:       about 0.8s
```

## Scope Check

- Single primary goal of this PR: Improve Git branch loading performance in the Bridge Server.
- What is intentionally out of scope: `git_fetch` sync/async behavior, Git view initialization order, long session history truncation, and mobile UI/state changes.
- Can this be split into smaller PRs? No, the implementation and regression tests are one small Bridge-only change.

## Test plan

- [x] Bridge Server targeted tests pass (`npm test --workspace=packages/bridge -- src/git-operations.test.ts`)
- [ ] Flutter tests pass (`cd apps/mobile && flutter test`)
- [ ] Manual testing done

Targeted checks run locally:

```text
npm test --workspace=packages/bridge -- src/git-operations.test.ts
npm run build --workspace=packages/bridge
```

Results:

```text
src/git-operations.test.ts: 45 passed
build: passed
```

## Platform validation

- Target platform: macOS / Bridge Server
- Platform version: macOS 26.3.1 (25D2128)
- Node.js: v22.16.0
- npm: 10.9.2
- Git: Apple Git 2.50.1 (Apple Git-155)
- What I validated on that platform: Targeted Bridge Server Git operations tests, TypeScript build, and local before/after branch-loading measurements.
- Logs / screenshots / notes: The before/after repository metrics above are from a private repository, so I intentionally omitted repository names and local paths.

## Notes

This intentionally does not change fetch ordering or async behavior. It only reduces branch-loading subprocess work inside `listBranches()`.
