### PR TITLE
feat(bridge): support Codex shared app-server co-presence

### DIFF
--- a/packages/bridge/src/cli.ts
+++ b/packages/bridge/src/cli.ts
@@ -46,6 +46,9 @@ if (subcommand === "doctor") {
     host: parseFlag("host"),
     apiKey: parseFlag("api-key"),
     publicWsUrl: parseFlag("public-ws-url"),
+    codexAppServerMode: parseFlag("codex-app-server-mode"),
+    codexAppServerPort: parseFlag("codex-app-server-port"),
+    codexAppServerUrl: parseFlag("codex-app-server-url"),
   };
 
   if (platform() === "darwin") {
@@ -78,11 +81,23 @@ if (subcommand === "doctor") {
   const host = parseFlag("host");
   const apiKey = parseFlag("api-key");
   const publicWsUrl = parseFlag("public-ws-url");
+  const codexAppServerMode = parseFlag("codex-app-server-mode");
+  const codexAppServerPort = parseFlag("codex-app-server-port");
+  const codexAppServerUrl = parseFlag("codex-app-server-url");
 
   if (port) process.env.BRIDGE_PORT = port;
   if (host) process.env.BRIDGE_HOST = host;
   if (apiKey) process.env.BRIDGE_API_KEY = apiKey;
   if (publicWsUrl) process.env.BRIDGE_PUBLIC_WS_URL = publicWsUrl;
+  if (codexAppServerMode) {
+    process.env.BRIDGE_CODEX_APP_SERVER_MODE = codexAppServerMode;
+  }
+  if (codexAppServerPort) {
+    process.env.BRIDGE_CODEX_APP_SERVER_PORT = codexAppServerPort;
+  }
+  if (codexAppServerUrl) {
+    process.env.BRIDGE_CODEX_APP_SERVER_URL = codexAppServerUrl;
+  }
   if (hasFlag("no-mdns")) process.env.BRIDGE_DISABLE_MDNS = "1";
 
   startServer();

--- a/packages/bridge/src/codex-app-server-config.ts
+++ b/packages/bridge/src/codex-app-server-config.ts
@@ -1,0 +1,8 @@
+const DEFAULT_CODEX_APP_SERVER_PORT = "8767";
+const FALLBACK_CODEX_APP_SERVER_PORT = "8768";
+
+export function defaultCodexAppServerPort(bridgePort?: string): string {
+  return bridgePort?.trim() === DEFAULT_CODEX_APP_SERVER_PORT
+    ? FALLBACK_CODEX_APP_SERVER_PORT
+    : DEFAULT_CODEX_APP_SERVER_PORT;
+}

--- a/packages/bridge/src/codex-process.test.ts
+++ b/packages/bridge/src/codex-process.test.ts
@@ -37,6 +37,29 @@ vi.mock("node:child_process", () => ({
 }));
 
 import { buildCodexSpawnSpec, CodexProcess } from "./codex-process.js";
+import { stopManagedCodexAppServers } from "./codex-transport.js";
+
+const originalCodexAppServerEnv = {
+  bridgePort: process.env.BRIDGE_PORT,
+  mode: process.env.BRIDGE_CODEX_APP_SERVER_MODE,
+  port: process.env.BRIDGE_CODEX_APP_SERVER_PORT,
+  url: process.env.BRIDGE_CODEX_APP_SERVER_URL,
+};
+
+function restoreCodexAppServerEnv(): void {
+  restoreEnvVar("BRIDGE_PORT", originalCodexAppServerEnv.bridgePort);
+  restoreEnvVar("BRIDGE_CODEX_APP_SERVER_MODE", originalCodexAppServerEnv.mode);
+  restoreEnvVar("BRIDGE_CODEX_APP_SERVER_PORT", originalCodexAppServerEnv.port);
+  restoreEnvVar("BRIDGE_CODEX_APP_SERVER_URL", originalCodexAppServerEnv.url);
+}
+
+function restoreEnvVar(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key];
+    return;
+  }
+  process.env[key] = value;
+}
 
 describe("CodexProcess (app-server)", () => {
   beforeEach(() => {
@@ -50,11 +73,31 @@ describe("CodexProcess (app-server)", () => {
   });
 
   afterEach(() => {
+    stopManagedCodexAppServers();
+    restoreCodexAppServerEnv();
     for (const child of fakeChildren) {
       if (!child.killed) {
         child.kill();
       }
     }
+  });
+
+  it("moves the default managed app-server port when Bridge uses 8767", () => {
+    process.env.BRIDGE_PORT = "8767";
+    process.env.BRIDGE_CODEX_APP_SERVER_MODE = "managed";
+    delete process.env.BRIDGE_CODEX_APP_SERVER_PORT;
+    delete process.env.BRIDGE_CODEX_APP_SERVER_URL;
+
+    const proc = new CodexProcess("linux");
+    proc.start("/tmp/project-managed-port");
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      "codex",
+      ["app-server", "--listen", "ws://127.0.0.1:8768"],
+      expect.objectContaining({ cwd: "/tmp/project-managed-port" }),
+    );
+
+    proc.stop();
   });
 
   it("starts codex app-server and sends initialize + thread/start", async () => {
@@ -133,6 +176,40 @@ describe("CodexProcess (app-server)", () => {
     );
 
     proc.stop();
+  });
+
+  it("handles managed app-server spawn errors without crashing", () => {
+    process.env.BRIDGE_CODEX_APP_SERVER_MODE = "managed";
+    process.env.BRIDGE_CODEX_APP_SERVER_URL = "ws://127.0.0.1:18767";
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      const proc = new CodexProcess("linux");
+      proc.start("/tmp/project-managed-error");
+
+      expect(spawnMock).toHaveBeenCalledWith(
+        "codex",
+        ["app-server", "--listen", "ws://127.0.0.1:18767"],
+        expect.objectContaining({ cwd: "/tmp/project-managed-error" }),
+      );
+
+      expect(() => {
+        fakeChildren[0].emit("error", new Error("spawn failed"));
+      }).not.toThrow();
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        "[codex-app-server] Failed to start: spawn failed",
+      );
+
+      const nextProc = new CodexProcess("linux");
+      nextProc.start("/tmp/project-managed-error-next");
+      expect(spawnMock).toHaveBeenCalledTimes(2);
+
+      proc.stop();
+      nextProc.stop();
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 
   it("falls back to requested approval reviewer in init when thread response omits it", async () => {
@@ -532,6 +609,164 @@ describe("CodexProcess (app-server)", () => {
     const initialized = nextOutgoingNotification(child);
     expect(initialized.method).toBe("initialized");
     expect(() => nextOutgoingRequest(child)).toThrow();
+
+    proc.stop();
+  });
+
+  it("emits user_input for app-server user items from another client", async () => {
+    const proc = new CodexProcess("linux");
+    const messages: unknown[] = [];
+    proc.on("message", (msg) => messages.push(msg));
+
+    proc.start("/tmp/project-copresence");
+    const child = fakeChildren[0];
+    await tick();
+
+    const initReq = nextOutgoingRequest(child);
+    child.stdout.emit(
+      "data",
+      `${JSON.stringify({ id: initReq.id, result: {} })}\n`,
+    );
+    await tick();
+    nextOutgoingNotification(child);
+    const startReq = nextOutgoingRequest(child);
+    child.stdout.emit(
+      "data",
+      `${JSON.stringify({
+        id: startReq.id,
+        result: { thread: { id: "thr_copresence" } },
+      })}\n`,
+    );
+    await tick();
+
+    child.stdout.emit(
+      "data",
+      `${JSON.stringify({
+        method: "item/completed",
+        params: {
+          threadId: "thr_copresence",
+          item: {
+            id: "user_1",
+            type: "user_message",
+            content: [{ type: "text", text: "sent from terminal" }],
+            timestamp: "2026-05-12T10:00:00.000Z",
+          },
+        },
+      })}\n`,
+    );
+    await tick();
+
+    expect(messages).toContainEqual({
+      type: "user_input",
+      text: "sent from terminal",
+      userMessageUuid: "user_1",
+      timestamp: "2026-05-12T10:00:00.000Z",
+    });
+
+    proc.stop();
+  });
+
+  it("ignores app-server notifications for other threads", async () => {
+    const proc = new CodexProcess("linux");
+    const messages: unknown[] = [];
+    proc.on("message", (msg) => messages.push(msg));
+
+    proc.start("/tmp/project-thread-filter");
+    const child = fakeChildren[0];
+    await tick();
+
+    const initReq = nextOutgoingRequest(child);
+    child.stdout.emit(
+      "data",
+      `${JSON.stringify({ id: initReq.id, result: {} })}\n`,
+    );
+    await tick();
+    nextOutgoingNotification(child);
+    const startReq = nextOutgoingRequest(child);
+    child.stdout.emit(
+      "data",
+      `${JSON.stringify({
+        id: startReq.id,
+        result: {
+          thread: {
+            id: "thr_self",
+            agentNickname: "self-agent",
+            agentRole: "primary",
+          },
+        },
+      })}\n`,
+    );
+    await tick();
+
+    expect(proc.sessionId).toBe("thr_self");
+    expect(proc.agentNickname).toBe("self-agent");
+    expect(proc.agentRole).toBe("primary");
+
+    child.stdout.emit(
+      "data",
+      `${JSON.stringify({
+        method: "thread/started",
+        params: {
+          threadId: "thr_other",
+          thread: {
+            id: "thr_other",
+            agentNickname: "other-agent",
+            agentRole: "secondary",
+          },
+        },
+      })}\n`,
+    );
+    child.stdout.emit(
+      "data",
+      `${JSON.stringify({
+        method: "turn/started",
+        params: { threadId: "thr_other", turn: { id: "turn_other" } },
+      })}\n`,
+    );
+    child.stdout.emit(
+      "data",
+      `${JSON.stringify({
+        method: "item/completed",
+        params: {
+          threadId: "thr_other",
+          item: {
+            id: "user_other",
+            type: "userMessage",
+            content: [{ type: "text", text: "foreign input" }],
+          },
+        },
+      })}\n`,
+    );
+    await tick();
+
+    expect(proc.sessionId).toBe("thr_self");
+    expect(proc.agentNickname).toBe("self-agent");
+    expect(proc.agentRole).toBe("primary");
+    expect(messages).not.toContainEqual(
+      expect.objectContaining({ text: "foreign input" }),
+    );
+
+    child.stdout.emit(
+      "data",
+      `${JSON.stringify({
+        method: "item/completed",
+        params: {
+          threadId: "thr_self",
+          item: {
+            id: "user_self",
+            type: "userMessage",
+            content: [{ type: "text", text: "own input" }],
+          },
+        },
+      })}\n`,
+    );
+    await tick();
+
+    expect(messages).toContainEqual({
+      type: "user_input",
+      text: "own input",
+      userMessageUuid: "user_self",
+    });
 
     proc.stop();
   });
@@ -1875,7 +2110,7 @@ describe("CodexProcess (app-server)", () => {
     const child = new FakeChildProcess();
     fakeChildren.push(child);
     const internal = proc as any;
-    internal.child = child;
+    attachFakeTransport(internal, child);
     internal._projectPath = "/tmp/project-completions";
     const emitRpc = (message: Record<string, unknown>) => {
       internal.handleStdoutChunk(`${JSON.stringify(message)}\n`);
@@ -1937,7 +2172,7 @@ describe("CodexProcess (app-server)", () => {
     const messages: unknown[] = [];
     proc.on("message", (msg) => messages.push(msg));
     const internal = proc as any;
-    internal.child = child;
+    attachFakeTransport(internal, child);
     internal._projectPath = "/tmp/project-plugins";
     const emitRpc = (message: Record<string, unknown>) => {
       internal.handleStdoutChunk(`${JSON.stringify(message)}\n`);
@@ -2025,7 +2260,7 @@ describe("CodexProcess (app-server)", () => {
     const messages: unknown[] = [];
     proc.on("message", (msg) => messages.push(msg));
     const internal = proc as any;
-    internal.child = child;
+    attachFakeTransport(internal, child);
     internal._projectPath = "/tmp/project-plugin-error";
     const emitRpc = (message: Record<string, unknown>) => {
       internal.handleStdoutChunk(`${JSON.stringify(message)}\n`);
@@ -2182,6 +2417,22 @@ function nextOutgoingResponse(
       value.result !== undefined &&
       value.method === undefined,
   );
+}
+
+function attachFakeTransport(
+  internal: { transport?: unknown },
+  child: FakeChildProcess,
+): void {
+  internal.transport = {
+    isRunning: true,
+    write(envelope: Record<string, unknown>) {
+      child.stdin.write(`${JSON.stringify(envelope)}\n`);
+    },
+    stop() {},
+    on() {
+      return this;
+    },
+  };
 }
 
 async function tick(): Promise<void> {

--- a/packages/bridge/src/codex-process.ts
+++ b/packages/bridge/src/codex-process.ts
@@ -3,9 +3,15 @@ import { randomUUID } from "node:crypto";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { rm, writeFile } from "node:fs/promises";
-import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import type { ServerMessage, ProcessStatus } from "./parser.js";
+import {
+  createCodexTransport,
+  buildCodexSpawnSpec,
+  type CodexTransport,
+} from "./codex-transport.js";
 import { resolvePlatformPath } from "./path-utils.js";
+
+export { buildCodexSpawnSpec };
 
 const DEFAULT_CODEX_MODEL = "gpt-5.5";
 const COMPLETION_FETCH_COOLDOWN_MS = 1000;
@@ -178,47 +184,8 @@ interface CodexModelListResponse {
   nextCursor?: unknown;
 }
 
-export function buildCodexSpawnSpec(
-  projectPath: string,
-  platform: NodeJS.Platform = process.platform,
-): {
-  command: string;
-  args: string[];
-  options: {
-    cwd: string;
-    stdio: "pipe";
-    env: NodeJS.ProcessEnv;
-    windowsVerbatimArguments?: boolean;
-  };
-} {
-  const cwd = resolvePlatformPath(projectPath, platform);
-
-  if (platform === "win32") {
-    return {
-      command: "cmd.exe",
-      args: ["/d", "/s", "/c", "codex app-server --listen stdio://"],
-      options: {
-        cwd,
-        stdio: "pipe",
-        env: process.env,
-        windowsVerbatimArguments: true,
-      },
-    };
-  }
-
-  return {
-    command: "codex",
-    args: ["app-server", "--listen", "stdio://"],
-    options: {
-      cwd,
-      stdio: "pipe",
-      env: process.env,
-    },
-  };
-}
-
 export class CodexProcess extends EventEmitter<CodexProcessEvents> {
-  private child: ChildProcessWithoutNullStreams | null = null;
+  private transport: CodexTransport | null = null;
   private _status: ProcessStatus = "starting";
   private _threadId: string | null = null;
   private _agentNickname: string | null = null;
@@ -315,7 +282,7 @@ export class CodexProcess extends EventEmitter<CodexProcessEvents> {
   }
 
   get isRunning(): boolean {
-    return this.child !== null;
+    return this.transport?.isRunning ?? false;
   }
 
   get approvalPolicy(): string {
@@ -516,7 +483,7 @@ export class CodexProcess extends EventEmitter<CodexProcessEvents> {
   }
 
   start(projectPath: string, options?: CodexStartOptions): void {
-    if (this.child) {
+    if (this.transport) {
       this.stop();
     }
 
@@ -527,7 +494,7 @@ export class CodexProcess extends EventEmitter<CodexProcessEvents> {
   }
 
   async initializeOnly(projectPath: string): Promise<void> {
-    if (this.child) {
+    if (this.transport) {
       this.stop();
     }
     this.prepareLaunch(projectPath);
@@ -549,9 +516,9 @@ export class CodexProcess extends EventEmitter<CodexProcessEvents> {
     this.cleanupSteerTempPaths();
     this.rejectAllPending(new Error("stopped"));
 
-    if (this.child) {
-      this.child.kill("SIGTERM");
-      this.child = null;
+    if (this.transport) {
+      this.transport.stop();
+      this.transport = null;
     }
 
     this.setStatus("idle");
@@ -589,32 +556,25 @@ export class CodexProcess extends EventEmitter<CodexProcessEvents> {
     projectPath: string,
     options?: CodexStartOptions,
   ): void {
-    const spawnSpec = buildCodexSpawnSpec(projectPath, this.platform);
     console.log(
-      `[codex-process] Starting app-server (cwd: ${spawnSpec.options.cwd}, sandbox: ${options?.sandboxMode ?? "workspace-write"}, approval: ${options?.approvalPolicy ?? "never"}, reviewer: ${this.approvalsReviewer}, model: ${options?.model ?? "default"}, collaboration: ${this._collaborationMode})`,
+      `[codex-process] Starting app-server (cwd: ${projectPath}, sandbox: ${options?.sandboxMode ?? "workspace-write"}, approval: ${options?.approvalPolicy ?? "never"}, reviewer: ${this.approvalsReviewer}, model: ${options?.model ?? "default"}, collaboration: ${this._collaborationMode})`,
     );
 
-    const child = spawn(
-      spawnSpec.command,
-      spawnSpec.args,
-      spawnSpec.options,
-    );
-    this.child = child;
+    const transport = createCodexTransport(projectPath, this.platform);
+    this.transport = transport;
 
-    child.stdout.setEncoding("utf8");
-    child.stdout.on("data", (chunk: string) => {
+    transport.on("data", (chunk: string) => {
       this.handleStdoutChunk(chunk);
     });
 
-    child.stderr.setEncoding("utf8");
-    child.stderr.on("data", (chunk: string) => {
+    transport.on("log", (chunk: string) => {
       const line = chunk.trim();
       if (line) {
         console.log(`[codex-process] stderr: ${line}`);
       }
     });
 
-    child.on("error", (err) => {
+    transport.on("error", (err) => {
       if (this.stopped) return;
       console.error("[codex-process] app-server process error:", err);
       this.emitMessage({
@@ -625,9 +585,9 @@ export class CodexProcess extends EventEmitter<CodexProcessEvents> {
       this.emit("exit", 1);
     });
 
-    child.on("exit", (code) => {
+    transport.on("exit", (code) => {
       const exitCode = code ?? 0;
-      this.child = null;
+      this.transport = null;
       this.rejectAllPending(new Error("codex app-server exited"));
       if (!this.stopped && exitCode !== 0) {
         this.emitMessage({
@@ -638,6 +598,8 @@ export class CodexProcess extends EventEmitter<CodexProcessEvents> {
       this.setStatus("idle");
       this.emit("exit", code);
     });
+
+    transport.start(projectPath);
   }
 
   interrupt(): void {
@@ -1131,6 +1093,8 @@ export class CodexProcess extends EventEmitter<CodexProcessEvents> {
       }
 
       this._threadId = threadId;
+      this._agentNickname = stringOrNull(thread?.agentNickname);
+      this._agentRole = stringOrNull(thread?.agentRole);
       this.emitMessage({
         type: "system",
         subtype: "init",
@@ -1837,6 +1801,8 @@ export class CodexProcess extends EventEmitter<CodexProcessEvents> {
     method: string,
     params: Record<string, unknown>,
   ): void {
+    if (this.isForeignThreadNotification(method, params)) return;
+
     switch (method) {
       case "thread/started": {
         const thread = params.thread as Record<string, unknown> | undefined;
@@ -1977,6 +1943,22 @@ export class CodexProcess extends EventEmitter<CodexProcessEvents> {
       default:
         break;
     }
+  }
+
+  private isForeignThreadNotification(
+    method: string,
+    params: Record<string, unknown>,
+  ): boolean {
+    if (!isThreadScopedNotification(method)) return false;
+    const threadId = notificationThreadId(params);
+    if (!threadId) return false;
+
+    // Thread binding comes from the thread/start or thread/resume response.
+    // In shared app-server modes, early notifications can belong to another
+    // client, so explicit-thread notifications are ignored until this process
+    // has its own authoritative thread id.
+    if (!this._threadId) return true;
+    return threadId !== this._threadId;
   }
 
   private handleTurnCompleted(turn: Record<string, unknown> | undefined): void {
@@ -2218,6 +2200,22 @@ export class CodexProcess extends EventEmitter<CodexProcessEvents> {
             model: this.getMessageModel(),
           },
         });
+        break;
+      }
+
+      case "user":
+      case "usermessage":
+      case "userinput": {
+        const text = extractUserText(item);
+        if (!text) return;
+        this.emitMessage({
+          type: "user_input",
+          text,
+          userMessageUuid: itemId,
+          ...(typeof item.timestamp === "string"
+            ? { timestamp: item.timestamp }
+            : {}),
+        } as ServerMessage);
         break;
       }
 
@@ -2485,11 +2483,10 @@ export class CodexProcess extends EventEmitter<CodexProcessEvents> {
   }
 
   private writeEnvelope(envelope: Record<string, unknown>): void {
-    if (!this.child || this.child.killed) {
+    if (!this.transport || !this.transport.isRunning) {
       throw new Error("codex app-server is not running");
     }
-    const line = `${JSON.stringify(envelope)}\n`;
-    this.child.stdin.write(line);
+    this.transport.write(envelope);
   }
 
   private rejectAllPending(error: Error): void {
@@ -2785,6 +2782,33 @@ function normalizeItemType(raw: unknown): string {
   return raw.replace(/[_\s-]/g, "").toLowerCase();
 }
 
+function isThreadScopedNotification(method: string): boolean {
+  return (
+    method.startsWith("thread/") ||
+    method.startsWith("turn/") ||
+    method.startsWith("item/") ||
+    method === "serverRequest/resolved"
+  );
+}
+
+function notificationThreadId(params: Record<string, unknown>): string | null {
+  if (typeof params.threadId === "string") return params.threadId;
+
+  const thread = params.thread;
+  if (thread && typeof thread === "object") {
+    const id = (thread as Record<string, unknown>).id;
+    if (typeof id === "string") return id;
+  }
+
+  const turn = params.turn;
+  if (turn && typeof turn === "object") {
+    const id = (turn as Record<string, unknown>).threadId;
+    if (typeof id === "string") return id;
+  }
+
+  return null;
+}
+
 function numberOrUndefined(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value)
     ? value
@@ -3073,6 +3097,12 @@ function extractAgentText(item: Record<string, unknown>): string {
   }
 
   return "";
+}
+
+function extractUserText(item: Record<string, unknown>): string {
+  if (typeof item.text === "string") return item.text;
+  if (typeof item.message === "string") return item.message;
+  return extractAgentText(item);
 }
 
 function extractReasoningText(item: Record<string, unknown>): string {

--- a/packages/bridge/src/codex-transport.ts
+++ b/packages/bridge/src/codex-transport.ts
@@ -1,0 +1,317 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { resolvePlatformPath } from "./path-utils.js";
+import { defaultCodexAppServerPort } from "./codex-app-server-config.js";
+import WebSocket from "ws";
+
+export type CodexAppServerMode = "private" | "managed" | "external";
+
+export interface CodexTransportEvents {
+  data: [string];
+  log: [string];
+  error: [Error];
+  exit: [number | null];
+}
+
+export abstract class CodexTransport extends EventEmitter<CodexTransportEvents> {
+  abstract start(projectPath: string): void;
+  abstract write(envelope: Record<string, unknown>): void;
+  abstract stop(): void;
+  abstract get isRunning(): boolean;
+}
+
+export function buildCodexSpawnSpec(
+  projectPath: string,
+  platform: NodeJS.Platform = process.platform,
+): {
+  command: string;
+  args: string[];
+  options: {
+    cwd: string;
+    stdio: "pipe";
+    env: NodeJS.ProcessEnv;
+    windowsVerbatimArguments?: boolean;
+  };
+} {
+  const cwd = resolvePlatformPath(projectPath, platform);
+
+  if (platform === "win32") {
+    return {
+      command: "cmd.exe",
+      args: ["/d", "/s", "/c", "codex app-server --listen stdio://"],
+      options: {
+        cwd,
+        stdio: "pipe",
+        env: process.env,
+        windowsVerbatimArguments: true,
+      },
+    };
+  }
+
+  return {
+    command: "codex",
+    args: ["app-server", "--listen", "stdio://"],
+    options: {
+      cwd,
+      stdio: "pipe",
+      env: process.env,
+    },
+  };
+}
+
+class StdioCodexTransport extends CodexTransport {
+  private child: ChildProcessWithoutNullStreams | null = null;
+
+  constructor(private readonly platform: NodeJS.Platform) {
+    super();
+  }
+
+  get isRunning(): boolean {
+    return this.child !== null && !this.child.killed;
+  }
+
+  start(projectPath: string): void {
+    const spawnSpec = buildCodexSpawnSpec(projectPath, this.platform);
+    const child = spawn(spawnSpec.command, spawnSpec.args, spawnSpec.options);
+    this.child = child;
+
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      this.emit("data", chunk);
+    });
+
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk: string) => {
+      const line = chunk.trim();
+      if (line) this.emit("log", line);
+    });
+
+    child.on("error", (err) => {
+      this.emit("error", err);
+    });
+
+    child.on("exit", (code) => {
+      this.child = null;
+      this.emit("exit", code ?? 0);
+    });
+  }
+
+  write(envelope: Record<string, unknown>): void {
+    if (!this.child || this.child.killed) {
+      throw new Error("codex app-server is not running");
+    }
+    this.child.stdin.write(`${JSON.stringify(envelope)}\n`);
+  }
+
+  stop(): void {
+    if (this.child) {
+      this.child.kill("SIGTERM");
+      this.child = null;
+    }
+  }
+}
+
+class WebSocketCodexTransport extends CodexTransport {
+  private ws: WebSocket | null = null;
+  private stopped = false;
+  private connected = false;
+  private queue: string[] = [];
+  private retryTimer: NodeJS.Timeout | null = null;
+  private firstAttemptAt = 0;
+
+  constructor(
+    private readonly url: string,
+    private readonly retryDurationMs = 0,
+  ) {
+    super();
+  }
+
+  get isRunning(): boolean {
+    return !this.stopped && (this.connected || this.ws !== null);
+  }
+
+  start(_projectPath: string): void {
+    this.stopped = false;
+    this.firstAttemptAt = Date.now();
+    this.connect();
+  }
+
+  write(envelope: Record<string, unknown>): void {
+    if (this.stopped) {
+      throw new Error("codex app-server is not running");
+    }
+    const payload = JSON.stringify(envelope);
+    if (this.connected && this.ws?.readyState === WebSocket.OPEN) {
+      this.ws.send(payload);
+      return;
+    }
+    this.queue.push(payload);
+  }
+
+  stop(): void {
+    this.stopped = true;
+    this.queue = [];
+    if (this.retryTimer) {
+      clearTimeout(this.retryTimer);
+      this.retryTimer = null;
+    }
+    if (this.ws) {
+      this.ws.close();
+      this.ws = null;
+    }
+  }
+
+  private connect(): void {
+    if (this.stopped) return;
+
+    const ws = new WebSocket(this.url);
+    this.ws = ws;
+
+    ws.on("open", () => {
+      this.connected = true;
+      const queued = this.queue.splice(0);
+      for (const payload of queued) {
+        ws.send(payload);
+      }
+    });
+
+    ws.on("message", (data) => {
+      const text = data.toString();
+      this.emit("data", text.endsWith("\n") ? text : `${text}\n`);
+    });
+
+    ws.on("error", (err) => {
+      if (this.shouldRetry()) return;
+      this.emit("error", err instanceof Error ? err : new Error(String(err)));
+    });
+
+    ws.on("close", () => {
+      this.connected = false;
+      this.ws = null;
+      if (this.stopped) return;
+      if (this.shouldRetry()) {
+        this.retryTimer = setTimeout(() => this.connect(), 100);
+        return;
+      }
+      this.emit("exit", 1);
+    });
+  }
+
+  private shouldRetry(): boolean {
+    return (
+      !this.stopped &&
+      this.retryDurationMs > 0 &&
+      Date.now() - this.firstAttemptAt < this.retryDurationMs
+    );
+  }
+}
+
+class ManagedCodexAppServer {
+  private child: ChildProcessWithoutNullStreams | null = null;
+
+  constructor(
+    private readonly url: string,
+    private readonly platform: NodeJS.Platform,
+  ) {}
+
+  ensureStarted(projectPath: string): void {
+    if (this.child && !this.child.killed) return;
+
+    const cwd = resolvePlatformPath(projectPath, this.platform);
+    const child =
+      this.platform === "win32"
+        ? spawn(
+            "cmd.exe",
+            ["/d", "/s", "/c", `codex app-server --listen ${this.url}`],
+            {
+              cwd,
+              stdio: "pipe",
+              env: process.env,
+              windowsVerbatimArguments: true,
+            },
+          )
+        : spawn("codex", ["app-server", "--listen", this.url], {
+            cwd,
+            stdio: "pipe",
+            env: process.env,
+          });
+
+    this.child = child;
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      const line = chunk.trim();
+      if (line) console.log(`[codex-app-server] ${line}`);
+    });
+    child.stderr.on("data", (chunk: string) => {
+      const line = chunk.trim();
+      if (line) console.log(`[codex-app-server] ${line}`);
+    });
+    child.on("error", (err) => {
+      if (this.child === child) {
+        this.child = null;
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`[codex-app-server] Failed to start: ${message}`);
+    });
+    child.on("exit", () => {
+      this.child = null;
+    });
+  }
+
+  createTransport(projectPath: string): CodexTransport {
+    this.ensureStarted(projectPath);
+    return new WebSocketCodexTransport(this.url, 5000);
+  }
+
+  stop(): void {
+    if (!this.child) return;
+    this.child.kill("SIGTERM");
+    this.child = null;
+  }
+}
+
+const managedServers = new Map<string, ManagedCodexAppServer>();
+
+export function createCodexTransport(
+  projectPath: string,
+  platform: NodeJS.Platform = process.platform,
+): CodexTransport {
+  const mode = readCodexAppServerMode();
+  if (mode === "external") {
+    return new WebSocketCodexTransport(readCodexAppServerUrl());
+  }
+  if (mode === "managed") {
+    const url = readCodexAppServerUrl();
+    let manager = managedServers.get(url);
+    if (!manager) {
+      manager = new ManagedCodexAppServer(url, platform);
+      managedServers.set(url, manager);
+    }
+    return manager.createTransport(projectPath);
+  }
+  return new StdioCodexTransport(platform);
+}
+
+export function stopManagedCodexAppServers(): void {
+  for (const manager of managedServers.values()) {
+    manager.stop();
+  }
+  managedServers.clear();
+}
+
+function readCodexAppServerMode(): CodexAppServerMode {
+  const raw = process.env.BRIDGE_CODEX_APP_SERVER_MODE;
+  if (raw === "managed" || raw === "external") return raw;
+  return "private";
+}
+
+function readCodexAppServerUrl(): string {
+  const explicit = process.env.BRIDGE_CODEX_APP_SERVER_URL?.trim();
+  if (explicit) return explicit;
+
+  const port =
+    process.env.BRIDGE_CODEX_APP_SERVER_PORT?.trim() ||
+    defaultCodexAppServerPort(process.env.BRIDGE_PORT);
+  return `ws://127.0.0.1:${port}`;
+}

--- a/packages/bridge/src/session.test.ts
+++ b/packages/bridge/src/session.test.ts
@@ -896,7 +896,7 @@ describe("SessionManager claude UUID backfill", () => {
     expect(merged?.text).toBe("check this screenshot");
   });
 
-  it("SDK echo merge works for text-only user_input (no imageCount)", () => {
+  it("SDK echo merge works for text-only user_input even when echo text changes", () => {
     const manager = new SessionManager(() => {});
     const sessionId = manager.create("/tmp/project-merge-text");
 
@@ -913,16 +913,223 @@ describe("SessionManager claude UUID backfill", () => {
     // SDK echo with UUID
     sdkInstances[0].emit("message", {
       type: "user_input",
-      text: "hello world",
+      text: "hello world normalized",
       userMessageUuid: "uuid-text",
     } as ServerMessage);
 
-    const merged = session.history.find(
-      (msg) => msg.type === "user_input" && "userMessageUuid" in msg,
-    ) as Record<string, unknown> | undefined;
+    const userInputs = session.history.filter((msg) => msg.type === "user_input");
+    expect(userInputs).toHaveLength(1);
+    const merged = userInputs[0] as Record<string, unknown> | undefined;
     expect(merged).toBeDefined();
     expect(merged?.userMessageUuid).toBe("uuid-text");
     expect(merged?.text).toBe("hello world");
+  });
+
+  it("merges Codex user echo when mobile placeholder has a synthetic UUID", () => {
+    const broadcasts: Array<{ id: string; msg: ServerMessage }> = [];
+    const manager = new SessionManager((id, msg) => {
+      broadcasts.push({ id, msg });
+    });
+    const sessionId = manager.create(
+      "/tmp/project-merge-codex",
+      undefined,
+      undefined,
+      undefined,
+      "codex",
+    );
+
+    const session = manager.get(sessionId);
+    expect(session).toBeDefined();
+    if (!session) return;
+
+    manager.appendHistory(sessionId, {
+      type: "user_input",
+      text: "sync this turn",
+      userMessageUuid: "codex:user-turn:1",
+      clientMessageId: "cm-codex-merge",
+    } as ServerMessage);
+
+    codexInstances[0].emit("message", {
+      type: "user_input",
+      text: "sync this turn",
+      userMessageUuid: "item-real-1",
+    } as ServerMessage);
+
+    let userInputs = session.history.filter(
+      (msg) => msg.type === "user_input",
+    );
+    expect(userInputs).toHaveLength(1);
+    expect(userInputs[0]).toMatchObject({
+      type: "user_input",
+      text: "sync this turn",
+      userMessageUuid: "codex:user-turn:1",
+      clientMessageId: "cm-codex-merge",
+    });
+    expect(broadcasts.at(-1)).toMatchObject({
+      id: sessionId,
+      msg: {
+        type: "user_input",
+        text: "sync this turn",
+        userMessageUuid: "codex:user-turn:1",
+        clientMessageId: "cm-codex-merge",
+      },
+    });
+
+    codexInstances[0].emit("message", {
+      type: "user_input",
+      text: "sync this turn",
+      userMessageUuid: "item-real-2",
+    } as ServerMessage);
+
+    userInputs = session.history.filter((msg) => msg.type === "user_input");
+    expect(userInputs).toHaveLength(2);
+    expect(userInputs[1]).toMatchObject({
+      type: "user_input",
+      text: "sync this turn",
+      userMessageUuid: "codex:user-turn:2",
+    });
+  });
+
+  it("does not merge distinct real Codex user item IDs with identical text", () => {
+    const broadcasts: Array<{ id: string; msg: ServerMessage }> = [];
+    const manager = new SessionManager((id, msg) => {
+      broadcasts.push({ id, msg });
+    });
+    const sessionId = manager.create(
+      "/tmp/project-distinct-codex",
+      undefined,
+      undefined,
+      undefined,
+      "codex",
+    );
+
+    const session = manager.get(sessionId);
+    expect(session).toBeDefined();
+    if (!session) return;
+
+    manager.appendHistory(sessionId, {
+      type: "user_input",
+      text: "repeat",
+      userMessageUuid: "item-real-1",
+    } as ServerMessage);
+
+    codexInstances[0].emit("message", {
+      type: "user_input",
+      text: "repeat",
+      userMessageUuid: "item-real-2",
+    } as ServerMessage);
+
+    expect(
+      session.history.filter((msg) => msg.type === "user_input"),
+    ).toHaveLength(2);
+    expect(
+      session.history.filter((msg) => msg.type === "user_input")[1],
+    ).toMatchObject({
+      type: "user_input",
+      text: "repeat",
+      userMessageUuid: "codex:user-turn:2",
+    });
+    expect(broadcasts.at(-1)).toMatchObject({
+      id: sessionId,
+      msg: {
+        type: "user_input",
+        text: "repeat",
+      },
+    });
+    expect(
+      "userMessageUuid" in (broadcasts.at(-1)?.msg ?? {}),
+    ).toBe(false);
+  });
+
+  it("counts resumed Codex past messages when assigning remote user turn UUIDs", () => {
+    const broadcasts: Array<{ id: string; msg: ServerMessage }> = [];
+    const manager = new SessionManager((id, msg) => {
+      broadcasts.push({ id, msg });
+    });
+    const sessionId = manager.create(
+      "/tmp/project-resumed-codex",
+      undefined,
+      [
+        {
+          role: "user",
+          uuid: "codex:user-turn:1",
+          content: [{ type: "text", text: "old turn" }],
+        },
+      ],
+      undefined,
+      "codex",
+    );
+
+    const session = manager.get(sessionId);
+    expect(session).toBeDefined();
+    if (!session) return;
+
+    codexInstances[0].emit("message", {
+      type: "user_input",
+      text: "remote after resume",
+      userMessageUuid: "item-real-after-resume",
+    } as ServerMessage);
+
+    expect(session.history).toContainEqual(
+      expect.objectContaining({
+        type: "user_input",
+        text: "remote after resume",
+        userMessageUuid: "codex:user-turn:2",
+      }),
+    );
+    expect(broadcasts.at(-1)).toMatchObject({
+      id: sessionId,
+      msg: {
+        type: "user_input",
+        text: "remote after resume",
+      },
+    });
+    expect(
+      "userMessageUuid" in (broadcasts.at(-1)?.msg ?? {}),
+    ).toBe(false);
+  });
+
+  it("counts queued Codex input when assigning remote user turn UUIDs", () => {
+    const manager = new SessionManager(() => {});
+    const sessionId = manager.create(
+      "/tmp/project-queued-codex",
+      undefined,
+      undefined,
+      undefined,
+      "codex",
+    );
+
+    const session = manager.get(sessionId);
+    expect(session).toBeDefined();
+    if (!session) return;
+
+    manager.appendHistory(sessionId, {
+      type: "user_input",
+      text: "first local",
+      userMessageUuid: "codex:user-turn:1",
+    } as ServerMessage);
+    expect(
+      manager.queueCodexInput(sessionId, {
+        itemId: "queued-1",
+        text: "queued local",
+        createdAt: "2026-05-12T10:00:00.000Z",
+        userMessageUuid: "codex:user-turn:2",
+      }),
+    ).toBe(true);
+
+    codexInstances[0].emit("message", {
+      type: "user_input",
+      text: "remote while queued",
+      userMessageUuid: "item-real-queued-race",
+    } as ServerMessage);
+
+    expect(session.history).toContainEqual(
+      expect.objectContaining({
+        type: "user_input",
+        text: "remote while queued",
+        userMessageUuid: "codex:user-turn:3",
+      }),
+    );
   });
 
   it("falls back to scanning all project dirs when primary slug lookup misses", () => {

--- a/packages/bridge/src/session.ts
+++ b/packages/bridge/src/session.ts
@@ -5,6 +5,8 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import {
   pathToSlug,
+  codexUserTurnUuid,
+  isCodexUserTurnUuid,
   renameClaudeSession,
   renameCodexSession,
   saveCodexSessionAdditionalWritableRoots,
@@ -77,6 +79,10 @@ export interface SessionInfo {
   sandboxEnabled?: boolean;
   /** Codex-only pending input waiting for the next turn. */
   codexQueuedInput?: QueuedCodexInput;
+  /** Synthetic Codex user UUIDs waiting for their app-server echo. */
+  pendingCodexUserEchoUuids?: Set<string>;
+  /** Raw Codex app-server user item ids mapped to valid ccpocket turn UUIDs. */
+  codexUserTurnUuidByRawId?: Map<string, string>;
   /** Whether to generate a session name after the first completed turn. */
   autoRename?: boolean;
   /** Prevents automatic rename from running more than once. */
@@ -520,51 +526,23 @@ export class SessionManager {
         }
 
         // Don't add streaming deltas to history
+        let mergedUserInput = false;
+        let historyMsg = msg;
         if (msg.type !== "stream_delta" && msg.type !== "thinking_delta") {
-          // When SDK echoes back a user_input with UUID, merge into the
-          // UUID-less placeholder that websocket.ts pushed earlier.
-          // This avoids duplicate entries while preserving the UUID needed
-          // for rewind candidate matching.
-          let merged = false;
-          if (
-            msg.type === "user_input" &&
-            "userMessageUuid" in msg &&
-            msg.userMessageUuid
-          ) {
-            for (let i = session.history.length - 1; i >= 0; i--) {
-              const m = session.history[i];
-              if (
-                m.type === "user_input" &&
-                !("userMessageUuid" in m && m.userMessageUuid)
-              ) {
-                // Preserve the original text from the user input and only
-                // take the UUID from the SDK echo.  The SDK may return a
-                // transformed/translated version of the user's message, so
-                // we must not overwrite the original text.
-                const mergedMsg = {
-                  ...m,
-                  userMessageUuid: msg.userMessageUuid,
-                };
-                if (session.historyEntries[i]) {
-                  (mergedMsg as Record<string, unknown>).historySeq =
-                    session.historyEntries[i].seq;
-                }
-                session.history[i] = mergedMsg;
-                if (session.historyEntries[i]) {
-                  session.historyEntries[i].message = mergedMsg;
-                }
-                merged = true;
-                break;
-              }
-            }
-          }
-
-          if (!merged) {
-            this.appendHistoryToSession(session, msg);
+          const mergedMsg = this.mergeUserInputIntoHistory(session, msg);
+          if (mergedMsg) {
+            mergedUserInput = true;
+            historyMsg = mergedMsg;
+          } else {
+            historyMsg = this.buildHistoryProcessMessage(session, msg);
+            this.appendHistoryToSession(session, historyMsg);
           }
         }
 
-        this.onMessage(id, msg);
+        this.onMessage(
+          id,
+          this.buildLiveProcessMessage(session, historyMsg, mergedUserInput),
+        );
 
         // After a result (turn complete), backfill UUIDs from disk.
         // The SDK does not echo user messages via the stream, so
@@ -687,7 +665,9 @@ export class SessionManager {
   appendHistory(sessionId: string, msg: ServerMessage): HistoryEntry | undefined {
     const session = this.sessions.get(sessionId);
     if (!session) return undefined;
-    return this.appendHistoryToSession(session, msg);
+    const entry = this.appendHistoryToSession(session, msg);
+    this.markPendingCodexUserEcho(session, msg);
+    return entry;
   }
 
   getHistorySince(
@@ -820,6 +800,219 @@ export class SessionManager {
     session.historyEntries.push(entry);
     this.trimHistory(session);
     return entry;
+  }
+
+  private mergeUserInputIntoHistory(
+    session: SessionInfo,
+    msg: ServerMessage,
+  ): ServerMessage | null {
+    if (msg.type !== "user_input") return null;
+
+    for (let i = session.history.length - 1; i >= 0; i--) {
+      const current = session.history[i];
+      if (current.type !== "user_input") continue;
+      if (!this.isSameUserInput(session, current, msg)) continue;
+
+      const mergedMsg = {
+        ...current,
+        userMessageUuid: this.mergeUserMessageUuid(current, msg),
+        timestamp:
+          ("timestamp" in current && current.timestamp) ||
+          ("timestamp" in msg ? msg.timestamp : undefined),
+      } as ServerMessage;
+
+      const entry = session.historyEntries[i];
+      if (entry) {
+        (mergedMsg as Record<string, unknown>).historySeq = entry.seq;
+        entry.message = mergedMsg;
+      }
+      session.history[i] = mergedMsg;
+      this.clearPendingCodexUserEcho(session, current);
+      this.clearPendingCodexUserEcho(session, msg);
+      return mergedMsg;
+    }
+
+    return null;
+  }
+
+  private buildLiveProcessMessage(
+    session: SessionInfo,
+    msg: ServerMessage,
+    mergedUserInput: boolean,
+  ): ServerMessage {
+    if (
+      session.provider === "codex" &&
+      msg.type === "user_input" &&
+      !mergedUserInput &&
+      "userMessageUuid" in msg &&
+      msg.userMessageUuid
+    ) {
+      // Current mobile builds treat a user_input with userMessageUuid as a UUID
+      // backfill for an optimistic local message.  New remote turns need to be
+      // added as chat entries, while history still keeps the Codex item id.
+      const { userMessageUuid: _, ...liveMsg } = msg;
+      return liveMsg as ServerMessage;
+    }
+    return msg;
+  }
+
+  private buildHistoryProcessMessage(
+    session: SessionInfo,
+    msg: ServerMessage,
+  ): ServerMessage {
+    if (session.provider !== "codex" || msg.type !== "user_input") return msg;
+    const uuid = "userMessageUuid" in msg ? msg.userMessageUuid : undefined;
+    if (!uuid || isCodexUserTurnUuid(uuid)) return msg;
+    return {
+      ...msg,
+      userMessageUuid: this.codexUserTurnUuidForRawItem(session, uuid),
+    } as ServerMessage;
+  }
+
+  private isSameUserInput(
+    session: SessionInfo,
+    existing: ServerMessage,
+    incoming: ServerMessage,
+  ): boolean {
+    if (existing.type !== "user_input" || incoming.type !== "user_input") {
+      return false;
+    }
+
+    const existingClientId =
+      "clientMessageId" in existing ? existing.clientMessageId : undefined;
+    const incomingClientId =
+      "clientMessageId" in incoming ? incoming.clientMessageId : undefined;
+    if (existingClientId && incomingClientId) {
+      return existingClientId === incomingClientId;
+    }
+
+    const existingUuid =
+      "userMessageUuid" in existing ? existing.userMessageUuid : undefined;
+    const incomingUuid =
+      "userMessageUuid" in incoming ? incoming.userMessageUuid : undefined;
+    if (existingUuid && incomingUuid && existingUuid === incomingUuid) {
+      return true;
+    }
+
+    if (session.provider !== "codex" && !existingUuid && incomingUuid) {
+      return true;
+    }
+
+    if (existing.text !== incoming.text) return false;
+    const existingHasImageCount = "imageCount" in existing;
+    const incomingHasImageCount = "imageCount" in incoming;
+    if (existingHasImageCount && incomingHasImageCount) {
+      const existingImages = existing.imageCount ?? 0;
+      const incomingImages = incoming.imageCount ?? 0;
+      if (existingImages !== incomingImages) return false;
+    }
+    if (isCodexUserTurnUuid(existingUuid) || isCodexUserTurnUuid(incomingUuid)) {
+      return (
+        this.isPendingCodexUserEcho(session, existingUuid) ||
+        this.isPendingCodexUserEcho(session, incomingUuid)
+      );
+    }
+    return !existingUuid || !incomingUuid;
+  }
+
+  private mergeUserMessageUuid(
+    existing: ServerMessage,
+    incoming: ServerMessage,
+  ): string | undefined {
+    const existingUuid =
+      existing.type === "user_input" && "userMessageUuid" in existing
+        ? existing.userMessageUuid
+        : undefined;
+    const incomingUuid =
+      incoming.type === "user_input" && "userMessageUuid" in incoming
+        ? incoming.userMessageUuid
+        : undefined;
+    if (isCodexUserTurnUuid(existingUuid)) {
+      return existingUuid;
+    }
+    if (isCodexUserTurnUuid(incomingUuid)) {
+      return incomingUuid;
+    }
+    return existingUuid || incomingUuid;
+  }
+
+  private markPendingCodexUserEcho(
+    session: SessionInfo,
+    msg: ServerMessage,
+  ): void {
+    if (session.provider !== "codex" || msg.type !== "user_input") return;
+    const uuid = "userMessageUuid" in msg ? msg.userMessageUuid : undefined;
+    if (!isCodexUserTurnUuid(uuid)) return;
+    session.pendingCodexUserEchoUuids ??= new Set<string>();
+    session.pendingCodexUserEchoUuids.add(uuid);
+  }
+
+  private clearPendingCodexUserEcho(
+    session: SessionInfo,
+    msg: ServerMessage,
+  ): void {
+    if (session.provider !== "codex" || msg.type !== "user_input") return;
+    const uuid = "userMessageUuid" in msg ? msg.userMessageUuid : undefined;
+    if (!isCodexUserTurnUuid(uuid)) return;
+    session.pendingCodexUserEchoUuids?.delete(uuid);
+  }
+
+  private isPendingCodexUserEcho(
+    session: SessionInfo,
+    uuid: string | undefined,
+  ): boolean {
+    return (
+      isCodexUserTurnUuid(uuid) &&
+      (session.pendingCodexUserEchoUuids?.has(uuid) ?? false)
+    );
+  }
+
+  private codexUserTurnUuidForRawItem(
+    session: SessionInfo,
+    rawId: string,
+  ): string {
+    session.codexUserTurnUuidByRawId ??= new Map<string, string>();
+    const existing = session.codexUserTurnUuidByRawId.get(rawId);
+    if (existing) return existing;
+    const uuid = this.nextCodexUserTurnUuid(session);
+    session.codexUserTurnUuidByRawId.set(rawId, uuid);
+    return uuid;
+  }
+
+  private nextCodexUserTurnUuid(session: SessionInfo): string {
+    let maxOrdinal = 0;
+    let userTurnCount = 0;
+
+    const observe = (uuid?: string): void => {
+      userTurnCount += 1;
+      if (!isCodexUserTurnUuid(uuid)) return;
+      const ordinal = Number(uuid.slice("codex:user-turn:".length));
+      if (Number.isInteger(ordinal)) {
+        maxOrdinal = Math.max(maxOrdinal, ordinal);
+      }
+    };
+
+    for (const message of session.pastMessages ?? []) {
+      if (!message || typeof message !== "object") continue;
+      const item = message as {
+        role?: unknown;
+        uuid?: unknown;
+        isMeta?: unknown;
+      };
+      if (item.role !== "user" || item.isMeta === true) continue;
+      observe(typeof item.uuid === "string" ? item.uuid : undefined);
+    }
+
+    for (const message of session.history) {
+      if (message.type !== "user_input") continue;
+      observe(
+        "userMessageUuid" in message ? message.userMessageUuid : undefined,
+      );
+    }
+    if (session.codexQueuedInput) {
+      observe(session.codexQueuedInput.userMessageUuid);
+    }
+    return codexUserTurnUuid(Math.max(maxOrdinal, userTurnCount) + 1);
   }
 
   private trimHistory(session: SessionInfo): void {
@@ -1038,6 +1231,7 @@ export class SessionManager {
 
     const userMsg = this.buildQueuedUserInputMessage(queued);
     this.appendHistoryToSession(session, userMsg);
+    this.markPendingCodexUserEcho(session, userMsg);
     this.onMessage(session.id, userMsg);
     return { ok: true };
   }
@@ -1063,6 +1257,7 @@ export class SessionManager {
 
     const userMsg = this.buildQueuedUserInputMessage(queued);
     this.appendHistoryToSession(session, userMsg);
+    this.markPendingCodexUserEcho(session, userMsg);
     this.onMessage(session.id, userMsg);
 
     session.process.sendInputStructured(queued.text, {

--- a/packages/bridge/src/sessions-index.ts
+++ b/packages/bridge/src/sessions-index.ts
@@ -1715,6 +1715,10 @@ export function codexUserTurnUuid(ordinal: number): string {
   return `codex:user-turn:${ordinal}`;
 }
 
+export function isCodexUserTurnUuid(uuid: string | undefined): uuid is string {
+  return typeof uuid === "string" && /^codex:user-turn:\d+$/.test(uuid);
+}
+
 function numberToIsoTimestamp(value: unknown): string | undefined {
   return typeof value === "number" && Number.isFinite(value)
     ? new Date(value * 1000).toISOString()

--- a/packages/bridge/src/setup-launchd.test.ts
+++ b/packages/bridge/src/setup-launchd.test.ts
@@ -23,16 +23,23 @@ vi.mock("node:os", () => ({
 const { setupLaunchd, uninstallLaunchd } = await import("./setup-launchd.js");
 
 const PLIST_PATH = "/Users/testuser/Library/LaunchAgents/com.ccpocket.bridge.plist";
+const originalBridgeEnv = {
+  publicWsUrl: process.env.BRIDGE_PUBLIC_WS_URL,
+  codexAppServerMode: process.env.BRIDGE_CODEX_APP_SERVER_MODE,
+  codexAppServerPort: process.env.BRIDGE_CODEX_APP_SERVER_PORT,
+  codexAppServerUrl: process.env.BRIDGE_CODEX_APP_SERVER_URL,
+};
 
 describe("setup-launchd", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    clearBridgeEnv();
     mockExistsSync.mockReturnValue(true);
     mockExecSync.mockReturnValue("/usr/bin/npx\n");
   });
 
   afterEach(() => {
-    delete process.env.BRIDGE_PUBLIC_WS_URL;
+    restoreBridgeEnv();
   });
 
   describe("setupLaunchd", () => {
@@ -45,6 +52,12 @@ describe("setup-launchd", () => {
       expect(content).toContain("<key>BRIDGE_PORT</key>");
       expect(content).toContain("<string>8765</string>");
       expect(content).toContain("<key>BRIDGE_HOST</key>");
+      expect(content).toContain("<key>BRIDGE_CODEX_APP_SERVER_MODE</key>");
+      expect(content).toContain("<string>managed</string>");
+      expect(content).toContain("<key>BRIDGE_CODEX_APP_SERVER_PORT</key>");
+      expect(content).toContain("<string>8767</string>");
+      expect(content).toContain("<key>BRIDGE_CODEX_APP_SERVER_URL</key>");
+      expect(content).toContain("<string>ws://127.0.0.1:8767</string>");
       expect(content).toContain(
         "<string>exec npx --yes @ccpocket/bridge@latest</string>",
       );
@@ -69,6 +82,46 @@ describe("setup-launchd", () => {
       expect(content).toContain("<string>wss://flag.example.com</string>");
       expect(content).not.toContain("wss://env.example.com");
     });
+
+    it("includes explicit Codex app-server startup options", () => {
+      setupLaunchd({
+        codexAppServerMode: "external",
+        codexAppServerPort: "18766",
+        codexAppServerUrl: "ws://127.0.0.1:18766",
+      });
+
+      const content = mockWriteFileSync.mock.calls[0]![1] as string;
+      expect(content).toContain("<key>BRIDGE_CODEX_APP_SERVER_MODE</key>");
+      expect(content).toContain("<string>external</string>");
+      expect(content).toContain("<key>BRIDGE_CODEX_APP_SERVER_PORT</key>");
+      expect(content).toContain("<string>18766</string>");
+      expect(content).toContain("<key>BRIDGE_CODEX_APP_SERVER_URL</key>");
+      expect(content).toContain("<string>ws://127.0.0.1:18766</string>");
+    });
+
+    it("leaves the documented test Bridge port free by default", () => {
+      setupLaunchd({ port: "8765" });
+
+      const content = mockWriteFileSync.mock.calls[0]![1] as string;
+      expect(content).toContain("<key>BRIDGE_PORT</key>");
+      expect(content).toContain("<string>8765</string>");
+      expect(content).toContain("<key>BRIDGE_CODEX_APP_SERVER_PORT</key>");
+      expect(content).toContain("<string>8767</string>");
+      expect(content).toContain("<key>BRIDGE_CODEX_APP_SERVER_URL</key>");
+      expect(content).toContain("<string>ws://127.0.0.1:8767</string>");
+    });
+
+    it("moves the default Codex app-server port when Bridge uses 8767", () => {
+      setupLaunchd({ port: "8767" });
+
+      const content = mockWriteFileSync.mock.calls[0]![1] as string;
+      expect(content).toContain("<key>BRIDGE_PORT</key>");
+      expect(content).toContain("<string>8767</string>");
+      expect(content).toContain("<key>BRIDGE_CODEX_APP_SERVER_PORT</key>");
+      expect(content).toContain("<string>8768</string>");
+      expect(content).toContain("<key>BRIDGE_CODEX_APP_SERVER_URL</key>");
+      expect(content).toContain("<string>ws://127.0.0.1:8768</string>");
+    });
   });
 
   describe("uninstallLaunchd", () => {
@@ -81,3 +134,34 @@ describe("setup-launchd", () => {
     });
   });
 });
+
+function clearBridgeEnv(): void {
+  delete process.env.BRIDGE_PUBLIC_WS_URL;
+  delete process.env.BRIDGE_CODEX_APP_SERVER_MODE;
+  delete process.env.BRIDGE_CODEX_APP_SERVER_PORT;
+  delete process.env.BRIDGE_CODEX_APP_SERVER_URL;
+}
+
+function restoreBridgeEnv(): void {
+  restoreEnvVar("BRIDGE_PUBLIC_WS_URL", originalBridgeEnv.publicWsUrl);
+  restoreEnvVar(
+    "BRIDGE_CODEX_APP_SERVER_MODE",
+    originalBridgeEnv.codexAppServerMode,
+  );
+  restoreEnvVar(
+    "BRIDGE_CODEX_APP_SERVER_PORT",
+    originalBridgeEnv.codexAppServerPort,
+  );
+  restoreEnvVar(
+    "BRIDGE_CODEX_APP_SERVER_URL",
+    originalBridgeEnv.codexAppServerUrl,
+  );
+}
+
+function restoreEnvVar(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key];
+    return;
+  }
+  process.env[key] = value;
+}

--- a/packages/bridge/src/setup-launchd.ts
+++ b/packages/bridge/src/setup-launchd.ts
@@ -2,6 +2,7 @@ import { execSync } from "node:child_process";
 import { existsSync, mkdirSync, writeFileSync, unlinkSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { defaultCodexAppServerPort } from "./codex-app-server-config.js";
 
 const PLIST_LABEL = "com.ccpocket.bridge";
 
@@ -29,6 +30,9 @@ interface SetupOptions {
   host?: string;
   apiKey?: string;
   publicWsUrl?: string;
+  codexAppServerMode?: string;
+  codexAppServerPort?: string;
+  codexAppServerUrl?: string;
 }
 
 export function setupLaunchd(opts: SetupOptions): void {
@@ -37,6 +41,18 @@ export function setupLaunchd(opts: SetupOptions): void {
   const apiKey = opts.apiKey ?? process.env.BRIDGE_API_KEY ?? "";
   const publicWsUrl =
     opts.publicWsUrl ?? process.env.BRIDGE_PUBLIC_WS_URL ?? "";
+  const codexAppServerMode =
+    opts.codexAppServerMode ??
+    process.env.BRIDGE_CODEX_APP_SERVER_MODE ??
+    "managed";
+  const codexAppServerPort =
+    opts.codexAppServerPort ??
+    process.env.BRIDGE_CODEX_APP_SERVER_PORT ??
+    defaultCodexAppServerPort(port);
+  const codexAppServerUrl =
+    opts.codexAppServerUrl ??
+    process.env.BRIDGE_CODEX_APP_SERVER_URL ??
+    `ws://127.0.0.1:${codexAppServerPort}`;
   const plistPath = getPlistPath();
 
   // Resolve the npx binary path
@@ -66,6 +82,14 @@ export function setupLaunchd(opts: SetupOptions): void {
         <key>BRIDGE_PUBLIC_WS_URL</key>
         <string>${publicWsUrl}</string>`;
   }
+
+  envBlock += `
+        <key>BRIDGE_CODEX_APP_SERVER_MODE</key>
+        <string>${codexAppServerMode}</string>
+        <key>BRIDGE_CODEX_APP_SERVER_PORT</key>
+        <string>${codexAppServerPort}</string>
+        <key>BRIDGE_CODEX_APP_SERVER_URL</key>
+        <string>${codexAppServerUrl}</string>`;
 
   // Generate plist
   // Use zsh -li -c to inherit the user's full shell environment
@@ -117,6 +141,7 @@ ${envBlock}
   try {
     execSync(`launchctl start "${PLIST_LABEL}"`);
     console.log(`==> Bridge Server started on port ${port}`);
+    console.log(`    Codex remote: codex --remote ${codexAppServerUrl}`);
   } catch {
     console.log("==> Service registered (start may have failed — check logs at /tmp/ccpocket-bridge.log)");
   }

--- a/packages/bridge/src/setup-launchd.ts
+++ b/packages/bridge/src/setup-launchd.ts
@@ -141,7 +141,9 @@ ${envBlock}
   try {
     execSync(`launchctl start "${PLIST_LABEL}"`);
     console.log(`==> Bridge Server started on port ${port}`);
-    console.log(`    Codex remote: codex --remote ${codexAppServerUrl}`);
+    console.log(
+      `    Codex remote: codex resume --all --remote ${codexAppServerUrl}`,
+    );
   } catch {
     console.log("==> Service registered (start may have failed — check logs at /tmp/ccpocket-bridge.log)");
   }

--- a/packages/bridge/src/setup-systemd.test.ts
+++ b/packages/bridge/src/setup-systemd.test.ts
@@ -28,6 +28,12 @@ const { setupSystemd, uninstallSystemd } = await import("./setup-systemd.js");
 
 const SERVICE_PATH =
   "/home/testuser/.config/systemd/user/ccpocket-bridge.service";
+const originalBridgeEnv = {
+  publicWsUrl: process.env.BRIDGE_PUBLIC_WS_URL,
+  codexAppServerMode: process.env.BRIDGE_CODEX_APP_SERVER_MODE,
+  codexAppServerPort: process.env.BRIDGE_CODEX_APP_SERVER_PORT,
+  codexAppServerUrl: process.env.BRIDGE_CODEX_APP_SERVER_URL,
+};
 
 describe("setup-systemd", () => {
   const originalPlatform = process.platform;
@@ -35,6 +41,7 @@ describe("setup-systemd", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     Object.defineProperty(process, "platform", { value: "linux" });
+    clearBridgeEnv();
     // Default: directory exists, npx found
     mockExistsSync.mockReturnValue(true);
     mockExecSync.mockReturnValue("/usr/bin/npx\n");
@@ -42,6 +49,7 @@ describe("setup-systemd", () => {
 
   afterEach(() => {
     Object.defineProperty(process, "platform", { value: originalPlatform });
+    restoreBridgeEnv();
   });
 
   describe("setupSystemd", () => {
@@ -64,6 +72,15 @@ describe("setup-systemd", () => {
       );
       expect(content).toContain("Environment=BRIDGE_PORT=8765");
       expect(content).toContain("Environment=BRIDGE_HOST=0.0.0.0");
+      expect(content).toContain(
+        "Environment=BRIDGE_CODEX_APP_SERVER_MODE=managed",
+      );
+      expect(content).toContain(
+        "Environment=BRIDGE_CODEX_APP_SERVER_PORT=8767",
+      );
+      expect(content).toContain(
+        "Environment=BRIDGE_CODEX_APP_SERVER_URL=ws://127.0.0.1:8767",
+      );
       expect(content).toContain("Restart=on-failure");
       expect(content).toContain("WantedBy=default.target");
       expect(content).not.toContain("BRIDGE_API_KEY");
@@ -95,6 +112,51 @@ describe("setup-systemd", () => {
         "Environment=BRIDGE_PUBLIC_WS_URL=wss://flag.example.com",
       );
       expect(content).not.toContain("wss://env.example.com");
+    });
+
+    it("includes explicit Codex app-server startup options", () => {
+      setupSystemd({
+        codexAppServerMode: "external",
+        codexAppServerPort: "18766",
+        codexAppServerUrl: "ws://127.0.0.1:18766",
+      });
+
+      const content = mockWriteFileSync.mock.calls[0]![1] as string;
+      expect(content).toContain(
+        "Environment=BRIDGE_CODEX_APP_SERVER_MODE=external",
+      );
+      expect(content).toContain(
+        "Environment=BRIDGE_CODEX_APP_SERVER_PORT=18766",
+      );
+      expect(content).toContain(
+        "Environment=BRIDGE_CODEX_APP_SERVER_URL=ws://127.0.0.1:18766",
+      );
+    });
+
+    it("leaves the documented test Bridge port free by default", () => {
+      setupSystemd({ port: "8765" });
+
+      const content = mockWriteFileSync.mock.calls[0]![1] as string;
+      expect(content).toContain("Environment=BRIDGE_PORT=8765");
+      expect(content).toContain(
+        "Environment=BRIDGE_CODEX_APP_SERVER_PORT=8767",
+      );
+      expect(content).toContain(
+        "Environment=BRIDGE_CODEX_APP_SERVER_URL=ws://127.0.0.1:8767",
+      );
+    });
+
+    it("moves the default Codex app-server port when Bridge uses 8767", () => {
+      setupSystemd({ port: "8767" });
+
+      const content = mockWriteFileSync.mock.calls[0]![1] as string;
+      expect(content).toContain("Environment=BRIDGE_PORT=8767");
+      expect(content).toContain(
+        "Environment=BRIDGE_CODEX_APP_SERVER_PORT=8768",
+      );
+      expect(content).toContain(
+        "Environment=BRIDGE_CODEX_APP_SERVER_URL=ws://127.0.0.1:8768",
+      );
     });
 
     it("omits BRIDGE_API_KEY when apiKey is empty", () => {
@@ -231,3 +293,34 @@ describe("setup-systemd", () => {
     });
   });
 });
+
+function clearBridgeEnv(): void {
+  delete process.env.BRIDGE_PUBLIC_WS_URL;
+  delete process.env.BRIDGE_CODEX_APP_SERVER_MODE;
+  delete process.env.BRIDGE_CODEX_APP_SERVER_PORT;
+  delete process.env.BRIDGE_CODEX_APP_SERVER_URL;
+}
+
+function restoreBridgeEnv(): void {
+  restoreEnvVar("BRIDGE_PUBLIC_WS_URL", originalBridgeEnv.publicWsUrl);
+  restoreEnvVar(
+    "BRIDGE_CODEX_APP_SERVER_MODE",
+    originalBridgeEnv.codexAppServerMode,
+  );
+  restoreEnvVar(
+    "BRIDGE_CODEX_APP_SERVER_PORT",
+    originalBridgeEnv.codexAppServerPort,
+  );
+  restoreEnvVar(
+    "BRIDGE_CODEX_APP_SERVER_URL",
+    originalBridgeEnv.codexAppServerUrl,
+  );
+}
+
+function restoreEnvVar(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key];
+    return;
+  }
+  process.env[key] = value;
+}

--- a/packages/bridge/src/setup-systemd.ts
+++ b/packages/bridge/src/setup-systemd.ts
@@ -2,6 +2,7 @@ import { execSync } from "node:child_process";
 import { existsSync, mkdirSync, writeFileSync, unlinkSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
+import { defaultCodexAppServerPort } from "./codex-app-server-config.js";
 
 const SERVICE_NAME = "ccpocket-bridge";
 
@@ -48,6 +49,9 @@ interface SetupOptions {
   host?: string;
   apiKey?: string;
   publicWsUrl?: string;
+  codexAppServerMode?: string;
+  codexAppServerPort?: string;
+  codexAppServerUrl?: string;
 }
 
 export function setupSystemd(opts: SetupOptions): void {
@@ -56,6 +60,18 @@ export function setupSystemd(opts: SetupOptions): void {
   const apiKey = opts.apiKey ?? process.env.BRIDGE_API_KEY ?? "";
   const publicWsUrl =
     opts.publicWsUrl ?? process.env.BRIDGE_PUBLIC_WS_URL ?? "";
+  const codexAppServerMode =
+    opts.codexAppServerMode ??
+    process.env.BRIDGE_CODEX_APP_SERVER_MODE ??
+    "managed";
+  const codexAppServerPort =
+    opts.codexAppServerPort ??
+    process.env.BRIDGE_CODEX_APP_SERVER_PORT ??
+    defaultCodexAppServerPort(port);
+  const codexAppServerUrl =
+    opts.codexAppServerUrl ??
+    process.env.BRIDGE_CODEX_APP_SERVER_URL ??
+    `ws://127.0.0.1:${codexAppServerPort}`;
   const servicePath = getServicePath();
 
   // Resolve the npx binary path
@@ -85,6 +101,9 @@ Environment=BRIDGE_HOST=${host}`;
   if (publicWsUrl) {
     envLines += `\nEnvironment=BRIDGE_PUBLIC_WS_URL=${publicWsUrl}`;
   }
+  envLines += `\nEnvironment=BRIDGE_CODEX_APP_SERVER_MODE=${codexAppServerMode}`;
+  envLines += `\nEnvironment=BRIDGE_CODEX_APP_SERVER_PORT=${codexAppServerPort}`;
+  envLines += `\nEnvironment=BRIDGE_CODEX_APP_SERVER_URL=${codexAppServerUrl}`;
 
   // Generate systemd user service unit
   // Run npx directly with its full path. We set Environment=PATH to include
@@ -117,6 +136,7 @@ WantedBy=default.target
   try {
     execSync(`systemctl --user restart "${SERVICE_NAME}"`);
     console.log(`==> Bridge Server started on port ${port}`);
+    console.log(`    Codex remote: codex --remote ${codexAppServerUrl}`);
   } catch {
     console.log(
       "==> Service registered (start may have failed — check logs with: journalctl --user -u ccpocket-bridge)",

--- a/packages/bridge/src/setup-systemd.ts
+++ b/packages/bridge/src/setup-systemd.ts
@@ -136,7 +136,9 @@ WantedBy=default.target
   try {
     execSync(`systemctl --user restart "${SERVICE_NAME}"`);
     console.log(`==> Bridge Server started on port ${port}`);
-    console.log(`    Codex remote: codex --remote ${codexAppServerUrl}`);
+    console.log(
+      `    Codex remote: codex resume --all --remote ${codexAppServerUrl}`,
+    );
   } catch {
     console.log(
       "==> Service registered (start may have failed — check logs with: journalctl --user -u ccpocket-bridge)",

--- a/packages/bridge/src/websocket.ts
+++ b/packages/bridge/src/websocket.ts
@@ -18,6 +18,7 @@ import {
   type CodexStartOptions,
   type CodexThreadSummary,
 } from "./codex-process.js";
+import { stopManagedCodexAppServers } from "./codex-transport.js";
 import {
   parseClientMessage,
   type ClientMessage,
@@ -1289,6 +1290,7 @@ export class BridgeWebSocketServer {
   close(): void {
     console.log("[ws] Shutting down...");
     this.sessionManager.destroyAll();
+    stopManagedCodexAppServers();
     this.debugEvents.clear();
     this.wss.close();
   }


### PR DESCRIPTION
## Summary
- add Bridge-managed/external Codex app-server transport for shared Codex co-presence
- persist managed Codex app-server startup through CLI, launchd, and systemd setup
- merge Codex user echoes into session history while preserving distinct remote user turns
- filter shared Codex app-server notifications by thread to avoid cross-session leakage

## Tests
- ./node_modules/.bin/tsc --noEmit -p packages/bridge/tsconfig.json
- ./node_modules/.bin/vitest run packages/bridge/src/codex-process.test.ts packages/bridge/src/session.test.ts packages/bridge/src/setup-launchd.test.ts packages/bridge/src/setup-systemd.test.ts
- ./node_modules/.bin/vitest run packages/bridge/src
- git diff --check && git diff --cached --check
- codex app-server --help
- codex app-server generate-ts --out /tmp/codex-proto
- managed app-server smoke with BRIDGE_CODEX_APP_SERVER_MODE=managed
- codex exec review --uncommitted

## Notes
- no mobile app changes
- manual phone/terminal smoke confirmed by tester before PR creation