### PR TITLE
fix(mobile): store jump host credentials separately from target credentials

### DIFF
--- a/apps/mobile/lib/features/session_list/session_list_screen.dart
+++ b/apps/mobile/lib/features/session_list/session_list_screen.dart
@@ -1922,7 +1922,14 @@ class _SessionListScreenState extends State<SessionListScreen>
           name: server.name,
           useSsl: useSsl,
         ),
-        onSave: ({required machine, apiKey, sshPassword, sshPrivateKey}) async {
+        onSave: ({
+          required machine,
+          apiKey,
+          sshPassword,
+          sshPrivateKey,
+          sshJumpPassword,
+          sshJumpPrivateKey,
+        }) async {
           final newMachine = cubit.createNewMachine(
             name: machine.name,
             host: machine.host,
@@ -1939,11 +1946,14 @@ class _SessionListScreenState extends State<SessionListScreen>
               sshJumpHost: machine.sshJumpHost,
               sshJumpPort: machine.sshJumpPort,
               sshJumpUsername: machine.sshJumpUsername,
+              sshJumpAuthType: machine.sshJumpAuthType,
               isFavorite: true,
             ),
             apiKey: apiKey,
             sshPassword: sshPassword,
             sshPrivateKey: sshPrivateKey,
+            sshJumpPassword: sshJumpPassword,
+            sshJumpPrivateKey: sshJumpPrivateKey,
           );
         },
         onSaveAndConnect: (machine, apiKey) {
@@ -2106,6 +2116,7 @@ class _SessionListScreenState extends State<SessionListScreen>
     final cubit = context.read<MachineManagerCubit>();
     final apiKey = await cubit.getApiKey(m.machine.id);
     final sshPassword = await cubit.getSshPassword(m.machine.id);
+    final sshJumpPassword = await cubit.getSshJumpPassword(m.machine.id);
 
     if (!mounted) return;
 
@@ -2118,12 +2129,22 @@ class _SessionListScreenState extends State<SessionListScreen>
         machine: m.machine,
         existingApiKey: apiKey,
         existingSshPassword: sshPassword,
-        onSave: ({required machine, apiKey, sshPassword, sshPrivateKey}) async {
+        existingSshJumpPassword: sshJumpPassword,
+        onSave: ({
+          required machine,
+          apiKey,
+          sshPassword,
+          sshPrivateKey,
+          sshJumpPassword,
+          sshJumpPrivateKey,
+        }) async {
           await cubit.updateMachine(
             machine,
             apiKey: apiKey,
             sshPassword: sshPassword,
             sshPrivateKey: sshPrivateKey,
+            sshJumpPassword: sshJumpPassword,
+            sshJumpPrivateKey: sshJumpPrivateKey,
           );
         },
         onTestConnection: cubit.testConnectionWithCredentials,
@@ -2168,7 +2189,14 @@ class _SessionListScreenState extends State<SessionListScreen>
       constraints: macOSModalBottomSheetConstraints(context),
       backgroundColor: Colors.transparent,
       builder: (ctx) => MachineEditSheet(
-        onSave: ({required machine, apiKey, sshPassword, sshPrivateKey}) async {
+        onSave: ({
+          required machine,
+          apiKey,
+          sshPassword,
+          sshPrivateKey,
+          sshJumpPassword,
+          sshJumpPrivateKey,
+        }) async {
           final newMachine = cubit.createNewMachine(
             name: machine.name,
             host: machine.host,
@@ -2185,11 +2213,14 @@ class _SessionListScreenState extends State<SessionListScreen>
               sshJumpHost: machine.sshJumpHost,
               sshJumpPort: machine.sshJumpPort,
               sshJumpUsername: machine.sshJumpUsername,
-              isFavorite: true, // New manually added machines are favorites
+              sshJumpAuthType: machine.sshJumpAuthType,
+              isFavorite: true,
             ),
             apiKey: apiKey,
             sshPassword: sshPassword,
             sshPrivateKey: sshPrivateKey,
+            sshJumpPassword: sshJumpPassword,
+            sshJumpPrivateKey: sshJumpPrivateKey,
           );
         },
         onSaveAndConnect: (machine, apiKey) {

--- a/apps/mobile/lib/features/session_list/widgets/machine_edit_sheet.dart
+++ b/apps/mobile/lib/features/session_list/widgets/machine_edit_sheet.dart
@@ -15,12 +15,17 @@ class MachineEditSheet extends StatefulWidget {
   /// Existing SSH password (for edit mode)
   final String? existingSshPassword;
 
+  /// Existing SSH jump host password (for edit mode)
+  final String? existingSshJumpPassword;
+
   /// Callback when save is pressed
   final Future<void> Function({
     required Machine machine,
     String? apiKey,
     String? sshPassword,
     String? sshPrivateKey,
+    String? sshJumpPassword,
+    String? sshJumpPrivateKey,
   })
   onSave;
 
@@ -37,6 +42,9 @@ class MachineEditSheet extends StatefulWidget {
     String? jumpHost,
     required int jumpPort,
     String? jumpUsername,
+    SshAuthType jumpAuthType,
+    String? jumpPassword,
+    String? jumpPrivateKey,
     String? password,
     String? privateKey,
   })
@@ -47,6 +55,7 @@ class MachineEditSheet extends StatefulWidget {
     this.machine,
     this.existingApiKey,
     this.existingSshPassword,
+    this.existingSshJumpPassword,
     required this.onSave,
     this.onSaveAndConnect,
     required this.onTestConnection,
@@ -66,11 +75,14 @@ class _MachineEditSheetState extends State<MachineEditSheet> {
   late final TextEditingController _sshJumpHostController;
   late final TextEditingController _sshJumpPortController;
   late final TextEditingController _sshJumpUsernameController;
+  late final TextEditingController _sshJumpPasswordController;
+  late final TextEditingController _sshJumpPrivateKeyController;
   late final TextEditingController _sshPasswordController;
   late final TextEditingController _sshPrivateKeyController;
   bool _useSsl = false;
   bool _sshEnabled = false;
   SshAuthType _sshAuthType = SshAuthType.password;
+  SshAuthType _sshJumpAuthType = SshAuthType.password;
   bool _isSaving = false;
   bool _isTesting = false;
   String? _testResult;
@@ -101,6 +113,10 @@ class _MachineEditSheetState extends State<MachineEditSheet> {
     _sshJumpUsernameController = TextEditingController(
       text: m?.sshJumpUsername ?? '',
     );
+    _sshJumpPasswordController = TextEditingController(
+      text: widget.existingSshJumpPassword ?? '',
+    );
+    _sshJumpPrivateKeyController = TextEditingController();
     _sshPasswordController = TextEditingController(
       text: widget.existingSshPassword ?? '',
     );
@@ -110,6 +126,7 @@ class _MachineEditSheetState extends State<MachineEditSheet> {
       _useSsl = m.useSsl;
       _sshEnabled = m.sshEnabled;
       _sshAuthType = m.sshAuthType;
+      _sshJumpAuthType = m.sshJumpAuthType;
     }
   }
 
@@ -124,6 +141,8 @@ class _MachineEditSheetState extends State<MachineEditSheet> {
     _sshJumpHostController.dispose();
     _sshJumpPortController.dispose();
     _sshJumpUsernameController.dispose();
+    _sshJumpPasswordController.dispose();
+    _sshJumpPrivateKeyController.dispose();
     _sshPasswordController.dispose();
     _sshPrivateKeyController.dispose();
     super.dispose();
@@ -170,6 +189,13 @@ class _MachineEditSheetState extends State<MachineEditSheet> {
         jumpPort: int.tryParse(_sshJumpPortController.text) ?? 22,
         jumpUsername: _sshJumpUsernameController.text.trim().isNotEmpty
             ? _sshJumpUsernameController.text.trim()
+            : null,
+        jumpAuthType: _sshJumpAuthType,
+        jumpPassword: _sshJumpAuthType == SshAuthType.password
+            ? _sshJumpPasswordController.text
+            : null,
+        jumpPrivateKey: _sshJumpAuthType == SshAuthType.privateKey
+            ? _sshJumpPrivateKeyController.text
             : null,
         password: _sshAuthType == SshAuthType.password
             ? _sshPasswordController.text
@@ -220,11 +246,13 @@ class _MachineEditSheetState extends State<MachineEditSheet> {
             _sshEnabled && _sshJumpUsernameController.text.trim().isNotEmpty
             ? _sshJumpUsernameController.text.trim()
             : null,
+        sshJumpAuthType: _sshJumpAuthType,
       );
 
       final apiKey = _apiKeyController.text.isNotEmpty
           ? _apiKeyController.text
           : null;
+      final hasJump = machine.sshJumpHost != null;
 
       await widget.onSave(
         machine: machine,
@@ -234,6 +262,14 @@ class _MachineEditSheetState extends State<MachineEditSheet> {
             : null,
         sshPrivateKey: _sshEnabled && _sshAuthType == SshAuthType.privateKey
             ? _sshPrivateKeyController.text
+            : null,
+        sshJumpPassword:
+            hasJump && _sshJumpAuthType == SshAuthType.password
+            ? _sshJumpPasswordController.text
+            : null,
+        sshJumpPrivateKey:
+            hasJump && _sshJumpAuthType == SshAuthType.privateKey
+            ? _sshJumpPrivateKeyController.text
             : null,
       );
 
@@ -513,7 +549,55 @@ class _MachineEditSheetState extends State<MachineEditSheet> {
                       ),
                       const SizedBox(height: 12),
 
-                      // Auth type selector
+                      // Jump host auth type selector
+                      SegmentedButton<SshAuthType>(
+                        key: const ValueKey('ssh_jump_auth_type_selector'),
+                        segments: const [
+                          ButtonSegment(
+                            value: SshAuthType.password,
+                            label: Text('Password'),
+                            icon: Icon(Icons.password),
+                          ),
+                          ButtonSegment(
+                            value: SshAuthType.privateKey,
+                            label: Text('Private Key'),
+                            icon: Icon(Icons.vpn_key),
+                          ),
+                        ],
+                        selected: {_sshJumpAuthType},
+                        onSelectionChanged: (set) {
+                          setState(() => _sshJumpAuthType = set.first);
+                        },
+                      ),
+                      const SizedBox(height: 12),
+
+                      if (_sshJumpAuthType == SshAuthType.password)
+                        TextField(
+                          key: const ValueKey('ssh_jump_password_field'),
+                          controller: _sshJumpPasswordController,
+                          obscureText: true,
+                          decoration: const InputDecoration(
+                            labelText: 'Jump Password',
+                            prefixIcon: Icon(Icons.lock),
+                            border: OutlineInputBorder(),
+                          ),
+                        )
+                      else
+                        TextField(
+                          key: const ValueKey('ssh_jump_private_key_field'),
+                          controller: _sshJumpPrivateKeyController,
+                          maxLines: 4,
+                          decoration: const InputDecoration(
+                            labelText: 'Jump Private Key (PEM)',
+                            hintText: '-----BEGIN ... PRIVATE KEY-----',
+                            prefixIcon: Icon(Icons.vpn_key),
+                            border: OutlineInputBorder(),
+                            alignLabelWithHint: true,
+                          ),
+                        ),
+                      const SizedBox(height: 12),
+
+                      // Target auth type selector
                       SegmentedButton<SshAuthType>(
                         segments: const [
                           ButtonSegment(

--- a/apps/mobile/lib/models/machine.dart
+++ b/apps/mobile/lib/models/machine.dart
@@ -128,8 +128,14 @@ abstract class Machine with _$Machine {
     /// Optional SSH jump username. Defaults to [sshUsername] when omitted.
     String? sshJumpUsername,
 
+    /// SSH authentication type for the jump host
+    @Default(SshAuthType.password) SshAuthType sshJumpAuthType,
+
     /// Whether SSH credentials are saved (password or private key in secure storage)
     @Default(false) bool hasCredentials,
+
+    /// Whether jump host credentials are saved in secure storage
+    @Default(false) bool hasJumpCredentials,
   }) = _Machine;
 
   factory Machine.fromJson(Map<String, dynamic> json) =>

--- a/apps/mobile/lib/models/machine.freezed.dart
+++ b/apps/mobile/lib/models/machine.freezed.dart
@@ -309,8 +309,10 @@ mixin _$Machine {
  SshAuthType get sshAuthType;/// Optional SSH jump host used to reach the target SSH server
  String? get sshJumpHost;/// SSH jump host port
  int get sshJumpPort;/// Optional SSH jump username. Defaults to [sshUsername] when omitted.
- String? get sshJumpUsername;/// Whether SSH credentials are saved (password or private key in secure storage)
- bool get hasCredentials;
+ String? get sshJumpUsername;/// SSH authentication type for the jump host
+ SshAuthType get sshJumpAuthType;/// Whether SSH credentials are saved (password or private key in secure storage)
+ bool get hasCredentials;/// Whether jump host credentials are saved in secure storage
+ bool get hasJumpCredentials;
 /// Create a copy of Machine
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -323,16 +325,16 @@ $MachineCopyWith<Machine> get copyWith => _$MachineCopyWithImpl<Machine>(this as
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is Machine&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.host, host) || other.host == host)&&(identical(other.port, port) || other.port == port)&&(identical(other.useSsl, useSsl) || other.useSsl == useSsl)&&(identical(other.hasApiKey, hasApiKey) || other.hasApiKey == hasApiKey)&&(identical(other.lastConnected, lastConnected) || other.lastConnected == lastConnected)&&(identical(other.isFavorite, isFavorite) || other.isFavorite == isFavorite)&&(identical(other.sshEnabled, sshEnabled) || other.sshEnabled == sshEnabled)&&(identical(other.sshUsername, sshUsername) || other.sshUsername == sshUsername)&&(identical(other.sshPort, sshPort) || other.sshPort == sshPort)&&(identical(other.sshAuthType, sshAuthType) || other.sshAuthType == sshAuthType)&&(identical(other.sshJumpHost, sshJumpHost) || other.sshJumpHost == sshJumpHost)&&(identical(other.sshJumpPort, sshJumpPort) || other.sshJumpPort == sshJumpPort)&&(identical(other.sshJumpUsername, sshJumpUsername) || other.sshJumpUsername == sshJumpUsername)&&(identical(other.hasCredentials, hasCredentials) || other.hasCredentials == hasCredentials));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Machine&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.host, host) || other.host == host)&&(identical(other.port, port) || other.port == port)&&(identical(other.useSsl, useSsl) || other.useSsl == useSsl)&&(identical(other.hasApiKey, hasApiKey) || other.hasApiKey == hasApiKey)&&(identical(other.lastConnected, lastConnected) || other.lastConnected == lastConnected)&&(identical(other.isFavorite, isFavorite) || other.isFavorite == isFavorite)&&(identical(other.sshEnabled, sshEnabled) || other.sshEnabled == sshEnabled)&&(identical(other.sshUsername, sshUsername) || other.sshUsername == sshUsername)&&(identical(other.sshPort, sshPort) || other.sshPort == sshPort)&&(identical(other.sshAuthType, sshAuthType) || other.sshAuthType == sshAuthType)&&(identical(other.sshJumpHost, sshJumpHost) || other.sshJumpHost == sshJumpHost)&&(identical(other.sshJumpPort, sshJumpPort) || other.sshJumpPort == sshJumpPort)&&(identical(other.sshJumpUsername, sshJumpUsername) || other.sshJumpUsername == sshJumpUsername)&&(identical(other.sshJumpAuthType, sshJumpAuthType) || other.sshJumpAuthType == sshJumpAuthType)&&(identical(other.hasCredentials, hasCredentials) || other.hasCredentials == hasCredentials)&&(identical(other.hasJumpCredentials, hasJumpCredentials) || other.hasJumpCredentials == hasJumpCredentials));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,name,host,port,useSsl,hasApiKey,lastConnected,isFavorite,sshEnabled,sshUsername,sshPort,sshAuthType,sshJumpHost,sshJumpPort,sshJumpUsername,hasCredentials);
+int get hashCode => Object.hash(runtimeType,id,name,host,port,useSsl,hasApiKey,lastConnected,isFavorite,sshEnabled,sshUsername,sshPort,sshAuthType,sshJumpHost,sshJumpPort,sshJumpUsername,sshJumpAuthType,hasCredentials,hasJumpCredentials);
 
 @override
 String toString() {
-  return 'Machine(id: $id, name: $name, host: $host, port: $port, useSsl: $useSsl, hasApiKey: $hasApiKey, lastConnected: $lastConnected, isFavorite: $isFavorite, sshEnabled: $sshEnabled, sshUsername: $sshUsername, sshPort: $sshPort, sshAuthType: $sshAuthType, sshJumpHost: $sshJumpHost, sshJumpPort: $sshJumpPort, sshJumpUsername: $sshJumpUsername, hasCredentials: $hasCredentials)';
+  return 'Machine(id: $id, name: $name, host: $host, port: $port, useSsl: $useSsl, hasApiKey: $hasApiKey, lastConnected: $lastConnected, isFavorite: $isFavorite, sshEnabled: $sshEnabled, sshUsername: $sshUsername, sshPort: $sshPort, sshAuthType: $sshAuthType, sshJumpHost: $sshJumpHost, sshJumpPort: $sshJumpPort, sshJumpUsername: $sshJumpUsername, sshJumpAuthType: $sshJumpAuthType, hasCredentials: $hasCredentials, hasJumpCredentials: $hasJumpCredentials)';
 }
 
 
@@ -343,7 +345,7 @@ abstract mixin class $MachineCopyWith<$Res>  {
   factory $MachineCopyWith(Machine value, $Res Function(Machine) _then) = _$MachineCopyWithImpl;
 @useResult
 $Res call({
- String id, String? name, String host, int port, bool useSsl, bool hasApiKey, DateTime? lastConnected, bool isFavorite, bool sshEnabled, String? sshUsername, int sshPort, SshAuthType sshAuthType, String? sshJumpHost, int sshJumpPort, String? sshJumpUsername, bool hasCredentials
+ String id, String? name, String host, int port, bool useSsl, bool hasApiKey, DateTime? lastConnected, bool isFavorite, bool sshEnabled, String? sshUsername, int sshPort, SshAuthType sshAuthType, String? sshJumpHost, int sshJumpPort, String? sshJumpUsername, SshAuthType sshJumpAuthType, bool hasCredentials, bool hasJumpCredentials
 });
 
 
@@ -360,7 +362,7 @@ class _$MachineCopyWithImpl<$Res>
 
 /// Create a copy of Machine
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = freezed,Object? host = null,Object? port = null,Object? useSsl = null,Object? hasApiKey = null,Object? lastConnected = freezed,Object? isFavorite = null,Object? sshEnabled = null,Object? sshUsername = freezed,Object? sshPort = null,Object? sshAuthType = null,Object? sshJumpHost = freezed,Object? sshJumpPort = null,Object? sshJumpUsername = freezed,Object? hasCredentials = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = freezed,Object? host = null,Object? port = null,Object? useSsl = null,Object? hasApiKey = null,Object? lastConnected = freezed,Object? isFavorite = null,Object? sshEnabled = null,Object? sshUsername = freezed,Object? sshPort = null,Object? sshAuthType = null,Object? sshJumpHost = freezed,Object? sshJumpPort = null,Object? sshJumpUsername = freezed,Object? sshJumpAuthType = null,Object? hasCredentials = null,Object? hasJumpCredentials = null,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
@@ -377,7 +379,9 @@ as int,sshAuthType: null == sshAuthType ? _self.sshAuthType : sshAuthType // ign
 as SshAuthType,sshJumpHost: freezed == sshJumpHost ? _self.sshJumpHost : sshJumpHost // ignore: cast_nullable_to_non_nullable
 as String?,sshJumpPort: null == sshJumpPort ? _self.sshJumpPort : sshJumpPort // ignore: cast_nullable_to_non_nullable
 as int,sshJumpUsername: freezed == sshJumpUsername ? _self.sshJumpUsername : sshJumpUsername // ignore: cast_nullable_to_non_nullable
-as String?,hasCredentials: null == hasCredentials ? _self.hasCredentials : hasCredentials // ignore: cast_nullable_to_non_nullable
+as String?,sshJumpAuthType: null == sshJumpAuthType ? _self.sshJumpAuthType : sshJumpAuthType // ignore: cast_nullable_to_non_nullable
+as SshAuthType,hasCredentials: null == hasCredentials ? _self.hasCredentials : hasCredentials // ignore: cast_nullable_to_non_nullable
+as bool,hasJumpCredentials: null == hasJumpCredentials ? _self.hasJumpCredentials : hasJumpCredentials // ignore: cast_nullable_to_non_nullable
 as bool,
   ));
 }
@@ -463,10 +467,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String? name,  String host,  int port,  bool useSsl,  bool hasApiKey,  DateTime? lastConnected,  bool isFavorite,  bool sshEnabled,  String? sshUsername,  int sshPort,  SshAuthType sshAuthType,  String? sshJumpHost,  int sshJumpPort,  String? sshJumpUsername,  bool hasCredentials)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String? name,  String host,  int port,  bool useSsl,  bool hasApiKey,  DateTime? lastConnected,  bool isFavorite,  bool sshEnabled,  String? sshUsername,  int sshPort,  SshAuthType sshAuthType,  String? sshJumpHost,  int sshJumpPort,  String? sshJumpUsername,  SshAuthType sshJumpAuthType,  bool hasCredentials,  bool hasJumpCredentials)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _Machine() when $default != null:
-return $default(_that.id,_that.name,_that.host,_that.port,_that.useSsl,_that.hasApiKey,_that.lastConnected,_that.isFavorite,_that.sshEnabled,_that.sshUsername,_that.sshPort,_that.sshAuthType,_that.sshJumpHost,_that.sshJumpPort,_that.sshJumpUsername,_that.hasCredentials);case _:
+return $default(_that.id,_that.name,_that.host,_that.port,_that.useSsl,_that.hasApiKey,_that.lastConnected,_that.isFavorite,_that.sshEnabled,_that.sshUsername,_that.sshPort,_that.sshAuthType,_that.sshJumpHost,_that.sshJumpPort,_that.sshJumpUsername,_that.sshJumpAuthType,_that.hasCredentials,_that.hasJumpCredentials);case _:
   return orElse();
 
 }
@@ -484,10 +488,10 @@ return $default(_that.id,_that.name,_that.host,_that.port,_that.useSsl,_that.has
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String? name,  String host,  int port,  bool useSsl,  bool hasApiKey,  DateTime? lastConnected,  bool isFavorite,  bool sshEnabled,  String? sshUsername,  int sshPort,  SshAuthType sshAuthType,  String? sshJumpHost,  int sshJumpPort,  String? sshJumpUsername,  bool hasCredentials)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String? name,  String host,  int port,  bool useSsl,  bool hasApiKey,  DateTime? lastConnected,  bool isFavorite,  bool sshEnabled,  String? sshUsername,  int sshPort,  SshAuthType sshAuthType,  String? sshJumpHost,  int sshJumpPort,  String? sshJumpUsername,  SshAuthType sshJumpAuthType,  bool hasCredentials,  bool hasJumpCredentials)  $default,) {final _that = this;
 switch (_that) {
 case _Machine():
-return $default(_that.id,_that.name,_that.host,_that.port,_that.useSsl,_that.hasApiKey,_that.lastConnected,_that.isFavorite,_that.sshEnabled,_that.sshUsername,_that.sshPort,_that.sshAuthType,_that.sshJumpHost,_that.sshJumpPort,_that.sshJumpUsername,_that.hasCredentials);case _:
+return $default(_that.id,_that.name,_that.host,_that.port,_that.useSsl,_that.hasApiKey,_that.lastConnected,_that.isFavorite,_that.sshEnabled,_that.sshUsername,_that.sshPort,_that.sshAuthType,_that.sshJumpHost,_that.sshJumpPort,_that.sshJumpUsername,_that.sshJumpAuthType,_that.hasCredentials,_that.hasJumpCredentials);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -504,10 +508,10 @@ return $default(_that.id,_that.name,_that.host,_that.port,_that.useSsl,_that.has
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String? name,  String host,  int port,  bool useSsl,  bool hasApiKey,  DateTime? lastConnected,  bool isFavorite,  bool sshEnabled,  String? sshUsername,  int sshPort,  SshAuthType sshAuthType,  String? sshJumpHost,  int sshJumpPort,  String? sshJumpUsername,  bool hasCredentials)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String? name,  String host,  int port,  bool useSsl,  bool hasApiKey,  DateTime? lastConnected,  bool isFavorite,  bool sshEnabled,  String? sshUsername,  int sshPort,  SshAuthType sshAuthType,  String? sshJumpHost,  int sshJumpPort,  String? sshJumpUsername,  SshAuthType sshJumpAuthType,  bool hasCredentials,  bool hasJumpCredentials)?  $default,) {final _that = this;
 switch (_that) {
 case _Machine() when $default != null:
-return $default(_that.id,_that.name,_that.host,_that.port,_that.useSsl,_that.hasApiKey,_that.lastConnected,_that.isFavorite,_that.sshEnabled,_that.sshUsername,_that.sshPort,_that.sshAuthType,_that.sshJumpHost,_that.sshJumpPort,_that.sshJumpUsername,_that.hasCredentials);case _:
+return $default(_that.id,_that.name,_that.host,_that.port,_that.useSsl,_that.hasApiKey,_that.lastConnected,_that.isFavorite,_that.sshEnabled,_that.sshUsername,_that.sshPort,_that.sshAuthType,_that.sshJumpHost,_that.sshJumpPort,_that.sshJumpUsername,_that.sshJumpAuthType,_that.hasCredentials,_that.hasJumpCredentials);case _:
   return null;
 
 }
@@ -519,7 +523,7 @@ return $default(_that.id,_that.name,_that.host,_that.port,_that.useSsl,_that.has
 @JsonSerializable()
 
 class _Machine extends Machine {
-  const _Machine({required this.id, this.name, required this.host, this.port = 8765, this.useSsl = false, this.hasApiKey = false, this.lastConnected, this.isFavorite = false, this.sshEnabled = false, this.sshUsername, this.sshPort = 22, this.sshAuthType = SshAuthType.password, this.sshJumpHost, this.sshJumpPort = 22, this.sshJumpUsername, this.hasCredentials = false}): super._();
+  const _Machine({required this.id, this.name, required this.host, this.port = 8765, this.useSsl = false, this.hasApiKey = false, this.lastConnected, this.isFavorite = false, this.sshEnabled = false, this.sshUsername, this.sshPort = 22, this.sshAuthType = SshAuthType.password, this.sshJumpHost, this.sshJumpPort = 22, this.sshJumpUsername, this.sshJumpAuthType = SshAuthType.password, this.hasCredentials = false, this.hasJumpCredentials = false}): super._();
   factory _Machine.fromJson(Map<String, dynamic> json) => _$MachineFromJson(json);
 
 /// Unique identifier (UUID)
@@ -553,8 +557,12 @@ class _Machine extends Machine {
 @override@JsonKey() final  int sshJumpPort;
 /// Optional SSH jump username. Defaults to [sshUsername] when omitted.
 @override final  String? sshJumpUsername;
+/// SSH authentication type for the jump host
+@override@JsonKey() final  SshAuthType sshJumpAuthType;
 /// Whether SSH credentials are saved (password or private key in secure storage)
 @override@JsonKey() final  bool hasCredentials;
+/// Whether jump host credentials are saved in secure storage
+@override@JsonKey() final  bool hasJumpCredentials;
 
 /// Create a copy of Machine
 /// with the given fields replaced by the non-null parameter values.
@@ -569,16 +577,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Machine&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.host, host) || other.host == host)&&(identical(other.port, port) || other.port == port)&&(identical(other.useSsl, useSsl) || other.useSsl == useSsl)&&(identical(other.hasApiKey, hasApiKey) || other.hasApiKey == hasApiKey)&&(identical(other.lastConnected, lastConnected) || other.lastConnected == lastConnected)&&(identical(other.isFavorite, isFavorite) || other.isFavorite == isFavorite)&&(identical(other.sshEnabled, sshEnabled) || other.sshEnabled == sshEnabled)&&(identical(other.sshUsername, sshUsername) || other.sshUsername == sshUsername)&&(identical(other.sshPort, sshPort) || other.sshPort == sshPort)&&(identical(other.sshAuthType, sshAuthType) || other.sshAuthType == sshAuthType)&&(identical(other.sshJumpHost, sshJumpHost) || other.sshJumpHost == sshJumpHost)&&(identical(other.sshJumpPort, sshJumpPort) || other.sshJumpPort == sshJumpPort)&&(identical(other.sshJumpUsername, sshJumpUsername) || other.sshJumpUsername == sshJumpUsername)&&(identical(other.hasCredentials, hasCredentials) || other.hasCredentials == hasCredentials));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Machine&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.host, host) || other.host == host)&&(identical(other.port, port) || other.port == port)&&(identical(other.useSsl, useSsl) || other.useSsl == useSsl)&&(identical(other.hasApiKey, hasApiKey) || other.hasApiKey == hasApiKey)&&(identical(other.lastConnected, lastConnected) || other.lastConnected == lastConnected)&&(identical(other.isFavorite, isFavorite) || other.isFavorite == isFavorite)&&(identical(other.sshEnabled, sshEnabled) || other.sshEnabled == sshEnabled)&&(identical(other.sshUsername, sshUsername) || other.sshUsername == sshUsername)&&(identical(other.sshPort, sshPort) || other.sshPort == sshPort)&&(identical(other.sshAuthType, sshAuthType) || other.sshAuthType == sshAuthType)&&(identical(other.sshJumpHost, sshJumpHost) || other.sshJumpHost == sshJumpHost)&&(identical(other.sshJumpPort, sshJumpPort) || other.sshJumpPort == sshJumpPort)&&(identical(other.sshJumpUsername, sshJumpUsername) || other.sshJumpUsername == sshJumpUsername)&&(identical(other.sshJumpAuthType, sshJumpAuthType) || other.sshJumpAuthType == sshJumpAuthType)&&(identical(other.hasCredentials, hasCredentials) || other.hasCredentials == hasCredentials)&&(identical(other.hasJumpCredentials, hasJumpCredentials) || other.hasJumpCredentials == hasJumpCredentials));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,name,host,port,useSsl,hasApiKey,lastConnected,isFavorite,sshEnabled,sshUsername,sshPort,sshAuthType,sshJumpHost,sshJumpPort,sshJumpUsername,hasCredentials);
+int get hashCode => Object.hash(runtimeType,id,name,host,port,useSsl,hasApiKey,lastConnected,isFavorite,sshEnabled,sshUsername,sshPort,sshAuthType,sshJumpHost,sshJumpPort,sshJumpUsername,sshJumpAuthType,hasCredentials,hasJumpCredentials);
 
 @override
 String toString() {
-  return 'Machine(id: $id, name: $name, host: $host, port: $port, useSsl: $useSsl, hasApiKey: $hasApiKey, lastConnected: $lastConnected, isFavorite: $isFavorite, sshEnabled: $sshEnabled, sshUsername: $sshUsername, sshPort: $sshPort, sshAuthType: $sshAuthType, sshJumpHost: $sshJumpHost, sshJumpPort: $sshJumpPort, sshJumpUsername: $sshJumpUsername, hasCredentials: $hasCredentials)';
+  return 'Machine(id: $id, name: $name, host: $host, port: $port, useSsl: $useSsl, hasApiKey: $hasApiKey, lastConnected: $lastConnected, isFavorite: $isFavorite, sshEnabled: $sshEnabled, sshUsername: $sshUsername, sshPort: $sshPort, sshAuthType: $sshAuthType, sshJumpHost: $sshJumpHost, sshJumpPort: $sshJumpPort, sshJumpUsername: $sshJumpUsername, sshJumpAuthType: $sshJumpAuthType, hasCredentials: $hasCredentials, hasJumpCredentials: $hasJumpCredentials)';
 }
 
 
@@ -589,7 +597,7 @@ abstract mixin class _$MachineCopyWith<$Res> implements $MachineCopyWith<$Res> {
   factory _$MachineCopyWith(_Machine value, $Res Function(_Machine) _then) = __$MachineCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String? name, String host, int port, bool useSsl, bool hasApiKey, DateTime? lastConnected, bool isFavorite, bool sshEnabled, String? sshUsername, int sshPort, SshAuthType sshAuthType, String? sshJumpHost, int sshJumpPort, String? sshJumpUsername, bool hasCredentials
+ String id, String? name, String host, int port, bool useSsl, bool hasApiKey, DateTime? lastConnected, bool isFavorite, bool sshEnabled, String? sshUsername, int sshPort, SshAuthType sshAuthType, String? sshJumpHost, int sshJumpPort, String? sshJumpUsername, SshAuthType sshJumpAuthType, bool hasCredentials, bool hasJumpCredentials
 });
 
 
@@ -606,7 +614,7 @@ class __$MachineCopyWithImpl<$Res>
 
 /// Create a copy of Machine
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = freezed,Object? host = null,Object? port = null,Object? useSsl = null,Object? hasApiKey = null,Object? lastConnected = freezed,Object? isFavorite = null,Object? sshEnabled = null,Object? sshUsername = freezed,Object? sshPort = null,Object? sshAuthType = null,Object? sshJumpHost = freezed,Object? sshJumpPort = null,Object? sshJumpUsername = freezed,Object? hasCredentials = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = freezed,Object? host = null,Object? port = null,Object? useSsl = null,Object? hasApiKey = null,Object? lastConnected = freezed,Object? isFavorite = null,Object? sshEnabled = null,Object? sshUsername = freezed,Object? sshPort = null,Object? sshAuthType = null,Object? sshJumpHost = freezed,Object? sshJumpPort = null,Object? sshJumpUsername = freezed,Object? sshJumpAuthType = null,Object? hasCredentials = null,Object? hasJumpCredentials = null,}) {
   return _then(_Machine(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
@@ -623,7 +631,9 @@ as int,sshAuthType: null == sshAuthType ? _self.sshAuthType : sshAuthType // ign
 as SshAuthType,sshJumpHost: freezed == sshJumpHost ? _self.sshJumpHost : sshJumpHost // ignore: cast_nullable_to_non_nullable
 as String?,sshJumpPort: null == sshJumpPort ? _self.sshJumpPort : sshJumpPort // ignore: cast_nullable_to_non_nullable
 as int,sshJumpUsername: freezed == sshJumpUsername ? _self.sshJumpUsername : sshJumpUsername // ignore: cast_nullable_to_non_nullable
-as String?,hasCredentials: null == hasCredentials ? _self.hasCredentials : hasCredentials // ignore: cast_nullable_to_non_nullable
+as String?,sshJumpAuthType: null == sshJumpAuthType ? _self.sshJumpAuthType : sshJumpAuthType // ignore: cast_nullable_to_non_nullable
+as SshAuthType,hasCredentials: null == hasCredentials ? _self.hasCredentials : hasCredentials // ignore: cast_nullable_to_non_nullable
+as bool,hasJumpCredentials: null == hasJumpCredentials ? _self.hasJumpCredentials : hasJumpCredentials // ignore: cast_nullable_to_non_nullable
 as bool,
   ));
 }

--- a/apps/mobile/lib/models/machine.g.dart
+++ b/apps/mobile/lib/models/machine.g.dart
@@ -46,7 +46,11 @@ _Machine _$MachineFromJson(Map<String, dynamic> json) => _Machine(
   sshJumpHost: json['sshJumpHost'] as String?,
   sshJumpPort: (json['sshJumpPort'] as num?)?.toInt() ?? 22,
   sshJumpUsername: json['sshJumpUsername'] as String?,
+  sshJumpAuthType:
+      $enumDecodeNullable(_$SshAuthTypeEnumMap, json['sshJumpAuthType']) ??
+      SshAuthType.password,
   hasCredentials: json['hasCredentials'] as bool? ?? false,
+  hasJumpCredentials: json['hasJumpCredentials'] as bool? ?? false,
 );
 
 Map<String, dynamic> _$MachineToJson(_Machine instance) => <String, dynamic>{
@@ -65,7 +69,9 @@ Map<String, dynamic> _$MachineToJson(_Machine instance) => <String, dynamic>{
   'sshJumpHost': instance.sshJumpHost,
   'sshJumpPort': instance.sshJumpPort,
   'sshJumpUsername': instance.sshJumpUsername,
+  'sshJumpAuthType': _$SshAuthTypeEnumMap[instance.sshJumpAuthType]!,
   'hasCredentials': instance.hasCredentials,
+  'hasJumpCredentials': instance.hasJumpCredentials,
 };
 
 const _$SshAuthTypeEnumMap = {

--- a/apps/mobile/lib/providers/machine_manager_cubit.dart
+++ b/apps/mobile/lib/providers/machine_manager_cubit.dart
@@ -214,6 +214,8 @@ class MachineManagerCubit extends Cubit<MachineManagerState> {
     String? apiKey,
     String? sshPassword,
     String? sshPrivateKey,
+    String? sshJumpPassword,
+    String? sshJumpPrivateKey,
   }) async {
     emit(state.copyWith(error: null, successMessage: null));
     try {
@@ -222,6 +224,8 @@ class MachineManagerCubit extends Cubit<MachineManagerState> {
         apiKey: apiKey,
         sshPassword: sshPassword,
         sshPrivateKey: sshPrivateKey,
+        sshJumpPassword: sshJumpPassword,
+        sshJumpPrivateKey: sshJumpPrivateKey,
       );
       emit(state.copyWith(successMessage: 'Machine added successfully'));
     } catch (e) {
@@ -235,8 +239,11 @@ class MachineManagerCubit extends Cubit<MachineManagerState> {
     String? apiKey,
     String? sshPassword,
     String? sshPrivateKey,
+    String? sshJumpPassword,
+    String? sshJumpPrivateKey,
     bool clearApiKey = false,
     bool clearCredentials = false,
+    bool clearJumpCredentials = false,
   }) async {
     emit(state.copyWith(error: null, successMessage: null));
     try {
@@ -245,8 +252,11 @@ class MachineManagerCubit extends Cubit<MachineManagerState> {
         apiKey: apiKey,
         sshPassword: sshPassword,
         sshPrivateKey: sshPrivateKey,
+        sshJumpPassword: sshJumpPassword,
+        sshJumpPrivateKey: sshJumpPrivateKey,
         clearApiKey: clearApiKey,
         clearCredentials: clearCredentials,
+        clearJumpCredentials: clearJumpCredentials,
       );
       emit(state.copyWith(successMessage: 'Machine updated successfully'));
     } catch (e) {
@@ -532,6 +542,10 @@ class MachineManagerCubit extends Cubit<MachineManagerState> {
   /// Get SSH password for a machine
   Future<String?> getSshPassword(String machineId) =>
       _service.getSshPassword(machineId);
+
+  /// Get SSH jump host password for a machine
+  Future<String?> getSshJumpPassword(String machineId) =>
+      _service.getSshJumpPassword(machineId);
 
   /// Build WebSocket URL with API key
   Future<String> buildWsUrl(String machineId) => _service.buildWsUrl(machineId);

--- a/apps/mobile/lib/providers/machine_manager_cubit.dart
+++ b/apps/mobile/lib/providers/machine_manager_cubit.dart
@@ -508,8 +508,11 @@ class MachineManagerCubit extends Cubit<MachineManagerState> {
     required String username,
     required SshAuthType authType,
     String? jumpHost,
-    int jumpPort = 22,
+    required int jumpPort,
     String? jumpUsername,
+    SshAuthType jumpAuthType = SshAuthType.password,
+    String? jumpPassword,
+    String? jumpPrivateKey,
     String? password,
     String? privateKey,
   }) async {
@@ -524,6 +527,9 @@ class MachineManagerCubit extends Cubit<MachineManagerState> {
       jumpHost: jumpHost,
       jumpPort: jumpPort,
       jumpUsername: jumpUsername,
+      jumpAuthType: jumpAuthType,
+      jumpPassword: jumpPassword,
+      jumpPrivateKey: jumpPrivateKey,
       password: password,
       privateKey: privateKey,
     );

--- a/apps/mobile/lib/services/machine_manager_service.dart
+++ b/apps/mobile/lib/services/machine_manager_service.dart
@@ -358,6 +358,8 @@ class MachineManagerService {
     String? apiKey,
     String? sshPassword,
     String? sshPrivateKey,
+    String? sshJumpPassword,
+    String? sshJumpPrivateKey,
   }) async {
     // Check if machine with same host:port already exists
     final existingIndex = _machines.indexWhere(
@@ -376,6 +378,8 @@ class MachineManagerService {
       apiKey: apiKey,
       sshPassword: sshPassword,
       sshPrivateKey: sshPrivateKey,
+      sshJumpPassword: sshJumpPassword,
+      sshJumpPrivateKey: sshJumpPrivateKey,
     );
 
     // Update hasApiKey and hasCredentials flags
@@ -383,16 +387,21 @@ class MachineManagerService {
     final hasCredentials =
         (sshPassword != null && sshPassword.isNotEmpty) ||
         (sshPrivateKey != null && sshPrivateKey.isNotEmpty);
+    final hasJumpCredentials =
+        (sshJumpPassword != null && sshJumpPassword.isNotEmpty) ||
+        (sshJumpPrivateKey != null && sshJumpPrivateKey.isNotEmpty);
 
     if (existingIndex != -1) {
       _machines[existingIndex] = machine.copyWith(
         hasApiKey: hasApiKey,
         hasCredentials: hasCredentials,
+        hasJumpCredentials: hasJumpCredentials,
       );
     } else {
       _machines[_machines.length - 1] = machine.copyWith(
         hasApiKey: hasApiKey,
         hasCredentials: hasCredentials,
+        hasJumpCredentials: hasJumpCredentials,
       );
     }
 
@@ -410,8 +419,11 @@ class MachineManagerService {
     String? apiKey,
     String? sshPassword,
     String? sshPrivateKey,
+    String? sshJumpPassword,
+    String? sshJumpPrivateKey,
     bool clearApiKey = false,
     bool clearCredentials = false,
+    bool clearJumpCredentials = false,
   }) async {
     final index = _machines.indexWhere((m) => m.id == machine.id);
     if (index == -1) return;
@@ -448,16 +460,43 @@ class MachineManagerService {
       }
     }
 
+    if (clearJumpCredentials) {
+      await _secureStorage.delete(
+        key: '$_secureKeyPrefix${machine.id}_jump_ssh_pass',
+      );
+      await _secureStorage.delete(
+        key: '$_secureKeyPrefix${machine.id}_jump_ssh_key',
+      );
+    } else {
+      if (sshJumpPassword != null && sshJumpPassword.isNotEmpty) {
+        await _secureStorage.write(
+          key: '$_secureKeyPrefix${machine.id}_jump_ssh_pass',
+          value: sshJumpPassword,
+        );
+      }
+      if (sshJumpPrivateKey != null && sshJumpPrivateKey.isNotEmpty) {
+        await _secureStorage.write(
+          key: '$_secureKeyPrefix${machine.id}_jump_ssh_key',
+          value: sshJumpPrivateKey,
+        );
+      }
+    }
+
     // Update flags
     final existingApiKey = await getApiKey(machine.id);
     final existingPassword = await getSshPassword(machine.id);
     final existingKey = await getSshPrivateKey(machine.id);
+    final existingJumpPassword = await getSshJumpPassword(machine.id);
+    final existingJumpKey = await getSshJumpPrivateKey(machine.id);
 
     _machines[index] = machine.copyWith(
       hasApiKey: existingApiKey != null && existingApiKey.isNotEmpty,
       hasCredentials:
           (existingPassword != null && existingPassword.isNotEmpty) ||
           (existingKey != null && existingKey.isNotEmpty),
+      hasJumpCredentials:
+          (existingJumpPassword != null && existingJumpPassword.isNotEmpty) ||
+          (existingJumpKey != null && existingJumpKey.isNotEmpty),
     );
 
     _sortMachines();
@@ -582,6 +621,8 @@ class MachineManagerService {
     String? apiKey,
     String? sshPassword,
     String? sshPrivateKey,
+    String? sshJumpPassword,
+    String? sshJumpPrivateKey,
   }) async {
     if (apiKey != null && apiKey.isNotEmpty) {
       await _secureStorage.write(
@@ -601,12 +642,30 @@ class MachineManagerService {
         value: sshPrivateKey,
       );
     }
+    if (sshJumpPassword != null && sshJumpPassword.isNotEmpty) {
+      await _secureStorage.write(
+        key: '$_secureKeyPrefix${machineId}_jump_ssh_pass',
+        value: sshJumpPassword,
+      );
+    }
+    if (sshJumpPrivateKey != null && sshJumpPrivateKey.isNotEmpty) {
+      await _secureStorage.write(
+        key: '$_secureKeyPrefix${machineId}_jump_ssh_key',
+        value: sshJumpPrivateKey,
+      );
+    }
   }
 
   Future<void> _deleteCredentials(String machineId) async {
     await _secureStorage.delete(key: '$_secureKeyPrefix${machineId}_api');
     await _secureStorage.delete(key: '$_secureKeyPrefix${machineId}_ssh_pass');
     await _secureStorage.delete(key: '$_secureKeyPrefix${machineId}_ssh_key');
+    await _secureStorage.delete(
+      key: '$_secureKeyPrefix${machineId}_jump_ssh_pass',
+    );
+    await _secureStorage.delete(
+      key: '$_secureKeyPrefix${machineId}_jump_ssh_key',
+    );
   }
 
   /// Get API key for a machine
@@ -625,6 +684,20 @@ class MachineManagerService {
   Future<String?> getSshPrivateKey(String machineId) async {
     return await _secureStorage.read(
       key: '$_secureKeyPrefix${machineId}_ssh_key',
+    );
+  }
+
+  /// Get SSH jump host password for a machine
+  Future<String?> getSshJumpPassword(String machineId) async {
+    return await _secureStorage.read(
+      key: '$_secureKeyPrefix${machineId}_jump_ssh_pass',
+    );
+  }
+
+  /// Get SSH jump host private key for a machine
+  Future<String?> getSshJumpPrivateKey(String machineId) async {
+    return await _secureStorage.read(
+      key: '$_secureKeyPrefix${machineId}_jump_ssh_key',
     );
   }
 

--- a/apps/mobile/lib/services/ssh_startup_service.dart
+++ b/apps/mobile/lib/services/ssh_startup_service.dart
@@ -27,8 +27,18 @@ class SshJumpConfig {
   final String host;
   final int port;
   final String? username;
+  final SshAuthType authType;
+  final String? password;
+  final String? privateKey;
 
-  const SshJumpConfig({required this.host, required this.port, this.username});
+  const SshJumpConfig({
+    required this.host,
+    required this.port,
+    this.username,
+    this.authType = SshAuthType.password,
+    this.password,
+    this.privateKey,
+  });
 }
 
 class SshCommandResult {
@@ -111,12 +121,17 @@ class DartSshConnectionGateway implements SshConnectionGateway {
       jump.port,
       timeout: connectionTimeout,
     );
+    final jumpIdentities = _validateCredentials(
+      jump.authType,
+      jump.password,
+      jump.privateKey,
+    );
     final jumpClient = _createClient(
       jumpSocket,
       username: jump.username ?? username,
-      authType: authType,
-      password: password,
-      identities: identities,
+      authType: jump.authType,
+      password: jump.password,
+      identities: jumpIdentities,
     );
 
     try {
@@ -682,6 +697,9 @@ ${_startCommand.trim()}
     String? jumpHost,
     int jumpPort = 22,
     String? jumpUsername,
+    SshAuthType jumpAuthType = SshAuthType.password,
+    String? jumpPassword,
+    String? jumpPrivateKey,
     String? password,
     String? privateKey,
   }) async {
@@ -706,6 +724,9 @@ ${_startCommand.trim()}
           host: jumpHost,
           port: jumpPort,
           username: jumpUsername,
+          authType: jumpAuthType,
+          password: jumpPassword,
+          privateKey: jumpPrivateKey,
         ),
       );
 
@@ -836,7 +857,7 @@ ${_startCommand.trim()}
     Machine machine, {
     String? password,
     String? privateKey,
-  }) {
+  }) async {
     return _connectionGateway.connect(
       host: machine.host,
       port: machine.sshPort,
@@ -844,15 +865,32 @@ ${_startCommand.trim()}
       authType: machine.sshAuthType,
       password: password,
       privateKey: privateKey,
-      jump: _machineJumpConfig(machine),
+      jump: await _machineJumpConfig(machine),
     );
   }
 
-  SshJumpConfig? _machineJumpConfig(Machine machine) {
-    return _inlineJumpConfig(
-      host: machine.sshJumpHost,
+  Future<SshJumpConfig?> _machineJumpConfig(Machine machine) async {
+    final trimmedHost = machine.sshJumpHost?.trim();
+    if (trimmedHost == null || trimmedHost.isEmpty) return null;
+
+    String? jumpPassword;
+    String? jumpPrivateKey;
+    if (machine.sshJumpAuthType == SshAuthType.password) {
+      jumpPassword = await _machineManager.getSshJumpPassword(machine.id);
+    } else {
+      jumpPrivateKey = await _machineManager.getSshJumpPrivateKey(machine.id);
+    }
+
+    final trimmedUsername = machine.sshJumpUsername?.trim();
+    return SshJumpConfig(
+      host: trimmedHost,
       port: machine.sshJumpPort,
-      username: machine.sshJumpUsername,
+      username: trimmedUsername == null || trimmedUsername.isEmpty
+          ? null
+          : trimmedUsername,
+      authType: machine.sshJumpAuthType,
+      password: jumpPassword,
+      privateKey: jumpPrivateKey,
     );
   }
 
@@ -860,6 +898,9 @@ ${_startCommand.trim()}
     required String? host,
     required int port,
     required String? username,
+    SshAuthType authType = SshAuthType.password,
+    String? password,
+    String? privateKey,
   }) {
     final trimmedHost = host?.trim();
     if (trimmedHost == null || trimmedHost.isEmpty) return null;
@@ -870,6 +911,9 @@ ${_startCommand.trim()}
       username: trimmedUsername == null || trimmedUsername.isEmpty
           ? null
           : trimmedUsername,
+      authType: authType,
+      password: password,
+      privateKey: privateKey,
     );
   }
 }

--- a/apps/mobile/lib/services/ssh_startup_service.dart
+++ b/apps/mobile/lib/services/ssh_startup_service.dart
@@ -28,16 +28,16 @@ class SshJumpConfig {
   final int port;
   final String? username;
   final SshAuthType authType;
-  final String? password;
-  final String? privateKey;
+  final String? jumpPassword;
+  final String? jumpPrivateKey;
 
   const SshJumpConfig({
     required this.host,
     required this.port,
     this.username,
     this.authType = SshAuthType.password,
-    this.password,
-    this.privateKey,
+    this.jumpPassword,
+    this.jumpPrivateKey,
   });
 }
 
@@ -123,14 +123,14 @@ class DartSshConnectionGateway implements SshConnectionGateway {
     );
     final jumpIdentities = _validateCredentials(
       jump.authType,
-      jump.password,
-      jump.privateKey,
+      jump.jumpPassword,
+      jump.jumpPrivateKey,
     );
     final jumpClient = _createClient(
       jumpSocket,
       username: jump.username ?? username,
       authType: jump.authType,
-      password: jump.password,
+      password: jump.jumpPassword,
       identities: jumpIdentities,
     );
 
@@ -889,8 +889,8 @@ ${_startCommand.trim()}
           ? null
           : trimmedUsername,
       authType: machine.sshJumpAuthType,
-      password: jumpPassword,
-      privateKey: jumpPrivateKey,
+      jumpPassword: jumpPassword,
+      jumpPrivateKey: jumpPrivateKey,
     );
   }
 
@@ -912,8 +912,8 @@ ${_startCommand.trim()}
           ? null
           : trimmedUsername,
       authType: authType,
-      password: password,
-      privateKey: privateKey,
+      jumpPassword: password,
+      jumpPrivateKey: privateKey,
     );
   }
 }

--- a/apps/mobile/test/machine_edit_sheet_test.dart
+++ b/apps/mobile/test/machine_edit_sheet_test.dart
@@ -34,6 +34,8 @@ void main() {
       String? apiKey,
       String? sshPassword,
       String? sshPrivateKey,
+      String? sshJumpPassword,
+      String? sshJumpPrivateKey,
     })
     onSave,
   }) async {
@@ -61,6 +63,9 @@ void main() {
                   jumpHost,
                   required jumpPort,
                   jumpUsername,
+                  jumpAuthType = SshAuthType.password,
+                  jumpPassword,
+                  jumpPrivateKey,
                   password,
                   privateKey,
                 }) async {
@@ -93,7 +98,7 @@ void main() {
           useSsl: true,
         ),
         onSave:
-            ({required machine, apiKey, sshPassword, sshPrivateKey}) async {},
+            ({required machine, apiKey, sshPassword, sshPrivateKey, sshJumpPassword, sshJumpPrivateKey}) async {},
       );
 
       final switchTile = tester.widget<SwitchListTile>(
@@ -110,7 +115,7 @@ void main() {
       await pumpSheet(
         tester,
         machine: const Machine(id: 'm2', host: 'bridge.example.com'),
-        onSave: ({required machine, apiKey, sshPassword, sshPrivateKey}) async {
+        onSave: ({required machine, apiKey, sshPassword, sshPrivateKey, sshJumpPassword, sshJumpPrivateKey}) async {
           savedMachine = machine;
         },
       );
@@ -142,7 +147,7 @@ void main() {
           sshJumpPort: 2222,
           sshJumpUsername: 'jump-user',
         ),
-        onSave: ({required machine, apiKey, sshPassword, sshPrivateKey}) async {
+        onSave: ({required machine, apiKey, sshPassword, sshPrivateKey, sshJumpPassword, sshJumpPrivateKey}) async {
           savedMachine = machine;
         },
       );
@@ -180,7 +185,7 @@ void main() {
         existingSshPassword: 'pw',
         onTestConnectionCall: (value) => call = value,
         onSave:
-            ({required machine, apiKey, sshPassword, sshPrivateKey}) async {},
+            ({required machine, apiKey, sshPassword, sshPrivateKey, sshJumpPassword, sshJumpPrivateKey}) async {},
       );
 
       await tester.tap(find.text('Test Connection'));

--- a/apps/mobile/test/machine_edit_sheet_test.dart
+++ b/apps/mobile/test/machine_edit_sheet_test.dart
@@ -12,6 +12,7 @@ class _TestConnectionCall {
   final String? jumpHost;
   final int jumpPort;
   final String? jumpUsername;
+  final String? jumpPassword;
 
   const _TestConnectionCall({
     required this.host,
@@ -20,6 +21,7 @@ class _TestConnectionCall {
     required this.jumpHost,
     required this.jumpPort,
     required this.jumpUsername,
+    this.jumpPassword,
   });
 }
 
@@ -29,6 +31,7 @@ void main() {
     Machine? machine,
     void Function(_TestConnectionCall call)? onTestConnectionCall,
     String? existingSshPassword,
+    String? existingSshJumpPassword,
     required Future<void> Function({
       required Machine machine,
       String? apiKey,
@@ -53,6 +56,7 @@ void main() {
           body: MachineEditSheet(
             machine: machine,
             existingSshPassword: existingSshPassword,
+            existingSshJumpPassword: existingSshJumpPassword,
             onSave: onSave,
             onTestConnection:
                 ({
@@ -77,6 +81,7 @@ void main() {
                       jumpHost: jumpHost,
                       jumpPort: jumpPort,
                       jumpUsername: jumpUsername,
+                      jumpPassword: jumpPassword,
                     ),
                   );
                   return SshResult.success();
@@ -135,6 +140,8 @@ void main() {
   group('MachineEditSheet SSH jump host', () {
     testWidgets('loads and saves SSH jump host fields', (tester) async {
       Machine? savedMachine;
+      String? savedSshJumpPassword;
+      String? savedSshPassword;
 
       await pumpSheet(
         tester,
@@ -147,8 +154,12 @@ void main() {
           sshJumpPort: 2222,
           sshJumpUsername: 'jump-user',
         ),
+        existingSshJumpPassword: 'jump-pw',
+        existingSshPassword: 'target-pw',
         onSave: ({required machine, apiKey, sshPassword, sshPrivateKey, sshJumpPassword, sshJumpPrivateKey}) async {
           savedMachine = machine;
+          savedSshPassword = sshPassword;
+          savedSshJumpPassword = sshJumpPassword;
         },
       );
 
@@ -164,6 +175,9 @@ void main() {
       expect(savedMachine!.sshJumpHost, 'jump.example.com');
       expect(savedMachine!.sshJumpPort, 2222);
       expect(savedMachine!.sshJumpUsername, 'jump-user');
+      // jump credentials are stored separately from target credentials
+      expect(savedSshJumpPassword, 'jump-pw');
+      expect(savedSshPassword, 'target-pw');
     });
 
     testWidgets('passes SSH jump host fields to Test Connection', (
@@ -182,7 +196,8 @@ void main() {
           sshJumpPort: 2222,
           sshJumpUsername: 'jump-user',
         ),
-        existingSshPassword: 'pw',
+        existingSshPassword: 'target-pw',
+        existingSshJumpPassword: 'jump-pw',
         onTestConnectionCall: (value) => call = value,
         onSave:
             ({required machine, apiKey, sshPassword, sshPrivateKey, sshJumpPassword, sshJumpPrivateKey}) async {},
@@ -198,6 +213,8 @@ void main() {
       expect(call!.jumpHost, 'jump.example.com');
       expect(call!.jumpPort, 2222);
       expect(call!.jumpUsername, 'jump-user');
+      // jump credentials are passed separately from target credentials
+      expect(call!.jumpPassword, 'jump-pw');
     });
   });
 }

--- a/apps/mobile/test/machine_manager_cubit_test.dart
+++ b/apps/mobile/test/machine_manager_cubit_test.dart
@@ -82,6 +82,8 @@ class MockMachineManagerService implements MachineManagerService {
     String? apiKey,
     String? sshPassword,
     String? sshPrivateKey,
+    String? sshJumpPassword,
+    String? sshJumpPrivateKey,
   }) async {
     calls.add('addMachine:${machine.id}');
     if (addMachineShouldFail) throw Exception('addMachine failed');
@@ -94,8 +96,11 @@ class MockMachineManagerService implements MachineManagerService {
     String? apiKey,
     String? sshPassword,
     String? sshPrivateKey,
+    String? sshJumpPassword,
+    String? sshJumpPrivateKey,
     bool clearApiKey = false,
     bool clearCredentials = false,
+    bool clearJumpCredentials = false,
   }) async {
     calls.add('updateMachine:${machine.id}');
     if (updateMachineShouldFail) throw Exception('updateMachine failed');
@@ -125,6 +130,12 @@ class MockMachineManagerService implements MachineManagerService {
 
   @override
   Future<String?> getSshPrivateKey(String machineId) async => null;
+
+  @override
+  Future<String?> getSshJumpPassword(String machineId) async => null;
+
+  @override
+  Future<String?> getSshJumpPrivateKey(String machineId) async => null;
 
   @override
   Future<String> buildWsUrl(String machineId) async => 'ws://mock:8765';
@@ -225,6 +236,9 @@ class MockSshStartupService implements SshStartupService {
     String? jumpHost,
     int jumpPort = 22,
     String? jumpUsername,
+    SshAuthType jumpAuthType = SshAuthType.password,
+    String? jumpPassword,
+    String? jumpPrivateKey,
     String? password,
     String? privateKey,
   }) async {
@@ -510,6 +524,7 @@ void main() {
         sshPort: 22,
         username: 'user',
         authType: SshAuthType.password,
+        jumpPort: 22,
       );
 
       expect(result.success, false);

--- a/apps/mobile/test/settings_usage_visibility_test.dart
+++ b/apps/mobile/test/settings_usage_visibility_test.dart
@@ -180,6 +180,8 @@ class _StaticMachineManagerService implements MachineManagerService {
     String? apiKey,
     String? sshPassword,
     String? sshPrivateKey,
+    String? sshJumpPassword,
+    String? sshJumpPrivateKey,
   }) async {}
 
   @override
@@ -188,8 +190,11 @@ class _StaticMachineManagerService implements MachineManagerService {
     String? apiKey,
     String? sshPassword,
     String? sshPrivateKey,
+    String? sshJumpPassword,
+    String? sshJumpPrivateKey,
     bool clearApiKey = false,
     bool clearCredentials = false,
+    bool clearJumpCredentials = false,
   }) async {}
 
   @override
@@ -209,6 +214,12 @@ class _StaticMachineManagerService implements MachineManagerService {
 
   @override
   Future<String?> getSshPrivateKey(String machineId) async => null;
+
+  @override
+  Future<String?> getSshJumpPassword(String machineId) async => null;
+
+  @override
+  Future<String?> getSshJumpPrivateKey(String machineId) async => null;
 
   @override
   Future<String> buildWsUrl(String machineId) async => 'ws://127.0.0.1:8765';

--- a/apps/mobile/test/workspace_shell_screen_test.dart
+++ b/apps/mobile/test/workspace_shell_screen_test.dart
@@ -270,6 +270,8 @@ class _StaticMachineManagerService implements MachineManagerService {
     String? apiKey,
     String? sshPassword,
     String? sshPrivateKey,
+    String? sshJumpPassword,
+    String? sshJumpPrivateKey,
   }) async {}
 
   @override
@@ -278,8 +280,11 @@ class _StaticMachineManagerService implements MachineManagerService {
     String? apiKey,
     String? sshPassword,
     String? sshPrivateKey,
+    String? sshJumpPassword,
+    String? sshJumpPrivateKey,
     bool clearApiKey = false,
     bool clearCredentials = false,
+    bool clearJumpCredentials = false,
   }) async {}
 
   @override
@@ -304,6 +309,12 @@ class _StaticMachineManagerService implements MachineManagerService {
 
   @override
   Future<String?> getSshPrivateKey(String machineId) async => null;
+
+  @override
+  Future<String?> getSshJumpPassword(String machineId) async => null;
+
+  @override
+  Future<String?> getSshJumpPrivateKey(String machineId) async => null;
 
   @override
   Future<String> buildWsUrl(String machineId) async => 'ws://127.0.0.1:8765';


### PR DESCRIPTION
## Problem

When connecting via SSH jump host, the target host's `authType`, `password`,
and private key were silently reused for the jump host connection because
`SshJumpConfig` had no auth fields. This caused authentication failures when
the jump host and target host use different credentials.

## Changes

**`SshJumpConfig`** — added `authType`, `jumpPassword`, `jumpPrivateKey` fields
so each hop carries its own credentials.

**`DartSshConnectionGateway.connect()`** — validates and passes jump-specific
credentials to the jump client instead of reusing target credentials.

**`machine_manager_service.dart`** — added `machine_<uuid>_jump_ssh_pass` and
`machine_<uuid>_jump_ssh_key` storage keys; added `getSshJumpPassword` /
`getSshJumpPrivateKey` accessors; updated `addMachine` / `updateMachine` to
accept and persist jump credentials separately.

**`machine_edit_sheet.dart`** — added jump auth type selector (Password /
Private Key) and corresponding credential input fields.

**`machine_manager_cubit.dart`** — forwarded jump auth params through
`testConnectionWithCredentials`.

## Tests

- `machine_edit_sheet_test.dart`: verifies that `sshJumpPassword` and
  `sshPassword` are captured as separate values in `onSave`, and that
  `jumpPassword` is forwarded separately in `onTestConnection`.
- All 1122 existing tests pass.

## Out of scope (follow-up)

- Jump host credential validation in `_sshConfigValid` (show error when jump
  host is set but credentials are empty)
- Pre-populating jump private key in edit mode (`existingSshJumpPrivateKey`)
- Refactoring `addMachine` / `updateMachine` flag-computation asymmetry