### PR TITLE
Support CCpocket on Linux

### DIFF
--- a/.github/workflows/android-patch.yml
+++ b/.github/workflows/android-patch.yml
@@ -46,6 +46,11 @@ jobs:
           EOF
       - name: Setup Firebase config
         run: echo "${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}" | base64 -d > apps/mobile/android/app/google-services.json
+      - name: Enable precompiled Rust artifacts for Android CI
+        run: |
+          cat > apps/mobile/cargokit_options.yaml <<'EOF'
+          use_precompiled_binaries: true
+          EOF
       - run: flutter pub get
         working-directory: apps/mobile
       - run: dart analyze .

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -43,6 +43,11 @@ jobs:
           EOF
       - name: Setup Firebase config
         run: echo "${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}" | base64 -d > apps/mobile/android/app/google-services.json
+      - name: Enable precompiled Rust artifacts for Android CI
+        run: |
+          cat > apps/mobile/cargokit_options.yaml <<'EOF'
+          use_precompiled_binaries: true
+          EOF
       - run: flutter pub get
         working-directory: apps/mobile
       - run: dart analyze .

--- a/apps/mobile/.metadata
+++ b/apps/mobile/.metadata
@@ -18,6 +18,9 @@ migration:
     - platform: macos
       create_revision: ff37bef603469fb030f2b72995ab929ccfc227f0
       base_revision: ff37bef603469fb030f2b72995ab929ccfc227f0
+    - platform: linux
+      create_revision: 00b0c91f06209d9e4a41f71b7a512d6eb3b9c694
+      base_revision: 00b0c91f06209d9e4a41f71b7a512d6eb3b9c694
 
   # User provided section
 

--- a/apps/mobile/cargokit_options.yaml
+++ b/apps/mobile/cargokit_options.yaml
@@ -1,1 +1,4 @@
-use_precompiled_binaries: true
+# Default to local Rust builds for development so `flutter run/build -d linux`
+# does not stall on GitHub precompiled binary downloads.
+# Android release workflows overwrite this file to keep CI fast.
+use_precompiled_binaries: false

--- a/apps/mobile/lib/features/session_list/session_list_screen.dart
+++ b/apps/mobile/lib/features/session_list/session_list_screen.dart
@@ -8,6 +8,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../l10n/app_localizations.dart';
+import '../../utils/bridge_url.dart';
 import '../../utils/platform_helper.dart';
 
 import '../../models/messages.dart';
@@ -449,6 +450,7 @@ class _SessionListScreenState extends State<SessionListScreen>
           port: uri.port != 0 ? uri.port : 8765,
           apiKey: trimmedApiKey.isNotEmpty ? trimmedApiKey : null,
           useSsl: uri.scheme == 'https',
+          wsUrl: url,
         );
       }
     }
@@ -2180,7 +2182,7 @@ class _SessionListScreenState extends State<SessionListScreen>
     if (!mounted) return;
     final bridge = context.read<BridgeService>();
     bridge.connect(wsUrl);
-    bridge.savePreferences(machine.wsUrl);
+    bridge.savePreferences(stripBridgeAuthToken(wsUrl));
     final tunnelService = context.read<SshBridgeTunnelService?>();
     if (tunnelService != null) {
       unawaited(tunnelService.closeAllExcept(machine.id));

--- a/apps/mobile/lib/providers/machine_manager_cubit.dart
+++ b/apps/mobile/lib/providers/machine_manager_cubit.dart
@@ -198,6 +198,7 @@ class MachineManagerCubit extends Cubit<MachineManagerState> {
     String? apiKey,
     String? name,
     bool? useSsl,
+    String? wsUrl,
   }) async {
     return await _service.recordConnection(
       host: host,
@@ -205,6 +206,7 @@ class MachineManagerCubit extends Cubit<MachineManagerState> {
       apiKey: apiKey,
       name: name,
       useSsl: useSsl,
+      wsUrl: wsUrl,
     );
   }
 

--- a/apps/mobile/lib/screens/qr_scan_screen.dart
+++ b/apps/mobile/lib/screens/qr_scan_screen.dart
@@ -1,8 +1,10 @@
 import 'package:auto_route/auto_route.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
 
 import '../services/connection_url_parser.dart';
+import '../utils/platform_helper.dart';
 
 @RoutePage()
 class QrScanScreen extends StatefulWidget {
@@ -13,12 +15,22 @@ class QrScanScreen extends StatefulWidget {
 }
 
 class _QrScanScreenState extends State<QrScanScreen> {
-  final MobileScannerController _controller = MobileScannerController();
+  MobileScannerController? _controller;
   bool _hasPopped = false;
+
+  bool get _isSupported => !kIsWeb && isMobilePlatform;
+
+  @override
+  void initState() {
+    super.initState();
+    if (_isSupported) {
+      _controller = MobileScannerController();
+    }
+  }
 
   @override
   void dispose() {
-    _controller.dispose();
+    _controller?.dispose();
     super.dispose();
   }
 
@@ -49,43 +61,54 @@ class _QrScanScreenState extends State<QrScanScreen> {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
+    final controller = _controller;
 
     return Scaffold(
       appBar: AppBar(title: const Text('Scan QR Code')),
-      body: Stack(
-        children: [
-          MobileScanner(controller: _controller, onDetect: _onDetect),
-          // Scan frame overlay
-          Center(
-            child: Container(
-              width: 260,
-              height: 260,
-              decoration: BoxDecoration(
-                border: Border.all(
-                  color: colorScheme.primary.withValues(alpha: 0.7),
-                  width: 3,
+      body: !_isSupported || controller == null
+          ? const Center(
+              child: Padding(
+                padding: EdgeInsets.all(24),
+                child: Text(
+                  'QR camera scan is not available on this platform. Enter the Bridge URL manually.',
+                  textAlign: TextAlign.center,
                 ),
-                borderRadius: BorderRadius.circular(16),
               ),
+            )
+          : Stack(
+              children: [
+                MobileScanner(controller: controller, onDetect: _onDetect),
+                // Scan frame overlay
+                Center(
+                  child: Container(
+                    width: 260,
+                    height: 260,
+                    decoration: BoxDecoration(
+                      border: Border.all(
+                        color: colorScheme.primary.withValues(alpha: 0.7),
+                        width: 3,
+                      ),
+                      borderRadius: BorderRadius.circular(16),
+                    ),
+                  ),
+                ),
+                // Hint text
+                Positioned(
+                  bottom: 80,
+                  left: 0,
+                  right: 0,
+                  child: Text(
+                    'Point camera at the QR code\nshown by bridge server',
+                    textAlign: TextAlign.center,
+                    style: TextStyle(
+                      color: colorScheme.onSurface.withValues(alpha: 0.8),
+                      fontSize: 14,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                ),
+              ],
             ),
-          ),
-          // Hint text
-          Positioned(
-            bottom: 80,
-            left: 0,
-            right: 0,
-            child: Text(
-              'Point camera at the QR code\nshown by bridge server',
-              textAlign: TextAlign.center,
-              style: TextStyle(
-                color: colorScheme.onSurface.withValues(alpha: 0.8),
-                fontSize: 14,
-                fontWeight: FontWeight.w500,
-              ),
-            ),
-          ),
-        ],
-      ),
     );
   }
 }

--- a/apps/mobile/lib/services/bridge_service.dart
+++ b/apps/mobile/lib/services/bridge_service.dart
@@ -10,6 +10,7 @@ import 'package:web_socket_channel/web_socket_channel.dart';
 import '../core/logger.dart';
 import '../models/messages.dart';
 import '../models/offline_pending_action.dart';
+import '../utils/bridge_url.dart';
 import '../utils/codex_plan_update.dart';
 import 'bridge_service_base.dart';
 import 'session_runtime_store.dart';
@@ -292,17 +293,9 @@ class BridgeService implements BridgeServiceBase {
   }
 
   /// Derive HTTP base URL from the WebSocket URL.
-  /// Example: ws://host:8765/path?query=1 -> http://host:8765
+  /// Example: ws://host:8765/path?query=1 -> http://host:8765/path
   @override
-  String? get httpBaseUrl {
-    final url = _lastUrl;
-    if (url == null) return null;
-    final uri = Uri.tryParse(url);
-    if (uri == null) return null;
-    final scheme = uri.scheme == 'wss' ? 'https' : 'http';
-    final port = uri.hasPort ? ':${uri.port}' : '';
-    return '$scheme://${uri.host}$port';
-  }
+  String? get httpBaseUrl => bridgeHttpBaseUrlFromWsUrl(_lastUrl);
 
   static const _prefKeyUrl = 'bridge_url';
   static const _prefKeyApiKey = 'bridge_api_key';
@@ -2042,11 +2035,9 @@ class BridgeService implements BridgeServiceBase {
   /// Returns the health JSON on success, null on failure.
   static Future<Map<String, dynamic>?> checkHealth(String wsUrl) async {
     try {
-      final uri = Uri.tryParse(wsUrl);
-      if (uri == null) return null;
-      final scheme = uri.scheme == 'wss' ? 'https' : 'http';
-      final port = uri.hasPort ? ':${uri.port}' : '';
-      final healthUrl = '$scheme://${uri.host}$port/health';
+      final httpBaseUrl = bridgeHttpBaseUrlFromWsUrl(wsUrl);
+      if (httpBaseUrl == null) return null;
+      final healthUrl = buildBridgeHttpUrl(httpBaseUrl, '/health');
       final response = await http
           .get(Uri.parse(healthUrl))
           .timeout(const Duration(seconds: 3));

--- a/apps/mobile/lib/services/fcm_service.dart
+++ b/apps/mobile/lib/services/fcm_service.dart
@@ -14,6 +14,12 @@ class FcmService {
 
   bool get isAvailable => _available;
 
+  bool get isSupportedPlatform {
+    if (kIsWeb) return false;
+    return defaultTargetPlatform == TargetPlatform.iOS ||
+        defaultTargetPlatform == TargetPlatform.android;
+  }
+
   FirebaseMessaging get _instance => _messaging ??= FirebaseMessaging.instance;
 
   Stream<String> get onTokenRefresh => _instance.onTokenRefresh;
@@ -28,7 +34,7 @@ class FcmService {
   Future<bool> init() async {
     if (_initAttempted) return _available;
     _initAttempted = true;
-    if (kIsWeb) {
+    if (!isSupportedPlatform) {
       _available = false;
       return false;
     }

--- a/apps/mobile/lib/services/machine_manager_service.dart
+++ b/apps/mobile/lib/services/machine_manager_service.dart
@@ -10,6 +10,7 @@ import 'package:uuid/uuid.dart';
 
 import '../constants/app_constants.dart';
 import '../models/machine.dart';
+import '../utils/bridge_url.dart';
 
 typedef BridgeWsUrlResolver =
     Future<String> Function(
@@ -36,6 +37,7 @@ typedef BridgeHttpBaseUrlResolver =
 class MachineManagerService {
   // New storage key for unified Machine model
   static const _prefsKey = 'machines_v2';
+  static const _prefsKeyWsUrlOverrides = 'machine_ws_url_overrides_v1';
   // Old keys for migration
   static const _oldMachinesKey = 'remote_machines';
   static const _oldUrlHistoryKey = 'url_history';
@@ -48,6 +50,7 @@ class MachineManagerService {
   final _machinesController =
       StreamController<List<MachineWithStatus>>.broadcast();
   List<Machine> _machines = [];
+  Map<String, String> _wsUrlOverrides = {};
   final Map<String, MachineStatus> _statusCache = {};
   final Map<String, DateTime> _lastChecked = {};
   final Map<String, String> _lastErrors = {};
@@ -89,6 +92,7 @@ class MachineManagerService {
   Future<void> init() async {
     await _migrateIfNeeded();
     _machines = _loadFromPrefs();
+    _wsUrlOverrides = _loadWsUrlOverrides();
     _sortMachines();
     _notifyListeners();
     // Start health check after loading
@@ -101,6 +105,7 @@ class MachineManagerService {
     if (_prefs.containsKey(_prefsKey)) return;
 
     final machines = <Machine>[];
+    final wsUrlOverrides = <String, String>{};
     final seenKeys = <String>{}; // host:port keys for deduplication
 
     // 1. Migrate old RemoteMachine entries (mark as favorites)
@@ -188,6 +193,10 @@ class MachineManagerService {
                 isFavorite: false, // URL history entries are not favorites
               ),
             );
+            final normalizedWsUrl = stripBridgeAuthToken(url);
+            if (_hasCustomWsTarget(normalizedWsUrl, host, port, useSsl)) {
+              wsUrlOverrides[machineId] = normalizedWsUrl;
+            }
           }
         }
       } catch (e) {
@@ -199,6 +208,10 @@ class MachineManagerService {
     if (machines.isNotEmpty) {
       _machines = machines;
       await _saveToPrefs();
+      if (wsUrlOverrides.isNotEmpty) {
+        _wsUrlOverrides = wsUrlOverrides;
+        await _saveWsUrlOverrides();
+      }
       logger.info('[MachineManager] Migrated ${machines.length} machines');
     }
 
@@ -225,10 +238,29 @@ class MachineManagerService {
     }
   }
 
+  Map<String, String> _loadWsUrlOverrides() {
+    final raw = _prefs.getString(_prefsKeyWsUrlOverrides);
+    if (raw == null || raw.isEmpty) return {};
+    try {
+      final decoded = jsonDecode(raw) as Map<String, dynamic>;
+      return decoded.map((key, value) => MapEntry(key, value.toString()));
+    } catch (e) {
+      logger.error('[MachineManager] Failed to load ws url overrides', e);
+      return {};
+    }
+  }
+
   /// Save machines to SharedPreferences
   Future<void> _saveToPrefs() async {
     final json = jsonEncode(_machines.map((m) => m.toJson()).toList());
     await _prefs.setString(_prefsKey, json);
+  }
+
+  Future<void> _saveWsUrlOverrides() async {
+    await _prefs.setString(
+      _prefsKeyWsUrlOverrides,
+      jsonEncode(_wsUrlOverrides),
+    );
   }
 
   /// Sort machines: favorites first, then by lastConnected DESC
@@ -270,9 +302,11 @@ class MachineManagerService {
     final toRemove = nonFavorites.skip(keepCount.clamp(0, nonFavorites.length));
     for (final m in toRemove) {
       await _deleteCredentials(m.id);
+      _wsUrlOverrides.remove(m.id);
     }
 
     _machines = [...favorites, ...toKeep];
+    await _saveWsUrlOverrides();
   }
 
   /// Notify listeners of updated machine list
@@ -310,6 +344,7 @@ class MachineManagerService {
     String? apiKey,
     String? name,
     bool? useSsl,
+    String? wsUrl,
   }) async {
     var machine = findByHostPort(host, port);
 
@@ -338,6 +373,14 @@ class MachineManagerService {
       _machines.add(machine);
     }
 
+    _rememberWsUrlOverride(
+      machine.id,
+      host: host,
+      port: port,
+      useSsl: useSsl ?? machine.useSsl,
+      wsUrl: wsUrl,
+    );
+
     // Save API key if provided
     if (apiKey != null && apiKey.isNotEmpty) {
       await _secureStorage.write(
@@ -355,6 +398,7 @@ class MachineManagerService {
     await _enforceMaxHistory();
     _sortMachines();
     await _saveToPrefs();
+    await _saveWsUrlOverrides();
     _notifyListeners();
 
     return machine;
@@ -431,8 +475,11 @@ class MachineManagerService {
       );
     }
 
+    _dropInvalidWsUrlOverride(machine);
+
     _sortMachines();
     await _saveToPrefs();
+    await _saveWsUrlOverrides();
     _notifyListeners();
 
     // Check health for the new/updated machine
@@ -523,8 +570,11 @@ class MachineManagerService {
           (existingJumpKey != null && existingJumpKey.isNotEmpty),
     );
 
+    _dropInvalidWsUrlOverride(machine);
+
     _sortMachines();
     await _saveToPrefs();
+    await _saveWsUrlOverrides();
     _notifyListeners();
   }
 
@@ -532,11 +582,13 @@ class MachineManagerService {
   Future<void> deleteMachine(String id) async {
     _machines.removeWhere((m) => m.id == id);
     await _deleteCredentials(id);
+    _wsUrlOverrides.remove(id);
     _statusCache.remove(id);
     _lastChecked.remove(id);
     _lastErrors.remove(id);
     _versionCache.remove(id);
     await _saveToPrefs();
+    await _saveWsUrlOverrides();
     _notifyListeners();
   }
 
@@ -571,7 +623,7 @@ class MachineManagerService {
         password: password,
         promptForPassword: promptForPassword,
       );
-      final healthUrl = '$httpBaseUrl/health';
+      final healthUrl = buildBridgeHttpUrl(httpBaseUrl, '/health');
       final response = await http.get(Uri.parse(healthUrl)).timeout(timeout);
 
       if (response.statusCode == 200) {
@@ -621,7 +673,7 @@ class MachineManagerService {
         password: password,
         promptForPassword: promptForPassword,
       );
-      final versionUrl = '$httpBaseUrl/version';
+      final versionUrl = buildBridgeHttpUrl(httpBaseUrl, '/version');
       final response = await http
           .get(Uri.parse(versionUrl))
           .timeout(const Duration(seconds: 3));
@@ -753,7 +805,8 @@ class MachineManagerService {
     var url = await _buildWsUrl(machine);
     final apiKey = await getApiKey(machineId);
     if (apiKey != null && apiKey.isNotEmpty) {
-      url = '$url?token=$apiKey';
+      final sep = url.contains('?') ? '&' : '?';
+      url = '$url${sep}token=$apiKey';
     }
     return url;
   }
@@ -773,7 +826,8 @@ class MachineManagerService {
     );
     final apiKey = await getApiKey(machineId);
     if (apiKey != null && apiKey.isNotEmpty) {
-      url = '$url?token=$apiKey';
+      final sep = url.contains('?') ? '&' : '?';
+      url = '$url${sep}token=$apiKey';
     }
     return url;
   }
@@ -784,9 +838,10 @@ class MachineManagerService {
     Future<String?> Function()? promptForPassword,
   }) async {
     final resolver = _bridgeWsUrlResolver;
-    if (resolver == null) return machine.wsUrl;
+    final storedWsUrl = _storedWsUrlForMachine(machine) ?? machine.wsUrl;
+    if (resolver == null) return storedWsUrl;
     return await resolver(
-      machine,
+      _machineWithWsUrl(machine, storedWsUrl),
       password: password,
       promptForPassword: promptForPassword,
     );
@@ -798,11 +853,86 @@ class MachineManagerService {
     Future<String?> Function()? promptForPassword,
   }) async {
     final resolver = _bridgeHttpBaseUrlResolver;
-    if (resolver == null) return machine.httpUrl;
+    final storedWsUrl = _storedWsUrlForMachine(machine);
+    if (resolver == null) {
+      if (storedWsUrl != null) {
+        return bridgeHttpBaseUrlFromWsUrl(storedWsUrl) ?? machine.httpUrl;
+      }
+      return machine.httpUrl;
+    }
     return await resolver(
-      machine,
+      _machineWithWsUrl(machine, storedWsUrl ?? machine.wsUrl),
       password: password,
       promptForPassword: promptForPassword,
+    );
+  }
+
+  String? _storedWsUrlForMachine(Machine machine) {
+    final wsUrl = _wsUrlOverrides[machine.id];
+    if (wsUrl == null || wsUrl.isEmpty) return null;
+    if (_matchesMachineTarget(wsUrl, machine)) return wsUrl;
+    return null;
+  }
+
+  void _rememberWsUrlOverride(
+    String machineId, {
+    required String host,
+    required int port,
+    required bool useSsl,
+    String? wsUrl,
+  }) {
+    final normalizedWsUrl = wsUrl == null ? null : stripBridgeAuthToken(wsUrl);
+    if (normalizedWsUrl == null || normalizedWsUrl.isEmpty) return;
+    if (_hasCustomWsTarget(normalizedWsUrl, host, port, useSsl)) {
+      _wsUrlOverrides[machineId] = normalizedWsUrl;
+    } else {
+      _wsUrlOverrides.remove(machineId);
+    }
+  }
+
+  void _dropInvalidWsUrlOverride(Machine machine) {
+    final wsUrl = _wsUrlOverrides[machine.id];
+    if (wsUrl == null) return;
+    if (!_matchesMachineTarget(wsUrl, machine)) {
+      _wsUrlOverrides.remove(machine.id);
+    }
+  }
+
+  bool _matchesMachineTarget(String wsUrl, Machine machine) {
+    final uri = Uri.tryParse(wsUrl);
+    if (uri == null) return false;
+    final expectedScheme = machine.useSsl ? 'wss' : 'ws';
+    final actualPort = uri.hasPort
+        ? uri.port
+        : (uri.scheme == 'wss' ? 443 : 80);
+    return uri.scheme == expectedScheme &&
+        uri.host == machine.host &&
+        actualPort == machine.port;
+  }
+
+  bool _hasCustomWsTarget(String wsUrl, String host, int port, bool useSsl) {
+    final uri = Uri.tryParse(wsUrl);
+    if (uri == null) return false;
+    final expectedScheme = useSsl ? 'wss' : 'ws';
+    final actualPort = uri.hasPort
+        ? uri.port
+        : (uri.scheme == 'wss' ? 443 : 80);
+    final hasCustomPath = uri.path.isNotEmpty && uri.path != '/';
+    final hasCustomQuery = uri.query.isNotEmpty;
+    return uri.scheme == expectedScheme &&
+        uri.host == host &&
+        actualPort == port &&
+        (hasCustomPath || hasCustomQuery);
+  }
+
+  Machine _machineWithWsUrl(Machine machine, String wsUrl) {
+    final uri = Uri.tryParse(wsUrl);
+    if (uri == null) return machine;
+    final port = uri.hasPort ? uri.port : (uri.scheme == 'wss' ? 443 : 80);
+    return machine.copyWith(
+      host: uri.host,
+      port: port,
+      useSsl: uri.scheme == 'wss',
     );
   }
 

--- a/apps/mobile/lib/services/notification_service.dart
+++ b/apps/mobile/lib/services/notification_service.dart
@@ -41,10 +41,14 @@ class NotificationService extends ChangeNotifier {
       requestBadgePermission: true,
       requestSoundPermission: true,
     );
+    const linuxSettings = LinuxInitializationSettings(
+      defaultActionName: 'Open CC Pocket',
+    );
     const settings = InitializationSettings(
       android: androidSettings,
       iOS: iosSettings,
       macOS: macosSettings,
+      linux: linuxSettings,
     );
 
     await _plugin.initialize(
@@ -136,10 +140,12 @@ class NotificationService extends ChangeNotifier {
     );
     const iosDetails = DarwinNotificationDetails();
     const macosDetails = DarwinNotificationDetails();
+    const linuxDetails = LinuxNotificationDetails();
     const details = NotificationDetails(
       android: androidDetails,
       iOS: iosDetails,
       macOS: macosDetails,
+      linux: linuxDetails,
     );
 
     await _plugin.show(

--- a/apps/mobile/lib/utils/bridge_url.dart
+++ b/apps/mobile/lib/utils/bridge_url.dart
@@ -1,0 +1,43 @@
+String? bridgeHttpBaseUrlFromWsUrl(String? wsUrl) {
+  if (wsUrl == null) return null;
+  final uri = Uri.tryParse(wsUrl.trim());
+  if (uri == null) return null;
+  final scheme = uri.scheme == 'wss' ? 'https' : 'http';
+  final normalizedPath = _normalizeBasePath(uri.path);
+  return Uri(
+    scheme: scheme,
+    host: uri.host,
+    port: uri.hasPort ? uri.port : null,
+    path: normalizedPath,
+  ).toString();
+}
+
+String buildBridgeHttpUrl(String httpBaseUrl, String endpointPath) {
+  final base = httpBaseUrl.endsWith('/')
+      ? httpBaseUrl.substring(0, httpBaseUrl.length - 1)
+      : httpBaseUrl;
+  final path = endpointPath.startsWith('/')
+      ? endpointPath.substring(1)
+      : endpointPath;
+  return '$base/$path';
+}
+
+String stripBridgeAuthToken(String wsUrl) {
+  final uri = Uri.tryParse(wsUrl.trim());
+  if (uri == null) return wsUrl.trim();
+
+  final query = Map<String, String>.from(uri.queryParameters);
+  query.remove('token');
+
+  return uri
+      .replace(queryParameters: query.isEmpty ? null : query, fragment: null)
+      .toString();
+}
+
+String _normalizeBasePath(String path) {
+  if (path.isEmpty || path == '/') return '';
+  if (path.endsWith('/')) {
+    return path.substring(0, path.length - 1);
+  }
+  return path;
+}

--- a/apps/mobile/linux/.gitignore
+++ b/apps/mobile/linux/.gitignore
@@ -1,0 +1,1 @@
+flutter/ephemeral

--- a/apps/mobile/linux/CMakeLists.txt
+++ b/apps/mobile/linux/CMakeLists.txt
@@ -1,0 +1,128 @@
+# Project-level configuration.
+cmake_minimum_required(VERSION 3.13)
+project(runner LANGUAGES CXX)
+
+# The name of the executable created for the application. Change this to change
+# the on-disk name of your application.
+set(BINARY_NAME "ccpocket")
+# The unique GTK application identifier for this application. See:
+# https://wiki.gnome.org/HowDoI/ChooseApplicationID
+set(APPLICATION_ID "com.k9i.ccpocket")
+
+# Explicitly opt in to modern CMake behaviors to avoid warnings with recent
+# versions of CMake.
+cmake_policy(SET CMP0063 NEW)
+
+# Load bundled libraries from the lib/ directory relative to the binary.
+set(CMAKE_INSTALL_RPATH "$ORIGIN/lib")
+
+# Root filesystem for cross-building.
+if(FLUTTER_TARGET_PLATFORM_SYSROOT)
+  set(CMAKE_SYSROOT ${FLUTTER_TARGET_PLATFORM_SYSROOT})
+  set(CMAKE_FIND_ROOT_PATH ${CMAKE_SYSROOT})
+  set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+  set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+  set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+  set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+endif()
+
+# Define build configuration options.
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  set(CMAKE_BUILD_TYPE "Debug" CACHE
+    STRING "Flutter build mode" FORCE)
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+    "Debug" "Profile" "Release")
+endif()
+
+# Compilation settings that should be applied to most targets.
+#
+# Be cautious about adding new options here, as plugins use this function by
+# default. In most cases, you should add new options to specific targets instead
+# of modifying this function.
+function(APPLY_STANDARD_SETTINGS TARGET)
+  target_compile_features(${TARGET} PUBLIC cxx_std_14)
+  target_compile_options(${TARGET} PRIVATE -Wall -Werror)
+  target_compile_options(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:-O3>")
+  target_compile_definitions(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:NDEBUG>")
+endfunction()
+
+# Flutter library and tool build rules.
+set(FLUTTER_MANAGED_DIR "${CMAKE_CURRENT_SOURCE_DIR}/flutter")
+add_subdirectory(${FLUTTER_MANAGED_DIR})
+
+# System-level dependencies.
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(GTK REQUIRED IMPORTED_TARGET gtk+-3.0)
+
+# Application build; see runner/CMakeLists.txt.
+add_subdirectory("runner")
+
+# Run the Flutter tool portions of the build. This must not be removed.
+add_dependencies(${BINARY_NAME} flutter_assemble)
+
+# Only the install-generated bundle's copy of the executable will launch
+# correctly, since the resources must in the right relative locations. To avoid
+# people trying to run the unbundled copy, put it in a subdirectory instead of
+# the default top-level location.
+set_target_properties(${BINARY_NAME}
+  PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/intermediates_do_not_run"
+)
+
+
+# Generated plugin build rules, which manage building the plugins and adding
+# them to the application.
+include(flutter/generated_plugins.cmake)
+
+
+# === Installation ===
+# By default, "installing" just makes a relocatable bundle in the build
+# directory.
+set(BUILD_BUNDLE_DIR "${PROJECT_BINARY_DIR}/bundle")
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+  set(CMAKE_INSTALL_PREFIX "${BUILD_BUNDLE_DIR}" CACHE PATH "..." FORCE)
+endif()
+
+# Start with a clean build bundle directory every time.
+install(CODE "
+  file(REMOVE_RECURSE \"${BUILD_BUNDLE_DIR}/\")
+  " COMPONENT Runtime)
+
+set(INSTALL_BUNDLE_DATA_DIR "${CMAKE_INSTALL_PREFIX}/data")
+set(INSTALL_BUNDLE_LIB_DIR "${CMAKE_INSTALL_PREFIX}/lib")
+
+install(TARGETS ${BINARY_NAME} RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}"
+  COMPONENT Runtime)
+
+install(FILES "${FLUTTER_ICU_DATA_FILE}" DESTINATION "${INSTALL_BUNDLE_DATA_DIR}"
+  COMPONENT Runtime)
+
+install(FILES "${FLUTTER_LIBRARY}" DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+  COMPONENT Runtime)
+
+foreach(bundled_library ${PLUGIN_BUNDLED_LIBRARIES})
+  install(FILES "${bundled_library}"
+    DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+    COMPONENT Runtime)
+endforeach(bundled_library)
+
+# Copy the native assets provided by the build.dart from all packages.
+set(NATIVE_ASSETS_DIR "${PROJECT_BUILD_DIR}native_assets/linux/")
+install(DIRECTORY "${NATIVE_ASSETS_DIR}"
+   DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+   COMPONENT Runtime)
+
+# Fully re-copy the assets directory on each build to avoid having stale files
+# from a previous install.
+set(FLUTTER_ASSET_DIR_NAME "flutter_assets")
+install(CODE "
+  file(REMOVE_RECURSE \"${INSTALL_BUNDLE_DATA_DIR}/${FLUTTER_ASSET_DIR_NAME}\")
+  " COMPONENT Runtime)
+install(DIRECTORY "${PROJECT_BUILD_DIR}/${FLUTTER_ASSET_DIR_NAME}"
+  DESTINATION "${INSTALL_BUNDLE_DATA_DIR}" COMPONENT Runtime)
+
+# Install the AOT library on non-Debug builds only.
+if(NOT CMAKE_BUILD_TYPE MATCHES "Debug")
+  install(FILES "${AOT_LIBRARY}" DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+    COMPONENT Runtime)
+endif()

--- a/apps/mobile/linux/flutter/CMakeLists.txt
+++ b/apps/mobile/linux/flutter/CMakeLists.txt
@@ -1,0 +1,88 @@
+# This file controls Flutter-level build steps. It should not be edited.
+cmake_minimum_required(VERSION 3.10)
+
+set(EPHEMERAL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ephemeral")
+
+# Configuration provided via flutter tool.
+include(${EPHEMERAL_DIR}/generated_config.cmake)
+
+# TODO: Move the rest of this into files in ephemeral. See
+# https://github.com/flutter/flutter/issues/57146.
+
+# Serves the same purpose as list(TRANSFORM ... PREPEND ...),
+# which isn't available in 3.10.
+function(list_prepend LIST_NAME PREFIX)
+    set(NEW_LIST "")
+    foreach(element ${${LIST_NAME}})
+        list(APPEND NEW_LIST "${PREFIX}${element}")
+    endforeach(element)
+    set(${LIST_NAME} "${NEW_LIST}" PARENT_SCOPE)
+endfunction()
+
+# === Flutter Library ===
+# System-level dependencies.
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(GTK REQUIRED IMPORTED_TARGET gtk+-3.0)
+pkg_check_modules(GLIB REQUIRED IMPORTED_TARGET glib-2.0)
+pkg_check_modules(GIO REQUIRED IMPORTED_TARGET gio-2.0)
+
+set(FLUTTER_LIBRARY "${EPHEMERAL_DIR}/libflutter_linux_gtk.so")
+
+# Published to parent scope for install step.
+set(FLUTTER_LIBRARY ${FLUTTER_LIBRARY} PARENT_SCOPE)
+set(FLUTTER_ICU_DATA_FILE "${EPHEMERAL_DIR}/icudtl.dat" PARENT_SCOPE)
+set(PROJECT_BUILD_DIR "${PROJECT_DIR}/build/" PARENT_SCOPE)
+set(AOT_LIBRARY "${PROJECT_DIR}/build/lib/libapp.so" PARENT_SCOPE)
+
+list(APPEND FLUTTER_LIBRARY_HEADERS
+  "fl_basic_message_channel.h"
+  "fl_binary_codec.h"
+  "fl_binary_messenger.h"
+  "fl_dart_project.h"
+  "fl_engine.h"
+  "fl_json_message_codec.h"
+  "fl_json_method_codec.h"
+  "fl_message_codec.h"
+  "fl_method_call.h"
+  "fl_method_channel.h"
+  "fl_method_codec.h"
+  "fl_method_response.h"
+  "fl_plugin_registrar.h"
+  "fl_plugin_registry.h"
+  "fl_standard_message_codec.h"
+  "fl_standard_method_codec.h"
+  "fl_string_codec.h"
+  "fl_value.h"
+  "fl_view.h"
+  "flutter_linux.h"
+)
+list_prepend(FLUTTER_LIBRARY_HEADERS "${EPHEMERAL_DIR}/flutter_linux/")
+add_library(flutter INTERFACE)
+target_include_directories(flutter INTERFACE
+  "${EPHEMERAL_DIR}"
+)
+target_link_libraries(flutter INTERFACE "${FLUTTER_LIBRARY}")
+target_link_libraries(flutter INTERFACE
+  PkgConfig::GTK
+  PkgConfig::GLIB
+  PkgConfig::GIO
+)
+add_dependencies(flutter flutter_assemble)
+
+# === Flutter tool backend ===
+# _phony_ is a non-existent file to force this command to run every time,
+# since currently there's no way to get a full input/output list from the
+# flutter tool.
+add_custom_command(
+  OUTPUT ${FLUTTER_LIBRARY} ${FLUTTER_LIBRARY_HEADERS}
+    ${CMAKE_CURRENT_BINARY_DIR}/_phony_
+  COMMAND ${CMAKE_COMMAND} -E env
+    ${FLUTTER_TOOL_ENVIRONMENT}
+    "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.sh"
+      ${FLUTTER_TARGET_PLATFORM} ${CMAKE_BUILD_TYPE}
+  VERBATIM
+)
+add_custom_target(flutter_assemble DEPENDS
+  "${FLUTTER_LIBRARY}"
+  ${FLUTTER_LIBRARY_HEADERS}
+)

--- a/apps/mobile/linux/flutter/generated_plugin_registrant.cc
+++ b/apps/mobile/linux/flutter/generated_plugin_registrant.cc
@@ -1,0 +1,35 @@
+//
+//  Generated file. Do not edit.
+//
+
+// clang-format off
+
+#include "generated_plugin_registrant.h"
+
+#include <file_selector_linux/file_selector_plugin.h>
+#include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
+#include <gtk/gtk_plugin.h>
+#include <irondash_engine_context/irondash_engine_context_plugin.h>
+#include <super_native_extensions/super_native_extensions_plugin.h>
+#include <url_launcher_linux/url_launcher_plugin.h>
+
+void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
+  file_selector_plugin_register_with_registrar(file_selector_linux_registrar);
+  g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
+  flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);
+  g_autoptr(FlPluginRegistrar) gtk_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "GtkPlugin");
+  gtk_plugin_register_with_registrar(gtk_registrar);
+  g_autoptr(FlPluginRegistrar) irondash_engine_context_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "IrondashEngineContextPlugin");
+  irondash_engine_context_plugin_register_with_registrar(irondash_engine_context_registrar);
+  g_autoptr(FlPluginRegistrar) super_native_extensions_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "SuperNativeExtensionsPlugin");
+  super_native_extensions_plugin_register_with_registrar(super_native_extensions_registrar);
+  g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
+  url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
+}

--- a/apps/mobile/linux/flutter/generated_plugin_registrant.h
+++ b/apps/mobile/linux/flutter/generated_plugin_registrant.h
@@ -1,0 +1,15 @@
+//
+//  Generated file. Do not edit.
+//
+
+// clang-format off
+
+#ifndef GENERATED_PLUGIN_REGISTRANT_
+#define GENERATED_PLUGIN_REGISTRANT_
+
+#include <flutter_linux/flutter_linux.h>
+
+// Registers Flutter plugins.
+void fl_register_plugins(FlPluginRegistry* registry);
+
+#endif  // GENERATED_PLUGIN_REGISTRANT_

--- a/apps/mobile/linux/flutter/generated_plugins.cmake
+++ b/apps/mobile/linux/flutter/generated_plugins.cmake
@@ -1,0 +1,30 @@
+#
+# Generated file, do not edit.
+#
+
+list(APPEND FLUTTER_PLUGIN_LIST
+  file_selector_linux
+  flutter_secure_storage_linux
+  gtk
+  irondash_engine_context
+  super_native_extensions
+  url_launcher_linux
+)
+
+list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  jni
+)
+
+set(PLUGIN_BUNDLED_LIBRARIES)
+
+foreach(plugin ${FLUTTER_PLUGIN_LIST})
+  add_subdirectory(flutter/ephemeral/.plugin_symlinks/${plugin}/linux plugins/${plugin})
+  target_link_libraries(${BINARY_NAME} PRIVATE ${plugin}_plugin)
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES $<TARGET_FILE:${plugin}_plugin>)
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${plugin}_bundled_libraries})
+endforeach(plugin)
+
+foreach(ffi_plugin ${FLUTTER_FFI_PLUGIN_LIST})
+  add_subdirectory(flutter/ephemeral/.plugin_symlinks/${ffi_plugin}/linux plugins/${ffi_plugin})
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${ffi_plugin}_bundled_libraries})
+endforeach(ffi_plugin)

--- a/apps/mobile/linux/runner/CMakeLists.txt
+++ b/apps/mobile/linux/runner/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.13)
+project(runner LANGUAGES CXX)
+
+# Define the application target. To change its name, change BINARY_NAME in the
+# top-level CMakeLists.txt, not the value here, or `flutter run` will no longer
+# work.
+#
+# Any new source files that you add to the application should be added here.
+add_executable(${BINARY_NAME}
+  "main.cc"
+  "my_application.cc"
+  "${FLUTTER_MANAGED_DIR}/generated_plugin_registrant.cc"
+)
+
+# Apply the standard set of build settings. This can be removed for applications
+# that need different build settings.
+apply_standard_settings(${BINARY_NAME})
+
+# Add preprocessor definitions for the application ID.
+add_definitions(-DAPPLICATION_ID="${APPLICATION_ID}")
+
+# Add dependency libraries. Add any application-specific dependencies here.
+target_link_libraries(${BINARY_NAME} PRIVATE flutter)
+target_link_libraries(${BINARY_NAME} PRIVATE PkgConfig::GTK)
+
+target_include_directories(${BINARY_NAME} PRIVATE "${CMAKE_SOURCE_DIR}")

--- a/apps/mobile/linux/runner/main.cc
+++ b/apps/mobile/linux/runner/main.cc
@@ -1,0 +1,6 @@
+#include "my_application.h"
+
+int main(int argc, char** argv) {
+  g_autoptr(MyApplication) app = my_application_new();
+  return g_application_run(G_APPLICATION(app), argc, argv);
+}

--- a/apps/mobile/linux/runner/my_application.cc
+++ b/apps/mobile/linux/runner/my_application.cc
@@ -1,0 +1,148 @@
+#include "my_application.h"
+
+#include <flutter_linux/flutter_linux.h>
+#ifdef GDK_WINDOWING_X11
+#include <gdk/gdkx.h>
+#endif
+
+#include "flutter/generated_plugin_registrant.h"
+
+struct _MyApplication {
+  GtkApplication parent_instance;
+  char** dart_entrypoint_arguments;
+};
+
+G_DEFINE_TYPE(MyApplication, my_application, GTK_TYPE_APPLICATION)
+
+// Called when first Flutter frame received.
+static void first_frame_cb(MyApplication* self, FlView* view) {
+  gtk_widget_show(gtk_widget_get_toplevel(GTK_WIDGET(view)));
+}
+
+// Implements GApplication::activate.
+static void my_application_activate(GApplication* application) {
+  MyApplication* self = MY_APPLICATION(application);
+  GtkWindow* window =
+      GTK_WINDOW(gtk_application_window_new(GTK_APPLICATION(application)));
+
+  // Use a header bar when running in GNOME as this is the common style used
+  // by applications and is the setup most users will be using (e.g. Ubuntu
+  // desktop).
+  // If running on X and not using GNOME then just use a traditional title bar
+  // in case the window manager does more exotic layout, e.g. tiling.
+  // If running on Wayland assume the header bar will work (may need changing
+  // if future cases occur).
+  gboolean use_header_bar = TRUE;
+#ifdef GDK_WINDOWING_X11
+  GdkScreen* screen = gtk_window_get_screen(window);
+  if (GDK_IS_X11_SCREEN(screen)) {
+    const gchar* wm_name = gdk_x11_screen_get_window_manager_name(screen);
+    if (g_strcmp0(wm_name, "GNOME Shell") != 0) {
+      use_header_bar = FALSE;
+    }
+  }
+#endif
+  if (use_header_bar) {
+    GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
+    gtk_widget_show(GTK_WIDGET(header_bar));
+    gtk_header_bar_set_title(header_bar, "CC Pocket");
+    gtk_header_bar_set_show_close_button(header_bar, TRUE);
+    gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
+  } else {
+    gtk_window_set_title(window, "CC Pocket");
+  }
+
+  gtk_window_set_default_size(window, 1280, 720);
+
+  g_autoptr(FlDartProject) project = fl_dart_project_new();
+  fl_dart_project_set_dart_entrypoint_arguments(
+      project, self->dart_entrypoint_arguments);
+
+  FlView* view = fl_view_new(project);
+  GdkRGBA background_color;
+  // Background defaults to black, override it here if necessary, e.g. #00000000
+  // for transparent.
+  gdk_rgba_parse(&background_color, "#000000");
+  fl_view_set_background_color(view, &background_color);
+  gtk_widget_show(GTK_WIDGET(view));
+  gtk_container_add(GTK_CONTAINER(window), GTK_WIDGET(view));
+
+  // Show the window when Flutter renders.
+  // Requires the view to be realized so we can start rendering.
+  g_signal_connect_swapped(view, "first-frame", G_CALLBACK(first_frame_cb),
+                           self);
+  gtk_widget_realize(GTK_WIDGET(view));
+
+  fl_register_plugins(FL_PLUGIN_REGISTRY(view));
+
+  gtk_widget_grab_focus(GTK_WIDGET(view));
+}
+
+// Implements GApplication::local_command_line.
+static gboolean my_application_local_command_line(GApplication* application,
+                                                  gchar*** arguments,
+                                                  int* exit_status) {
+  MyApplication* self = MY_APPLICATION(application);
+  // Strip out the first argument as it is the binary name.
+  self->dart_entrypoint_arguments = g_strdupv(*arguments + 1);
+
+  g_autoptr(GError) error = nullptr;
+  if (!g_application_register(application, nullptr, &error)) {
+    g_warning("Failed to register: %s", error->message);
+    *exit_status = 1;
+    return TRUE;
+  }
+
+  g_application_activate(application);
+  *exit_status = 0;
+
+  return TRUE;
+}
+
+// Implements GApplication::startup.
+static void my_application_startup(GApplication* application) {
+  // MyApplication* self = MY_APPLICATION(object);
+
+  // Perform any actions required at application startup.
+
+  G_APPLICATION_CLASS(my_application_parent_class)->startup(application);
+}
+
+// Implements GApplication::shutdown.
+static void my_application_shutdown(GApplication* application) {
+  // MyApplication* self = MY_APPLICATION(object);
+
+  // Perform any actions required at application shutdown.
+
+  G_APPLICATION_CLASS(my_application_parent_class)->shutdown(application);
+}
+
+// Implements GObject::dispose.
+static void my_application_dispose(GObject* object) {
+  MyApplication* self = MY_APPLICATION(object);
+  g_clear_pointer(&self->dart_entrypoint_arguments, g_strfreev);
+  G_OBJECT_CLASS(my_application_parent_class)->dispose(object);
+}
+
+static void my_application_class_init(MyApplicationClass* klass) {
+  G_APPLICATION_CLASS(klass)->activate = my_application_activate;
+  G_APPLICATION_CLASS(klass)->local_command_line =
+      my_application_local_command_line;
+  G_APPLICATION_CLASS(klass)->startup = my_application_startup;
+  G_APPLICATION_CLASS(klass)->shutdown = my_application_shutdown;
+  G_OBJECT_CLASS(klass)->dispose = my_application_dispose;
+}
+
+static void my_application_init(MyApplication* self) {}
+
+MyApplication* my_application_new() {
+  // Set the program name to the application ID, which helps various systems
+  // like GTK and desktop environments map this running application to its
+  // corresponding .desktop file. This ensures better integration by allowing
+  // the application to be recognized beyond its binary name.
+  g_set_prgname(APPLICATION_ID);
+
+  return MY_APPLICATION(g_object_new(my_application_get_type(),
+                                     "application-id", APPLICATION_ID, "flags",
+                                     G_APPLICATION_NON_UNIQUE, nullptr));
+}

--- a/apps/mobile/linux/runner/my_application.h
+++ b/apps/mobile/linux/runner/my_application.h
@@ -1,0 +1,21 @@
+#ifndef FLUTTER_MY_APPLICATION_H_
+#define FLUTTER_MY_APPLICATION_H_
+
+#include <gtk/gtk.h>
+
+G_DECLARE_FINAL_TYPE(MyApplication,
+                     my_application,
+                     MY,
+                     APPLICATION,
+                     GtkApplication)
+
+/**
+ * my_application_new:
+ *
+ * Creates a new Flutter-based application.
+ *
+ * Returns: a new #MyApplication.
+ */
+MyApplication* my_application_new();
+
+#endif  // FLUTTER_MY_APPLICATION_H_

--- a/apps/mobile/test/bridge_connection_path_test.dart
+++ b/apps/mobile/test/bridge_connection_path_test.dart
@@ -1,0 +1,135 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:ccpocket/models/machine.dart';
+import 'package:ccpocket/services/bridge_service.dart';
+import 'package:ccpocket/services/machine_manager_service.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _FakeSecureStorage implements FlutterSecureStorage {
+  final Map<String, String> values = {};
+
+  @override
+  Future<void> write({
+    required String key,
+    required String? value,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    if (value == null) {
+      values.remove(key);
+    } else {
+      values[key] = value;
+    }
+  }
+
+  @override
+  Future<String?> read({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    return values[key];
+  }
+
+  @override
+  Future<void> delete({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    values.remove(key);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  group('Bridge connection path handling', () {
+    test('BridgeService.checkHealth preserves websocket path prefix', () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => server.close(force: true));
+
+      server.listen((request) async {
+        if (request.uri.path == '/bridge/health') {
+          request.response
+            ..statusCode = 200
+            ..headers.contentType = ContentType.json
+            ..write(jsonEncode({'status': 'ok'}));
+        } else {
+          request.response
+            ..statusCode = 404
+            ..write('Not Found');
+        }
+        await request.response.close();
+      });
+
+      final health = await BridgeService.checkHealth(
+        'ws://127.0.0.1:${server.port}/bridge',
+      );
+
+      expect(health, isNotNull);
+      expect(health, containsPair('status', 'ok'));
+    });
+
+    test(
+      'MachineManagerService preserves full websocket URL for reconnect',
+      () async {
+        final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+        addTearDown(() => server.close(force: true));
+
+        server.listen((request) async {
+          if (request.uri.path == '/bridge/health') {
+            request.response
+              ..statusCode = 200
+              ..headers.contentType = ContentType.json
+              ..write(jsonEncode({'status': 'ok'}));
+          } else if (request.uri.path == '/bridge/version') {
+            request.response
+              ..statusCode = 200
+              ..headers.contentType = ContentType.json
+              ..write(jsonEncode({'version': '1.0.0'}));
+          } else {
+            request.response
+              ..statusCode = 404
+              ..write('Not Found');
+          }
+          await request.response.close();
+        });
+
+        SharedPreferences.setMockInitialValues({});
+        final prefs = await SharedPreferences.getInstance();
+        final manager = MachineManagerService(prefs, _FakeSecureStorage());
+        await manager.init();
+
+        final machine = await manager.recordConnection(
+          host: '127.0.0.1',
+          port: server.port,
+          useSsl: false,
+          wsUrl: 'ws://127.0.0.1:${server.port}/bridge',
+        );
+
+        expect(
+          await manager.buildWsUrl(machine.id),
+          'ws://127.0.0.1:${server.port}/bridge',
+        );
+        expect(await manager.checkHealth(machine.id), MachineStatus.online);
+      },
+    );
+  });
+}

--- a/apps/mobile/test/linux_desktop_client_test.dart
+++ b/apps/mobile/test/linux_desktop_client_test.dart
@@ -1,0 +1,37 @@
+import 'package:ccpocket/screens/qr_scan_screen.dart';
+import 'package:ccpocket/services/fcm_service.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  tearDown(() {
+    debugDefaultTargetPlatformOverride = null;
+  });
+
+  test('FcmService stays unavailable on Linux desktop', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+
+    final service = FcmService();
+
+    expect(service.isSupportedPlatform, isFalse);
+    expect(await service.init(), isFalse);
+    expect(service.isAvailable, isFalse);
+    debugDefaultTargetPlatformOverride = null;
+  });
+
+  testWidgets('QrScanScreen shows manual URL fallback on desktop', (
+    tester,
+  ) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+
+    await tester.pumpWidget(const MaterialApp(home: QrScanScreen()));
+
+    expect(
+      find.textContaining('QR camera scan is not available'),
+      findsOneWidget,
+    );
+    expect(find.textContaining('Bridge URL'), findsOneWidget);
+    debugDefaultTargetPlatformOverride = null;
+  });
+}

--- a/apps/mobile/test/machine_manager_cubit_test.dart
+++ b/apps/mobile/test/machine_manager_cubit_test.dart
@@ -67,6 +67,7 @@ class MockMachineManagerService implements MachineManagerService {
     String? apiKey,
     String? name,
     bool? useSsl,
+    String? wsUrl,
   }) async {
     calls.add('recordConnection:$host:$port');
     return Machine(

--- a/apps/mobile/test/settings_usage_visibility_test.dart
+++ b/apps/mobile/test/settings_usage_visibility_test.dart
@@ -166,6 +166,7 @@ class _StaticMachineManagerService implements MachineManagerService {
     String? apiKey,
     String? name,
     bool? useSsl,
+    String? wsUrl,
   }) async {
     return Machine(
       id: 'recorded',

--- a/apps/mobile/test/workspace_shell_screen_test.dart
+++ b/apps/mobile/test/workspace_shell_screen_test.dart
@@ -258,6 +258,7 @@ class _StaticMachineManagerService implements MachineManagerService {
     String? apiKey,
     String? name,
     bool? useSsl,
+    String? wsUrl,
   }) async => Machine(
     id: 'recorded',
     host: host,

--- a/docs/design/linux-client-prd.md
+++ b/docs/design/linux-client-prd.md
@@ -1,0 +1,201 @@
+# Linux Desktop Client PRD
+
+## 背景
+
+CC Pocket 目前已有 iOS、Android、macOS client 和 Bridge Server。Linux 现在主要作为
+Bridge Server 的 host 使用，但还没有提供 Flutter client 的 Linux desktop 版本。
+
+`apps/mobile` 已经具备一部分 desktop 适配能力，包括 adaptive workspace 和
+`TargetPlatform.linux` 判断。缺口主要在两类地方：
+
+- `apps/mobile/linux/` Flutter 平台工程尚未生成。
+- 少数移动端或 macOS 相关插件没有 Linux 实现，需要在 Linux 上降级或禁用。
+
+## 目标
+
+第一阶段目标是做出最小可用 Linux client：
+
+- Linux 上能 build 和 launch。
+- 能连接现有 Bridge Server。
+- 能启动 / 继续 Codex 或 Claude session。
+- 能处理消息、流式输出、审批、AskUserQuestion、Diff、Explorer 等核心工作流。
+
+## 非目标
+
+- 第一版不追求与 iOS / Android / macOS 完全等价。
+- 第一版不正式支持 FCM push、RevenueCat purchase、QR camera scan、Shorebird OTA。
+- 本 PRD 不覆盖 Linux Bridge Server / systemd host 的改造。
+- 第一版不要求 AppImage、deb、rpm 等正式安装包。
+
+## 当前判断
+
+- 当前机器的 Flutter Linux toolchain 可用。
+- Flutter 能识别 `Linux (desktop)` 设备。
+- `apps/mobile/linux/` 当前不存在。
+- 核心通信是 Dart WebSocket / HTTP，天然跨平台。
+- 主要 UI 已经有 tablet / macOS / Linux desktop layout 判断。
+- 最大风险来自插件支持，而不是业务逻辑或 UI 重写。
+
+## 插件风险表
+
+| 功能 | 当前 package | Linux 状态 | 最小 client 处理 |
+|---|---|---|---|
+| WebSocket / HTTP | Dart packages | 可用 | 直接使用 |
+| Settings | `shared_preferences` | 可用 | 直接使用 |
+| SSH credentials | `flutter_secure_storage` | 可用 | 直接使用 |
+| mDNS discovery | `bonsoir_linux` | 可用 | 直接使用 |
+| Deep links | `app_links_linux` | 可用 | 直接使用 |
+| File/image picker | `image_picker_linux` | 可用 | 直接使用 |
+| Clipboard / drag-drop | `super_native_extensions` | 可用 | 直接使用 |
+| Local DB | `sqflite` | 无 Linux backend | Phase 1 no-op，Phase 2 接 `sqflite_common_ffi` |
+| FCM push | `firebase_messaging` | 无 Linux 实现 | Linux 禁用 |
+| QR camera scan | `mobile_scanner` | 无 Linux 实现 | Linux 隐藏入口或提示手动输入 |
+| Voice input | `speech_to_text` | desktop 不作为核心能力 | 沿用现有 desktop 禁用 |
+| RevenueCat | `purchases_flutter` | Linux 不支持购买 | Linux 显示 unavailable |
+| Shorebird OTA | `shorebird_code_push` | mobile only | Linux 禁用 |
+| Local notifications | `flutter_local_notifications_linux` | 可用 | Phase 1 最小处理，Phase 2 polish |
+
+## Phase 1: 最小 Linux Client
+
+目标：Linux 上可以启动 client，并完成 Bridge 连接和主要 session 操作。
+
+### 功能要求
+
+- Linux desktop app 可以启动。
+- 可以通过手动 URL 连接 Bridge Server。
+- 可以通过 saved machines 连接。
+- mDNS discovery 可用时可以展示发现到的 Bridge。
+- 可以 start / resume Codex 和 Claude session。
+- 可以发送用户输入。
+- 可以显示 assistant message、stream delta、tool result。
+- 可以处理 approve / reject / AskUserQuestion answer。
+- Git diff、Explorer、Gallery 等 Bridge 侧功能保持可用。
+- SSH remote start / stop / update 保持现有 Dart SSH 能力，不额外扩展。
+
+### 降级功能
+
+- Linux 不显示 QR camera scan 入口，或者明确引导手动输入 URL。
+- Linux 不注册 FCM token，不初始化 Firebase Messaging handler。
+- Linux 不执行 Shorebird update。
+- Linux 不提供 RevenueCat purchase flow。
+- Prompt history local DB 在 Phase 1 可以 no-op，但不能导致 app crash。
+
+### 实施步骤
+
+1. 在 `apps/mobile` 下生成 Linux 平台工程：`flutter create --platforms=linux .`
+2. 确认 `.metadata` 包含 Linux platform migration。
+3. 运行 Linux build，收集编译错误。
+4. 对 Linux 不支持的插件调用加 platform guard。
+5. 在 Linux 隐藏 QR scan button / route 入口。
+6. 在 Linux 跳过 FCM background / foreground handler registration。
+7. 如 local notification 在 Linux 初始化时报错，Phase 1 先 no-op 化。
+8. 运行 `flutter run -d linux`，通过手动 URL 连接 Bridge。
+9. 做最小 smoke：session start、message send、approval、diff / Explorer。
+
+### 验收标准
+
+- `flutter build linux --debug` 通过。
+- `flutter run -d linux` 可以启动。
+- 手动 URL 可以连接 Bridge。
+- 可以启动一个 Codex session 并收到 assistant response。
+- approval request 可以展示，并能 approve 或 reject。
+- Linux 不支持功能不会造成 runtime crash。
+
+## Phase 2: Desktop Parity
+
+目标：让 Linux desktop client 达到日常可用质量。
+
+### 功能要求
+
+- 用 `sqflite_common_ffi` 支持 Linux prompt history cache。
+- 完成 Linux local notification 初始化和展示验证。
+- 验证 `app_links_linux` deep link 行为。
+- 验证 image picker、clipboard image paste、drag-and-drop。
+- 清理 macOS 专属 banner / settings 在 Linux 上的展示。
+- 检查 desktop keyboard shortcut 和窗口尺寸下的布局。
+
+### 实施步骤
+
+1. 加入 `sqflite_common_ffi`，只在 Linux 初始化 database factory。
+2. 为 `NotificationService` 补 Linux initialization / details。
+3. 用测试固定 macOS native app banner 不在 Linux 显示。
+4. 改善 QR scan 的替代入口，例如 paste connection URL。
+5. 运行 `dart analyze apps/mobile` 和 Linux 启动验证。
+6. 手动验证 chat、Git、Explorer、settings 主要页面。
+
+### 验收标准
+
+- Linux prompt history 可以持久化。
+- Linux local notification 不 crash，至少能显示基础通知。
+- macOS 专属 UI 不在 Linux 误展示。
+- desktop 主要页面没有明显布局崩坏。
+
+## Phase 3: Distribution
+
+目标：产出可分发的 Linux client。
+
+### 功能要求
+
+- 可以生成 release build。
+- app icon、desktop entry、app name 正确。
+- 至少提供 tarball，后续可加 AppImage。
+- GitHub Releases 可以附加 Linux artifact。
+
+### 实施步骤
+
+1. 跑通 `flutter build linux --release`。
+2. 调整 Linux icon / metadata / desktop file。
+3. 添加 tarball packaging script。
+4. 如需要，添加 AppImage packaging。
+5. 添加 GitHub Actions Linux build job。
+6. 更新 README 和 install page。
+
+### 验收标准
+
+- clean checkout 可以生成 Linux release artifact。
+- artifact 解压后可以启动 app。
+- GitHub Releases 可以发布 Linux build。
+
+## 验证计划
+
+Phase 1:
+
+- `flutter build linux --debug`
+- `flutter run -d linux`
+- 手动 Bridge 连接
+- Codex session smoke test
+- approval flow smoke test
+- Explorer / Git diff smoke test
+
+Phase 2:
+
+- `dart analyze apps/mobile`
+- `cd apps/mobile && flutter test`
+- Linux desktop 手动 UI 检查
+- prompt history persistence 检查
+- local notification 检查
+
+Phase 3:
+
+- `flutter build linux --release`
+- release artifact 启动检查
+- clean machine dependency 检查
+
+## 未决问题
+
+- Linux desktop client 是正式 release，还是先标记 experimental。
+- 第一种发布格式选 tarball 还是 AppImage。
+- Linux 上 Supporter / purchase 是完全隐藏，还是显示 unavailable 说明。
+- QR scan 的替代是否只做 manual URL，还是增加从图片文件 decode QR。
+
+## 推荐第一版 PR Scope
+
+第一版只做 Phase 1：
+
+- 生成 `apps/mobile/linux/`。
+- 给不支持 Linux 的 service / route 加 guard。
+- Linux 隐藏 QR camera scan。
+- 保证 build 和 launch。
+- 验证手动 Bridge 连接和一个 Codex session smoke path。
+
+这样可以最快确认 Linux client 的可行性，并把 polish 和 packaging 分离到后续 PR。


### PR DESCRIPTION
## Summary

  This PR adds the Phase 1 Linux desktop scaffold for the Flutter client, scopes Rust prebuilt artifacts to Android release workflows, and fixes Bridge URL persistence so path-prefixed WebSocket endpoints keep working across
  saves, reconnects, and health checks.

  ## Why This Is A PR

  - Why PR instead of Issue / Prompt Request first: The work is already reduced to a reviewable vertical slice with code, tests, and a follow-up plan in docs/design/linux-client-prd.md; the CI and URL fixes were found while
    making the Linux client scaffold usable.
  - Related Issue / Prompt Request: [None linked](https://github.com/K9i-0/ccpocket/issues/86).
  - Base PR (if stacked on another open PR): None.

  ## Changes

  - Add the Linux desktop Flutter scaffold under apps/mobile/linux/ and document the rollout plan in docs/design/linux-client-prd.md.
  - Guard Linux-unsupported mobile features by disabling FCM initialization off iOS/Android, adding a manual URL fallback for QR scan on desktop, and wiring Linux local notification initialization.
  - Change apps/mobile/cargokit_options.yaml to default to local Rust builds for development, and explicitly enable precompiled Rust artifacts only inside Android release/patch workflows.
  - Preserve full Bridge WebSocket URLs, including path/query prefixes, when saving machines, reconnecting, deriving HTTP endpoints, and appending auth tokens.
  - Add regression coverage for Linux desktop fallbacks and path-prefixed Bridge URLs.

  ## Scope Check

  - Single primary goal of this PR: Make the Linux desktop client bring-up reviewable without regressing existing Bridge connectivity or Android release CI.
  - What is intentionally out of scope: Linux feature parity beyond scaffold/guards, packaged Linux distribution, FCM on Linux, QR camera support on desktop, RevenueCat/Shorebird Linux support, and prompt-history DB parity.
  - Can this be split into smaller PRs? If not, why not: It could technically be split into a Linux scaffold PR and a Bridge URL fix PR, but the three commits are small follow-up changes discovered during the same Linux bring-up
    and together form one usable slice.

  ## Test plan

  - [x] Bridge Server tests pass (npm run test:bridge)
  - [x] Flutter tests pass (cd apps/mobile && flutter test)
  - [x] Manual testing done

  ## Platform validation

  - Target platform: Linux desktop client scaffold, plus Android release/patch CI workflows
  - Platform version: Linux desktop host not captured in this session; Android CI runs on ubuntu-latest
  - What I validated on that platform: Tested on Linux Mint 22.3. Ran Flutter tests including linux_desktop_client_test.dart and bridge_connection_path_test.dart; reviewed Android workflow changes statically
  - Logs / screenshots / notes: flutter test passed locally (1168 tests passed, 4 skipped).

<img width="2242" height="1239" alt="image" src="https://github.com/user-attachments/assets/2d8ea42a-9640-4bd2-b4cb-3ea8439b67a1" />


  ## Notes

  No protocol changes or migration steps are required. Saved machine entries now preserve custom Bridge path/query prefixes while still stripping transient token parameters before persistence.
