### PR TITLE
fix(bridge): support bonjour-service 1.4 exports

### DIFF
--- a/packages/bridge/src/mdns.test.ts
+++ b/packages/bridge/src/mdns.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveBonjourConstructor } from "./mdns.js";
+
+class BonjourV14 {
+  publish(): never {
+    throw new Error("not implemented");
+  }
+
+  destroy(): void {
+    // no-op
+  }
+}
+
+class BonjourV13 {
+  publish(): never {
+    throw new Error("not implemented");
+  }
+
+  destroy(): void {
+    // no-op
+  }
+}
+
+describe("resolveBonjourConstructor", () => {
+  it("returns the constructor from bonjour-service 1.4 export shape", () => {
+    expect(resolveBonjourConstructor(BonjourV14)).toBe(BonjourV14);
+  });
+
+  it("returns the constructor from bonjour-service 1.3 export shape", () => {
+    expect(
+      resolveBonjourConstructor({
+        Bonjour: BonjourV13,
+        default: BonjourV13,
+      }),
+    ).toBe(BonjourV13);
+  });
+
+  it("returns the constructor from nested default interop shape", () => {
+    expect(
+      resolveBonjourConstructor({
+        default: {
+          Bonjour: BonjourV13,
+        },
+      }),
+    ).toBe(BonjourV13);
+  });
+
+  it("throws for unsupported export shape", () => {
+    expect(() => resolveBonjourConstructor({})).toThrow(
+      "Unsupported bonjour-service export shape",
+    );
+  });
+});

--- a/packages/bridge/src/mdns.ts
+++ b/packages/bridge/src/mdns.ts
@@ -1,13 +1,64 @@
-import { Bonjour, type Service } from "bonjour-service";
+import BonjourModule from "bonjour-service";
+
+interface PublishedService {
+  on(event: "error", listener: (err: Error) => void): void;
+  stop?: () => void;
+}
+
+interface BonjourClient {
+  publish(opts: {
+    name: string;
+    type: string;
+    protocol: "tcp";
+    port: number;
+    probe: boolean;
+    txt: Record<string, string>;
+  }): PublishedService;
+  destroy(): void;
+}
+
+type BonjourConstructor = new (
+  opts?: Record<string, unknown>,
+  errorCallback?: (err: Error) => void,
+) => BonjourClient;
+
+function readExport(value: unknown, key: string): unknown {
+  if (typeof value !== "object" || value === null) return undefined;
+  return (value as Record<string, unknown>)[key];
+}
+
+export function resolveBonjourConstructor(
+  moduleExport: unknown,
+): BonjourConstructor {
+  const defaultExport = readExport(moduleExport, "default");
+  const candidates = [
+    moduleExport,
+    readExport(moduleExport, "Bonjour"),
+    defaultExport,
+    readExport(defaultExport, "Bonjour"),
+    readExport(defaultExport, "default"),
+  ];
+  const constructor = candidates.find(
+    (candidate): candidate is BonjourConstructor =>
+      typeof candidate === "function",
+  );
+
+  if (!constructor) {
+    throw new TypeError("Unsupported bonjour-service export shape");
+  }
+
+  return constructor;
+}
 
 export class MdnsAdvertiser {
-  private bonjour: Bonjour | null = null;
-  private service: Service | null = null;
+  private bonjour: BonjourClient | null = null;
+  private service: PublishedService | null = null;
   private disabled = false;
 
   start(port: number, apiKey?: string): void {
     if (this.disabled) return;
     try {
+      const Bonjour = resolveBonjourConstructor(BonjourModule);
       this.bonjour = new Bonjour({}, (err: Error) => {
         console.warn(
           `[bridge] mDNS: transport error (non-fatal): ${err.message}`,


### PR DESCRIPTION
## Summary

bonjour-service 1.4 changed its package entry from named ESM-style exports to a CommonJS export assignment, with types declared as export = Bonjour. That makes import { Bonjour } from "bonjour-service" fail when consumers resolve the 1.4 package.

<!-- What does this PR do? Keep it brief. -->

## Why This Is A PR

<!--
For non-trivial changes, we prefer a Prompt Request or Issue first.
If you are sending code directly, explain why this is ready for PR review now.
If this PR depends on another open PR, link it here.
-->

- Why PR instead of Issue / Prompt Request first: explicit import issue.
- Related Issue / Prompt Request:
- Base PR (if stacked on another open PR):

## Changes

<!-- List the key changes. -->

- Resolve the Bonjour constructor from both the old 1.3 named/default export shape and the new 1.4 direct CJS constructor shape so Bridge mDNS advertising works with either version.

## Scope Check

<!-- Help reviewers decide whether this should be split before review. -->

- Single primary goal of this PR: compat with bonjour-service 1.4
- What is intentionally out of scope:
- Can this be split into smaller PRs? If not, why not:

## Test plan

<!-- How was this tested? -->

- [x] Bridge Server tests pass (`npm run test:bridge`)
- [ ] Flutter tests pass (`cd apps/mobile && flutter test`)
- [ ] Manual testing done

## Platform validation

<!-- Required for platform-specific fixes, especially experimental / best-effort platforms like Windows Bridge or macOS mobile. -->

- Target platform: osx
- Platform version:
- What I validated on that platform:
- Logs / screenshots / notes:

## Notes

<!-- Anything reviewers should know? Breaking changes, migration steps, etc. -->
