### PR TITLE
fix(codex): restore bridge history from canonical threads

### DIFF
--- a/packages/bridge/src/codex-process.ts
+++ b/packages/bridge/src/codex-process.ts
@@ -116,6 +116,18 @@ export interface CodexThreadSummary {
   name: string | null;
 }
 
+export type CodexThreadSourceKind =
+  | "cli"
+  | "vscode"
+  | "exec"
+  | "appServer"
+  | "subAgent"
+  | "subAgentReview"
+  | "subAgentCompact"
+  | "subAgentThreadSpawn"
+  | "subAgentOther"
+  | "unknown";
+
 interface PendingApproval {
   requestId: string | number;
   toolUseId: string;
@@ -506,6 +518,8 @@ export class CodexProcess extends EventEmitter<CodexProcessEvents> {
       cursor?: string | null;
       cwd?: string;
       searchTerm?: string;
+      modelProviders?: string[];
+      sourceKinds?: CodexThreadSourceKind[];
     } = {},
   ): Promise<{ data: CodexThreadSummary[]; nextCursor: string | null }> {
     const result = (await this.request("thread/list", {
@@ -513,6 +527,12 @@ export class CodexProcess extends EventEmitter<CodexProcessEvents> {
       archived: false,
       ...(params.limit != null ? { limit: params.limit } : {}),
       ...(params.cursor !== undefined ? { cursor: params.cursor } : {}),
+      ...(params.modelProviders !== undefined
+        ? { modelProviders: params.modelProviders }
+        : {}),
+      ...(params.sourceKinds !== undefined
+        ? { sourceKinds: params.sourceKinds }
+        : {}),
       ...(params.cwd ? { cwd: params.cwd } : {}),
       ...(params.searchTerm ? { searchTerm: params.searchTerm } : {}),
     })) as { data?: unknown[]; nextCursor?: unknown };

--- a/packages/bridge/src/parser.ts
+++ b/packages/bridge/src/parser.ts
@@ -575,6 +575,8 @@ export type ServerMessage =
       isSynthetic?: boolean;
       isMeta?: boolean;
       imageCount?: number;
+      timestamp?: string;
+      images?: ImageRef[];
     }
   | { type: "window_list"; windows: WindowInfo[] }
   | {

--- a/packages/bridge/src/session.test.ts
+++ b/packages/bridge/src/session.test.ts
@@ -1089,6 +1089,59 @@ describe("SessionManager claude UUID backfill", () => {
     ).toBe(false);
   });
 
+  it("suppresses Codex raw user echo already restored from canonical history", () => {
+    const broadcasts: Array<{ id: string; msg: ServerMessage }> = [];
+    const manager = new SessionManager((id, msg) => {
+      broadcasts.push({ id, msg });
+    });
+    const sessionId = manager.create(
+      "/tmp/project-canonical-codex",
+      undefined,
+      [
+        {
+          role: "user",
+          uuid: "codex:user-turn:1",
+          rawItemId: "raw-user-1",
+          content: [{ type: "text", text: "canonical turn" }],
+        },
+      ],
+      undefined,
+      "codex",
+    );
+
+    const session = manager.get(sessionId);
+    expect(session).toBeDefined();
+    if (!session) return;
+    expect(session.codexUserTurnUuidByRawId?.get("raw-user-1")).toBe(
+      "codex:user-turn:1",
+    );
+
+    codexInstances[0].emit("message", {
+      type: "user_input",
+      text: "canonical turn",
+      userMessageUuid: "raw-user-1",
+    } as ServerMessage);
+
+    expect(
+      session.history.filter((msg) => msg.type === "user_input"),
+    ).toHaveLength(0);
+    expect(broadcasts).toHaveLength(0);
+
+    codexInstances[0].emit("message", {
+      type: "user_input",
+      text: "next remote",
+      userMessageUuid: "raw-user-2",
+    } as ServerMessage);
+
+    expect(session.history).toContainEqual(
+      expect.objectContaining({
+        type: "user_input",
+        text: "next remote",
+        userMessageUuid: "codex:user-turn:2",
+      }),
+    );
+  });
+
   it("counts queued Codex input when assigning remote user turn UUIDs", () => {
     const manager = new SessionManager(() => {});
     const sessionId = manager.create(

--- a/packages/bridge/src/session.ts
+++ b/packages/bridge/src/session.ts
@@ -84,6 +84,8 @@ export interface SessionInfo {
   pendingCodexUserEchoUuids?: Set<string>;
   /** Raw Codex app-server user item ids mapped to valid ccpocket turn UUIDs. */
   codexUserTurnUuidByRawId?: Map<string, string>;
+  /** Last Bridge history seq covered by the canonical Codex thread snapshot. */
+  codexCanonicalHistoryRevision?: number;
   /** Whether to generate a session name after the first completed turn. */
   autoRename?: boolean;
   /** Prevents automatic rename from running more than once. */
@@ -337,6 +339,9 @@ export class SessionManager {
       // can return it immediately (before the SDK sends a system/result event).
       claudeSessionId: options?.sessionId,
     };
+    if (effectiveProvider === "codex") {
+      this.seedCodexPastUserTurnUuidMap(session);
+    }
 
     // Cache tool_use id → name for enriching tool_result messages
     const toolUseNames = new Map<string, string>();
@@ -534,6 +539,9 @@ export class SessionManager {
         let mergedUserInput = false;
         let historyMsg = msg;
         if (msg.type !== "stream_delta" && msg.type !== "thinking_delta") {
+          if (this.shouldSuppressCodexCanonicalUserEcho(session, msg)) {
+            return;
+          }
           const mergedMsg = this.mergeUserInputIntoHistory(session, msg);
           if (mergedMsg) {
             mergedUserInput = true;
@@ -861,6 +869,57 @@ export class SessionManager {
       return liveMsg as ServerMessage;
     }
     return msg;
+  }
+
+  private shouldSuppressCodexCanonicalUserEcho(
+    session: SessionInfo,
+    msg: ServerMessage,
+  ): boolean {
+    if (session.provider !== "codex" || msg.type !== "user_input") {
+      return false;
+    }
+    const rawId = "userMessageUuid" in msg ? msg.userMessageUuid : undefined;
+    if (!rawId || isCodexUserTurnUuid(rawId)) return false;
+    const canonicalUuid = session.codexUserTurnUuidByRawId?.get(rawId);
+    if (!canonicalUuid) return false;
+    return this.hasPastCodexUserMessage(session, canonicalUuid);
+  }
+
+  private seedCodexPastUserTurnUuidMap(session: SessionInfo): void {
+    for (const message of session.pastMessages ?? []) {
+      if (!message || typeof message !== "object") continue;
+      const item = message as {
+        role?: unknown;
+        uuid?: unknown;
+        rawItemId?: unknown;
+        isMeta?: unknown;
+      };
+      if (
+        item.role !== "user" ||
+        item.isMeta === true ||
+        typeof item.rawItemId !== "string" ||
+        typeof item.uuid !== "string"
+      ) {
+        continue;
+      }
+      session.codexUserTurnUuidByRawId ??= new Map<string, string>();
+      session.codexUserTurnUuidByRawId.set(item.rawItemId, item.uuid);
+    }
+  }
+
+  private hasPastCodexUserMessage(
+    session: SessionInfo,
+    uuid: string,
+  ): boolean {
+    return (session.pastMessages ?? []).some((message) => {
+      if (!message || typeof message !== "object") return false;
+      const item = message as {
+        role?: unknown;
+        uuid?: unknown;
+        isMeta?: unknown;
+      };
+      return item.role === "user" && item.uuid === uuid && item.isMeta !== true;
+    });
   }
 
   private buildHistoryProcessMessage(

--- a/packages/bridge/src/sessions-index.test.ts
+++ b/packages/bridge/src/sessions-index.test.ts
@@ -78,14 +78,17 @@ describe("codexThreadToSessionHistory", () => {
       {
         role: "user",
         uuid: "codex:user-turn:1",
+        rawItemId: "u1",
         content: [{ type: "text", text: "hello" }],
       },
       {
         role: "assistant",
+        uuid: "a1",
         content: [{ type: "text", text: "hi" }],
       },
       {
         role: "assistant",
+        uuid: "cmd1",
         content: [
           {
             type: "tool_use",
@@ -102,6 +105,81 @@ describe("codexThreadToSessionHistory", () => {
         content: "status: completed\nexitCode: 0\nclean",
       },
     ]);
+  });
+
+  it("preserves distinct official agentMessage ids with duplicate text", () => {
+    const history = codexThreadToSessionHistory({
+      turns: [
+        {
+          items: [
+            { type: "agentMessage", id: "a1", text: "same reply" },
+            { type: "agentMessage", id: "a2", text: "same reply" },
+          ],
+        },
+      ],
+    });
+
+    expect(history).toEqual([
+      {
+        role: "assistant",
+        uuid: "a1",
+        content: [{ type: "text", text: "same reply" }],
+      },
+      {
+        role: "assistant",
+        uuid: "a2",
+        content: [{ type: "text", text: "same reply" }],
+      },
+    ]);
+  });
+
+  it("preserves official tool item ids and user image refs", () => {
+    const history = codexThreadToSessionHistory({
+      turns: [
+        {
+          items: [
+            {
+              type: "userMessage",
+              id: "u1",
+              content: [
+                { type: "text", text: "inspect this" },
+                { type: "localImage", path: "/tmp/local.png" },
+                {
+                  type: "image",
+                  imageUrl: "data:image/png;base64,aW1hZ2U=",
+                },
+              ],
+            },
+            {
+              type: "imageGeneration",
+              id: "img1",
+              status: "completed",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(history[0]).toMatchObject({
+      role: "user",
+      uuid: "codex:user-turn:1",
+      rawItemId: "u1",
+      content: [{ type: "text", text: "inspect this" }],
+      imageCount: 2,
+      imagePaths: ["/tmp/local.png"],
+      imageBase64: [{ data: "aW1hZ2U=", mimeType: "image/png" }],
+    });
+    expect(history[1]).toMatchObject({
+      role: "assistant",
+      uuid: "img1",
+      content: [
+        {
+          type: "tool_use",
+          id: "img1",
+          name: "ImageGeneration",
+        },
+      ],
+    });
   });
 });
 
@@ -1229,6 +1307,7 @@ describe("codex sessions integration", () => {
     });
     expect(history[1]).toEqual({
       role: "assistant",
+      uuid: "call-1",
       content: [
         {
           type: "tool_use",
@@ -1242,6 +1321,7 @@ describe("codex sessions integration", () => {
     expect(history[2].content[0].name).toBe("apply_patch");
     expect(history[3]).toEqual({
       role: "assistant",
+      uuid: "web-search-5",
       content: [
         {
           type: "tool_use",
@@ -1709,6 +1789,7 @@ describe("codex sessions integration", () => {
       },
       {
         role: "assistant",
+        uuid: "cmd-1",
         content: [
           {
             type: "tool_use",
@@ -1720,6 +1801,7 @@ describe("codex sessions integration", () => {
       },
       {
         role: "assistant",
+        uuid: "mcp-1",
         content: [
           {
             type: "tool_use",

--- a/packages/bridge/src/sessions-index.ts
+++ b/packages/bridge/src/sessions-index.ts
@@ -1896,6 +1896,8 @@ type SessionHistoryContentItem = {
 export interface SessionHistoryMessage {
   role: "user" | "assistant" | "tool_result";
   uuid?: string;
+  /** Raw provider item id, when it differs from the display-safe UUID. */
+  rawItemId?: string;
   timestamp?: string;
   /** Skill loading prompt or other meta message (rendered as a chip). */
   isMeta?: boolean;
@@ -1943,9 +1945,13 @@ function codexToolResultContent(value: unknown): string {
 function codexUserInputTextAndImages(content: unknown): {
   text: string;
   imageCount: number;
+  imagePaths: string[];
+  imageBase64: Array<{ data: string; mimeType: string }>;
 } {
   const textParts: string[] = [];
   let imageCount = 0;
+  const imagePaths: string[] = [];
+  const imageBase64: Array<{ data: string; mimeType: string }> = [];
 
   for (const entry of arrayValue(content)) {
     const item = asObject(entry);
@@ -1954,10 +1960,55 @@ function codexUserInputTextAndImages(content: unknown): {
       textParts.push(item.text);
     } else if (item.type === "image" || item.type === "localImage") {
       imageCount += 1;
+      const path = codexContentImagePath(item);
+      if (path) imagePaths.push(path);
+      const base64 = codexContentImageBase64(item);
+      if (base64) imageBase64.push(base64);
     }
   }
 
-  return { text: textParts.join("\n"), imageCount };
+  return {
+    text: textParts.join("\n"),
+    imageCount,
+    imagePaths,
+    imageBase64,
+  };
+}
+
+function codexContentImagePath(
+  item: Record<string, unknown>,
+): string | undefined {
+  return (
+    stringValue(item.path) ??
+    stringValue(item.localPath) ??
+    stringValue(item.local_path)
+  );
+}
+
+function codexContentImageBase64(
+  item: Record<string, unknown>,
+): { data: string; mimeType: string } | undefined {
+  const imageUrl =
+    stringValue(item.imageUrl) ??
+    stringValue(item.image_url) ??
+    stringValue(item.url);
+  const dataUri = extractDataUriImage(imageUrl);
+  if (dataUri) return { data: dataUri.base64, mimeType: dataUri.mimeType };
+
+  const source = asObject(item.source);
+  const data =
+    stringValue(item.base64) ??
+    stringValue(item.data) ??
+    stringValue(source?.data);
+  const mimeType =
+    stringValue(item.mimeType) ??
+    stringValue(item.mime_type) ??
+    stringValue(item.media_type) ??
+    stringValue(source?.mimeType) ??
+    stringValue(source?.mime_type) ??
+    stringValue(source?.media_type);
+
+  return data && mimeType ? { data, mimeType } : undefined;
 }
 
 function appendCodexThinkingMessage(
@@ -2002,14 +2053,14 @@ export function codexThreadToSessionHistory(
     for (const rawItem of arrayValue(turn.items)) {
       const item = asObject(rawItem);
       if (!item || typeof item.type !== "string") continue;
-      const itemId = stringValue(item.id) ?? `codex-item-${messages.length}`;
+      const rawItemId = stringValue(item.id);
+      const itemId = rawItemId ?? `codex-item-${messages.length}`;
       const itemTimestamp = turnCompletedAt ?? turnStartedAt;
 
       switch (item.type) {
         case "userMessage": {
-          const { text, imageCount } = codexUserInputTextAndImages(
-            item.content,
-          );
+          const { text, imageCount, imagePaths, imageBase64 } =
+            codexUserInputTextAndImages(item.content);
           const displayText =
             text.trim().length > 0
               ? text
@@ -2021,8 +2072,11 @@ export function codexThreadToSessionHistory(
           messages.push({
             role: "user",
             uuid: codexUserTurnUuid(userTurnOrdinal),
+            ...(rawItemId ? { rawItemId } : {}),
             content: [{ type: "text", text: displayText }],
             ...(imageCount > 0 ? { imageCount } : {}),
+            ...(imagePaths.length > 0 ? { imagePaths } : {}),
+            ...(imageBase64.length > 0 ? { imageBase64 } : {}),
             ...(turnStartedAt ? { timestamp: turnStartedAt } : {}),
           });
           break;
@@ -2034,6 +2088,7 @@ export function codexThreadToSessionHistory(
             "assistant",
             stringValue(item.text) ?? "",
             itemTimestamp,
+            itemId,
           );
           break;
         }
@@ -2243,6 +2298,7 @@ function appendTextMessage(
     && last.content[0].type === "text"
     && typeof last.content[0].text === "string"
     && last.content[0].text.trim() === normalized
+    && (!uuid || last.uuid === uuid)
   ) {
     return false;
   }
@@ -2390,6 +2446,7 @@ function appendToolUseMessage(
 
   messages.push({
     role: "assistant",
+    uuid: id,
     content: [
       {
         type: "tool_use",

--- a/packages/bridge/src/websocket.test.ts
+++ b/packages/bridge/src/websocket.test.ts
@@ -1093,6 +1093,1091 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     bridge.close();
   });
 
+  it("serves codex history deltas from canonical thread/read", async () => {
+    codexThreadToSessionHistoryMock.mockReturnValue([
+      {
+        role: "user",
+        uuid: "codex:user-turn:1",
+        rawItemId: "raw-user-1",
+        timestamp: "2026-05-29T00:00:00.000Z",
+        content: [{ type: "text", text: "sync this thread" }],
+      },
+      {
+        role: "assistant",
+        uuid: "assistant-1",
+        content: [{ type: "text", text: "synced" }],
+      },
+    ]);
+
+    const bridge = new BridgeWebSocketServer({ server: httpServer });
+    const ws = {
+      readyState: OPEN_STATE,
+      send: vi.fn(),
+    } as any;
+
+    await (bridge as any).handleClientMessage(
+      {
+        type: "start",
+        projectPath: "/tmp/project-codex",
+        provider: "codex",
+        model: "gpt-5.3-codex",
+      },
+      ws,
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const created = ws.send.mock.calls
+      .map((c: unknown[]) => JSON.parse(c[0] as string))
+      .find((m: any) => m.type === "system" && m.subtype === "session_created");
+    const sessionId = created.sessionId as string;
+    const session = (bridge as any).sessionManager.get(sessionId);
+    session.claudeSessionId = "thr_codex_1";
+    session.codexSettings = { model: "gpt-5.3-codex" };
+    session.process.readThread.mockResolvedValue({
+      id: "thr_codex_1",
+      turns: [],
+    });
+
+    ws.send.mockClear();
+    await (bridge as any).handleClientMessage(
+      {
+        type: "get_history_delta",
+        sessionId,
+        sinceSeq: 0,
+      },
+      ws,
+    );
+
+    expect(session.process.readThread).toHaveBeenCalledWith(
+      "thr_codex_1",
+      true,
+    );
+    const sends = ws.send.mock.calls.map((c: unknown[]) =>
+      JSON.parse(c[0] as string),
+    );
+    expect(sends.some((m: any) => m.type === "history_delta")).toBe(false);
+    expect(sends[0]).toMatchObject({
+      type: "history_snapshot",
+      sessionId,
+      fromSeq: 1,
+      toSeq: 2,
+      status: "idle",
+      reason: "reset",
+      messages: [
+        {
+          seq: 1,
+          message: {
+            type: "user_input",
+            text: "sync this thread",
+            userMessageUuid: "codex:user-turn:1",
+            timestamp: "2026-05-29T00:00:00.000Z",
+          },
+        },
+        {
+          seq: 2,
+          message: {
+            type: "assistant",
+            messageUuid: "assistant-1",
+            message: {
+              role: "assistant",
+              content: [{ type: "text", text: "synced" }],
+              model: "gpt-5.3-codex",
+            },
+          },
+        },
+      ],
+    });
+    expect(session.pastMessages).toHaveLength(2);
+    expect(session.history).toEqual([]);
+    expect(session.historyEntries).toEqual([]);
+    expect(session.historyRevision).toBe(2);
+    expect(session.codexCanonicalHistoryRevision).toBe(2);
+    expect(session.codexUserTurnUuidByRawId?.get("raw-user-1")).toBe(
+      "codex:user-turn:1",
+    );
+
+    ws.send.mockClear();
+    await (bridge as any).handleClientMessage(
+      {
+        type: "input",
+        sessionId,
+        text: "next turn",
+      },
+      ws,
+    );
+
+    const inputSends = ws.send.mock.calls.map((c: unknown[]) =>
+      JSON.parse(c[0] as string),
+    );
+    expect(inputSends[0]).toMatchObject({
+      type: "user_input",
+      text: "next turn",
+      userMessageUuid: "codex:user-turn:2",
+      historySeq: 3,
+    });
+
+    ws.send.mockClear();
+    await (bridge as any).handleClientMessage(
+      {
+        type: "get_history_delta",
+        sessionId,
+        sinceSeq: 2,
+      },
+      ws,
+    );
+
+    expect(session.process.readThread).toHaveBeenCalledTimes(1);
+    const deltaSends = ws.send.mock.calls.map((c: unknown[]) =>
+      JSON.parse(c[0] as string),
+    );
+    expect(deltaSends[0]).toMatchObject({
+      type: "history_delta",
+      sessionId,
+      fromSeq: 3,
+      toSeq: 3,
+      messages: [
+        {
+          seq: 3,
+          message: {
+            type: "user_input",
+            text: "next turn",
+            userMessageUuid: "codex:user-turn:2",
+            historySeq: 3,
+          },
+        },
+      ],
+    });
+
+    bridge.close();
+  });
+
+  it("serves codex get_history as legacy history from canonical thread/read", async () => {
+    codexThreadToSessionHistoryMock.mockReturnValue([
+      {
+        role: "user",
+        uuid: "codex:user-turn:1",
+        timestamp: "2026-05-29T00:00:00.000Z",
+        content: [{ type: "text", text: "restore legacy shape" }],
+      },
+      {
+        role: "assistant",
+        uuid: "assistant-legacy-1",
+        content: [{ type: "text", text: "legacy history restored" }],
+      },
+    ]);
+
+    const bridge = new BridgeWebSocketServer({ server: httpServer });
+    const ws = {
+      readyState: OPEN_STATE,
+      send: vi.fn(),
+    } as any;
+
+    await (bridge as any).handleClientMessage(
+      {
+        type: "start",
+        projectPath: "/tmp/project-codex",
+        provider: "codex",
+        model: "gpt-5.3-codex",
+      },
+      ws,
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const created = ws.send.mock.calls
+      .map((c: unknown[]) => JSON.parse(c[0] as string))
+      .find((m: any) => m.type === "system" && m.subtype === "session_created");
+    const sessionId = created.sessionId as string;
+    const session = (bridge as any).sessionManager.get(sessionId);
+    session.claudeSessionId = "thr_codex_legacy";
+    session.codexSettings = { model: "gpt-5.3-codex" };
+    session.process.readThread.mockResolvedValue({
+      id: "thr_codex_legacy",
+      turns: [],
+    });
+
+    ws.send.mockClear();
+    await (bridge as any).handleClientMessage(
+      {
+        type: "get_history",
+        sessionId,
+      },
+      ws,
+    );
+
+    expect(session.process.readThread).toHaveBeenCalledWith(
+      "thr_codex_legacy",
+      true,
+    );
+    const sends = ws.send.mock.calls.map((c: unknown[]) =>
+      JSON.parse(c[0] as string),
+    );
+    expect(sends.some((m: any) => m.type === "history_snapshot")).toBe(false);
+    expect(sends[0]).toMatchObject({
+      type: "history",
+      sessionId,
+      messages: [
+        {
+          type: "user_input",
+          text: "restore legacy shape",
+          userMessageUuid: "codex:user-turn:1",
+          timestamp: "2026-05-29T00:00:00.000Z",
+        },
+        {
+          type: "assistant",
+          messageUuid: "assistant-legacy-1",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "legacy history restored" }],
+            model: "gpt-5.3-codex",
+          },
+        },
+      ],
+    });
+    expect(sends[1]).toMatchObject({
+      type: "status",
+      status: "idle",
+      sessionId,
+    });
+
+    bridge.close();
+  });
+
+  it("serves empty codex history for unmaterialized threads", async () => {
+    codexThreadToSessionHistoryMock.mockReturnValue([]);
+
+    const bridge = new BridgeWebSocketServer({ server: httpServer });
+    const ws = {
+      readyState: OPEN_STATE,
+      send: vi.fn(),
+    } as any;
+
+    await (bridge as any).handleClientMessage(
+      {
+        type: "start",
+        projectPath: "/tmp/project-codex",
+        provider: "codex",
+        model: "gpt-5.3-codex",
+      },
+      ws,
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const created = ws.send.mock.calls
+      .map((c: unknown[]) => JSON.parse(c[0] as string))
+      .find((m: any) => m.type === "system" && m.subtype === "session_created");
+    const sessionId = created.sessionId as string;
+    const session = (bridge as any).sessionManager.get(sessionId);
+    session.claudeSessionId = "thr_codex_empty";
+    session.process.readThread.mockRejectedValue(
+      new Error(
+        "thread thr_codex_empty is not materialized yet; includeTurns is unavailable before first user message",
+      ),
+    );
+
+    ws.send.mockClear();
+    await (bridge as any).handleClientMessage(
+      {
+        type: "get_history_delta",
+        sessionId,
+        sinceSeq: 0,
+      },
+      ws,
+    );
+
+    expect(getCodexSessionHistoryMock).not.toHaveBeenCalled();
+    const sends = ws.send.mock.calls.map((c: unknown[]) =>
+      JSON.parse(c[0] as string),
+    );
+    expect(sends.some((m: any) => m.type === "error")).toBe(false);
+    expect(sends[0]).toMatchObject({
+      type: "history_snapshot",
+      sessionId,
+      fromSeq: 1,
+      toSeq: 0,
+      messages: [],
+      reason: "reset",
+    });
+    expect(session.pastMessages).toEqual([]);
+    expect(session.history).toEqual([]);
+    expect(session.historyRevision).toBe(0);
+    expect(session.codexCanonicalHistoryRevision).toBe(0);
+
+    bridge.close();
+  });
+
+  it("preserves codex live history when a canonical delta reset is needed", async () => {
+    codexThreadToSessionHistoryMock.mockReturnValue([
+      {
+        role: "user",
+        uuid: "codex:user-turn:1",
+        timestamp: "2026-05-29T00:00:00.000Z",
+        content: [{ type: "text", text: "restore this thread" }],
+      },
+    ]);
+
+    const bridge = new BridgeWebSocketServer({ server: httpServer });
+    const ws = {
+      readyState: OPEN_STATE,
+      send: vi.fn(),
+    } as any;
+
+    await (bridge as any).handleClientMessage(
+      {
+        type: "start",
+        projectPath: "/tmp/project-codex",
+        provider: "codex",
+        model: "gpt-5.3-codex",
+      },
+      ws,
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const created = ws.send.mock.calls
+      .map((c: unknown[]) => JSON.parse(c[0] as string))
+      .find((m: any) => m.type === "system" && m.subtype === "session_created");
+    const sessionId = created.sessionId as string;
+    const manager = (bridge as any).sessionManager;
+    const session = manager.get(sessionId);
+    session.claudeSessionId = "thr_codex_live";
+    session.codexSettings = { model: "gpt-5.3-codex" };
+    session.process.readThread.mockResolvedValue({
+      id: "thr_codex_live",
+      turns: [],
+    });
+    manager.appendHistory(sessionId, {
+      type: "assistant",
+      message: {
+        id: "live-assistant-1",
+        role: "assistant",
+        content: [{ type: "text", text: "live answer still streaming" }],
+        model: "gpt-5.3-codex",
+      },
+      messageUuid: "live-assistant-1",
+    });
+
+    ws.send.mockClear();
+    await (bridge as any).handleClientMessage(
+      {
+        type: "get_history_delta",
+        sessionId,
+        sinceSeq: 0,
+      },
+      ws,
+    );
+
+    const sends = ws.send.mock.calls.map((c: unknown[]) =>
+      JSON.parse(c[0] as string),
+    );
+    expect(sends[0]).toMatchObject({
+      type: "history_snapshot",
+      sessionId,
+      fromSeq: 1,
+      toSeq: 2,
+      reason: "reset",
+      messages: [
+        {
+          seq: 1,
+          message: {
+            type: "user_input",
+            text: "restore this thread",
+            userMessageUuid: "codex:user-turn:1",
+          },
+        },
+        {
+          seq: 2,
+          message: {
+            type: "assistant",
+            messageUuid: "live-assistant-1",
+            message: {
+              id: "live-assistant-1",
+              role: "assistant",
+              content: [{ type: "text", text: "live answer still streaming" }],
+              model: "gpt-5.3-codex",
+            },
+          },
+        },
+      ],
+    });
+    expect(session.codexCanonicalHistoryRevision).toBe(1);
+    expect(session.historyEntries).toMatchObject([
+      {
+        seq: 2,
+        message: {
+          type: "assistant",
+          messageUuid: "live-assistant-1",
+        },
+      },
+    ]);
+    expect(session.historyRevision).toBe(2);
+
+    bridge.close();
+  });
+
+  it("keeps codex live assistant with same text as canonical assistant when ids differ", async () => {
+    codexThreadToSessionHistoryMock.mockReturnValue([
+      {
+        role: "assistant",
+        uuid: "canonical-ok",
+        content: [{ type: "text", text: "OK" }],
+      },
+    ]);
+
+    const bridge = new BridgeWebSocketServer({ server: httpServer });
+    const ws = {
+      readyState: OPEN_STATE,
+      send: vi.fn(),
+    } as any;
+
+    await (bridge as any).handleClientMessage(
+      {
+        type: "start",
+        projectPath: "/tmp/project-codex",
+        provider: "codex",
+        model: "gpt-5.3-codex",
+      },
+      ws,
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const created = ws.send.mock.calls
+      .map((c: unknown[]) => JSON.parse(c[0] as string))
+      .find((m: any) => m.type === "system" && m.subtype === "session_created");
+    const sessionId = created.sessionId as string;
+    const manager = (bridge as any).sessionManager;
+    const session = manager.get(sessionId);
+    session.claudeSessionId = "thr_codex_same_text";
+    session.codexSettings = { model: "gpt-5.3-codex" };
+    session.process.readThread.mockResolvedValue({
+      id: "thr_codex_same_text",
+      turns: [],
+    });
+    manager.appendHistory(sessionId, {
+      type: "assistant",
+      message: {
+        id: "live-ok",
+        role: "assistant",
+        content: [{ type: "text", text: "OK" }],
+        model: "gpt-5.3-codex",
+      },
+    });
+
+    ws.send.mockClear();
+    await (bridge as any).handleClientMessage(
+      {
+        type: "get_history_delta",
+        sessionId,
+        sinceSeq: 0,
+      },
+      ws,
+    );
+
+    const sends = ws.send.mock.calls.map((c: unknown[]) =>
+      JSON.parse(c[0] as string),
+    );
+    expect(sends[0]).toMatchObject({
+      type: "history_snapshot",
+      sessionId,
+      fromSeq: 1,
+      toSeq: 2,
+      messages: [
+        {
+          seq: 1,
+          message: {
+            type: "assistant",
+            messageUuid: "canonical-ok",
+            message: {
+              id: "canonical-ok",
+              role: "assistant",
+              content: [{ type: "text", text: "OK" }],
+              model: "gpt-5.3-codex",
+            },
+          },
+        },
+        {
+          seq: 2,
+          message: {
+            type: "assistant",
+            message: {
+              id: "live-ok",
+              role: "assistant",
+              content: [{ type: "text", text: "OK" }],
+              model: "gpt-5.3-codex",
+            },
+          },
+        },
+      ],
+    });
+    expect(session.historyEntries).toMatchObject([
+      {
+        seq: 2,
+        message: {
+          type: "assistant",
+          message: {
+            id: "live-ok",
+          },
+        },
+      },
+    ]);
+
+    bridge.close();
+  });
+
+  it("deduplicates codex live tool use by canonical item id", async () => {
+    codexThreadToSessionHistoryMock.mockReturnValue([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "cmd-1",
+            name: "Bash",
+            input: { command: "npm test" },
+          },
+        ],
+      },
+    ]);
+
+    const bridge = new BridgeWebSocketServer({ server: httpServer });
+    const ws = {
+      readyState: OPEN_STATE,
+      send: vi.fn(),
+    } as any;
+
+    await (bridge as any).handleClientMessage(
+      {
+        type: "start",
+        projectPath: "/tmp/project-codex",
+        provider: "codex",
+        model: "gpt-5.3-codex",
+      },
+      ws,
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const created = ws.send.mock.calls
+      .map((c: unknown[]) => JSON.parse(c[0] as string))
+      .find((m: any) => m.type === "system" && m.subtype === "session_created");
+    const sessionId = created.sessionId as string;
+    const manager = (bridge as any).sessionManager;
+    const session = manager.get(sessionId);
+    session.claudeSessionId = "thr_codex_tool_dedupe";
+    session.codexSettings = { model: "gpt-5.3-codex" };
+    session.process.readThread.mockResolvedValue({
+      id: "thr_codex_tool_dedupe",
+      turns: [],
+    });
+    manager.appendHistory(sessionId, {
+      type: "assistant",
+      message: {
+        id: "cmd-1",
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "cmd-1",
+            name: "Bash",
+            input: { command: "npm test" },
+          },
+        ],
+        model: "gpt-5.3-codex",
+      },
+    });
+
+    ws.send.mockClear();
+    await (bridge as any).handleClientMessage(
+      {
+        type: "get_history_delta",
+        sessionId,
+        sinceSeq: 0,
+      },
+      ws,
+    );
+
+    const sends = ws.send.mock.calls.map((c: unknown[]) =>
+      JSON.parse(c[0] as string),
+    );
+    expect(sends[0]).toMatchObject({
+      type: "history_snapshot",
+      sessionId,
+      fromSeq: 1,
+      toSeq: 1,
+      messages: [
+        {
+          seq: 1,
+          message: {
+            type: "assistant",
+            message: {
+              id: "cmd-1",
+              content: [
+                {
+                  type: "tool_use",
+                  id: "cmd-1",
+                  name: "Bash",
+                },
+              ],
+            },
+          },
+        },
+      ],
+    });
+    expect(session.historyEntries).toEqual([]);
+    expect(session.historyRevision).toBe(1);
+
+    bridge.close();
+  });
+
+  it("deduplicates codex live tool result by canonical item id when content differs", async () => {
+    codexThreadToSessionHistoryMock.mockReturnValue([
+      {
+        role: "tool_result",
+        toolUseId: "cmd-1",
+        toolName: "Bash",
+        content: "status: completed\nexitCode: 0\nclean",
+      },
+    ]);
+
+    const bridge = new BridgeWebSocketServer({ server: httpServer });
+    const ws = {
+      readyState: OPEN_STATE,
+      send: vi.fn(),
+    } as any;
+
+    await (bridge as any).handleClientMessage(
+      {
+        type: "start",
+        projectPath: "/tmp/project-codex",
+        provider: "codex",
+        model: "gpt-5.3-codex",
+      },
+      ws,
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const created = ws.send.mock.calls
+      .map((c: unknown[]) => JSON.parse(c[0] as string))
+      .find((m: any) => m.type === "system" && m.subtype === "session_created");
+    const sessionId = created.sessionId as string;
+    const manager = (bridge as any).sessionManager;
+    const session = manager.get(sessionId);
+    session.claudeSessionId = "thr_codex_tool_result_dedupe";
+    session.codexSettings = { model: "gpt-5.3-codex" };
+    session.process.readThread.mockResolvedValue({
+      id: "thr_codex_tool_result_dedupe",
+      turns: [],
+    });
+    manager.appendHistory(sessionId, {
+      type: "tool_result",
+      toolUseId: "cmd-1",
+      toolName: "Bash",
+      content: "clean",
+    });
+
+    ws.send.mockClear();
+    await (bridge as any).handleClientMessage(
+      {
+        type: "get_history_delta",
+        sessionId,
+        sinceSeq: 0,
+      },
+      ws,
+    );
+
+    const sends = ws.send.mock.calls.map((c: unknown[]) =>
+      JSON.parse(c[0] as string),
+    );
+    expect(sends[0]).toMatchObject({
+      type: "history_snapshot",
+      sessionId,
+      fromSeq: 1,
+      toSeq: 1,
+      messages: [
+        {
+          seq: 1,
+          message: {
+            type: "tool_result",
+            toolUseId: "cmd-1",
+            toolName: "Bash",
+            content: "status: completed\nexitCode: 0\nclean",
+          },
+        },
+      ],
+    });
+    expect(session.historyEntries).toEqual([]);
+    expect(session.historyRevision).toBe(1);
+
+    bridge.close();
+  });
+
+  it("preserves codex live history appended while canonical read is pending", async () => {
+    codexThreadToSessionHistoryMock.mockReturnValue([
+      {
+        role: "user",
+        uuid: "codex:user-turn:1",
+        content: [{ type: "text", text: "stored before pending read" }],
+      },
+    ]);
+
+    const bridge = new BridgeWebSocketServer({ server: httpServer });
+    const ws = {
+      readyState: OPEN_STATE,
+      send: vi.fn(),
+    } as any;
+
+    await (bridge as any).handleClientMessage(
+      {
+        type: "start",
+        projectPath: "/tmp/project-codex",
+        provider: "codex",
+        model: "gpt-5.3-codex",
+      },
+      ws,
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const created = ws.send.mock.calls
+      .map((c: unknown[]) => JSON.parse(c[0] as string))
+      .find((m: any) => m.type === "system" && m.subtype === "session_created");
+    const sessionId = created.sessionId as string;
+    const manager = (bridge as any).sessionManager;
+    const session = manager.get(sessionId);
+    session.claudeSessionId = "thr_codex_pending";
+    session.codexSettings = { model: "gpt-5.3-codex" };
+
+    let resolveRead!: (thread: unknown) => void;
+    const pendingRead = new Promise((resolve) => {
+      resolveRead = resolve;
+    });
+    session.process.readThread.mockReturnValue(pendingRead);
+
+    ws.send.mockClear();
+    const pendingHistory = (bridge as any).handleClientMessage(
+      {
+        type: "get_history_delta",
+        sessionId,
+        sinceSeq: 0,
+      },
+      ws,
+    );
+    await Promise.resolve();
+
+    manager.appendHistory(sessionId, {
+      type: "assistant",
+      message: {
+        id: "live-during-read",
+        role: "assistant",
+        content: [{ type: "text", text: "arrived during read" }],
+        model: "gpt-5.3-codex",
+      },
+      messageUuid: "live-during-read",
+    });
+    resolveRead({ id: "thr_codex_pending", turns: [] });
+    await pendingHistory;
+
+    const sends = ws.send.mock.calls.map((c: unknown[]) =>
+      JSON.parse(c[0] as string),
+    );
+    expect(sends[0]).toMatchObject({
+      type: "history_snapshot",
+      sessionId,
+      fromSeq: 1,
+      toSeq: 2,
+      messages: [
+        {
+          seq: 1,
+          message: {
+            type: "user_input",
+            text: "stored before pending read",
+            userMessageUuid: "codex:user-turn:1",
+          },
+        },
+        {
+          seq: 2,
+          message: {
+            type: "assistant",
+            messageUuid: "live-during-read",
+            message: {
+              id: "live-during-read",
+              role: "assistant",
+              content: [{ type: "text", text: "arrived during read" }],
+              model: "gpt-5.3-codex",
+            },
+          },
+        },
+      ],
+    });
+    expect(session.historyEntries).toMatchObject([
+      {
+        seq: 2,
+        message: {
+          type: "assistant",
+          messageUuid: "live-during-read",
+        },
+      },
+    ]);
+
+    bridge.close();
+  });
+
+  it("keeps codex canonical tool result images in history snapshots", async () => {
+    codexThreadToSessionHistoryMock.mockReturnValue([
+      {
+        role: "tool_result",
+        toolUseId: "ig-1",
+        toolName: "ImageGeneration",
+        content: "status: completed",
+        imageBase64: [{ data: "aGVsbG8=", mimeType: "image/png" }],
+      },
+    ]);
+    const imageStore = {
+      extractImagePaths: vi.fn(() => []),
+      registerImages: vi.fn(async () => []),
+      registerFromBase64: vi.fn(() => ({
+        id: "img-canonical",
+        url: "/images/img-canonical",
+        mimeType: "image/png",
+      })),
+    };
+
+    const bridge = new BridgeWebSocketServer({
+      server: httpServer,
+      imageStore: imageStore as any,
+    });
+    const ws = {
+      readyState: OPEN_STATE,
+      send: vi.fn(),
+    } as any;
+
+    await (bridge as any).handleClientMessage(
+      {
+        type: "start",
+        projectPath: "/tmp/project-codex",
+        provider: "codex",
+      },
+      ws,
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const created = ws.send.mock.calls
+      .map((c: unknown[]) => JSON.parse(c[0] as string))
+      .find((m: any) => m.type === "system" && m.subtype === "session_created");
+    const sessionId = created.sessionId as string;
+    const session = (bridge as any).sessionManager.get(sessionId);
+    session.claudeSessionId = "thr_codex_images";
+    session.process.readThread.mockResolvedValue({
+      id: "thr_codex_images",
+      turns: [],
+    });
+
+    ws.send.mockClear();
+    await (bridge as any).handleClientMessage(
+      {
+        type: "get_history_delta",
+        sessionId,
+        sinceSeq: 0,
+      },
+      ws,
+    );
+
+    expect(imageStore.registerFromBase64).toHaveBeenCalledWith(
+      "aGVsbG8=",
+      "image/png",
+    );
+    const sends = ws.send.mock.calls.map((c: unknown[]) =>
+      JSON.parse(c[0] as string),
+    );
+    expect(sends[0]).toMatchObject({
+      type: "history_snapshot",
+      messages: [
+        {
+          seq: 1,
+          message: {
+            type: "tool_result",
+            toolUseId: "ig-1",
+            toolName: "ImageGeneration",
+            images: [
+              {
+                id: "img-canonical",
+                url: "/images/img-canonical",
+                mimeType: "image/png",
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    bridge.close();
+  });
+
+  it("keeps codex canonical user image refs in history snapshots", async () => {
+    codexThreadToSessionHistoryMock.mockReturnValue([
+      {
+        role: "user",
+        uuid: "codex:user-turn:1",
+        content: [{ type: "text", text: "look at this" }],
+        imageCount: 2,
+        imagePaths: ["/tmp/project-codex/local.png"],
+        imageBase64: [{ data: "aGVsbG8=", mimeType: "image/png" }],
+      },
+    ]);
+    const imageStore = {
+      registerImages: vi.fn(async () => [
+        {
+          id: "img-local",
+          url: "/images/img-local",
+          mimeType: "image/png",
+        },
+      ]),
+      registerFromBase64: vi.fn(() => ({
+        id: "img-base64",
+        url: "/images/img-base64",
+        mimeType: "image/png",
+      })),
+    };
+
+    const bridge = new BridgeWebSocketServer({
+      server: httpServer,
+      imageStore: imageStore as any,
+    });
+    const ws = {
+      readyState: OPEN_STATE,
+      send: vi.fn(),
+    } as any;
+
+    await (bridge as any).handleClientMessage(
+      {
+        type: "start",
+        projectPath: "/tmp/project-codex",
+        provider: "codex",
+      },
+      ws,
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const created = ws.send.mock.calls
+      .map((c: unknown[]) => JSON.parse(c[0] as string))
+      .find((m: any) => m.type === "system" && m.subtype === "session_created");
+    const sessionId = created.sessionId as string;
+    const session = (bridge as any).sessionManager.get(sessionId);
+    session.claudeSessionId = "thr_codex_user_images";
+    session.process.readThread.mockResolvedValue({
+      id: "thr_codex_user_images",
+      turns: [],
+    });
+
+    ws.send.mockClear();
+    await (bridge as any).handleClientMessage(
+      {
+        type: "get_history_delta",
+        sessionId,
+        sinceSeq: 0,
+      },
+      ws,
+    );
+
+    expect(imageStore.registerImages).toHaveBeenCalledWith(
+      ["/tmp/project-codex/local.png"],
+      "/tmp/project-codex",
+    );
+    expect(imageStore.registerFromBase64).toHaveBeenCalledWith(
+      "aGVsbG8=",
+      "image/png",
+    );
+    expect(extractMessageImagesMock).not.toHaveBeenCalled();
+    const sends = ws.send.mock.calls.map((c: unknown[]) =>
+      JSON.parse(c[0] as string),
+    );
+    expect(sends[0]).toMatchObject({
+      type: "history_snapshot",
+      messages: [
+        {
+          seq: 1,
+          message: {
+            type: "user_input",
+            text: "look at this",
+            imageCount: 2,
+            images: [
+              {
+                id: "img-local",
+                url: "/images/img-local",
+                mimeType: "image/png",
+              },
+              {
+                id: "img-base64",
+                url: "/images/img-base64",
+                mimeType: "image/png",
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    bridge.close();
+  });
+
+  it("reports codex canonical history read failures without JSONL fallback", async () => {
+    codexThreadToSessionHistoryMock.mockReturnValue([]);
+
+    const bridge = new BridgeWebSocketServer({ server: httpServer });
+    const ws = {
+      readyState: OPEN_STATE,
+      send: vi.fn(),
+    } as any;
+
+    await (bridge as any).handleClientMessage(
+      {
+        type: "start",
+        projectPath: "/tmp/project-codex",
+        provider: "codex",
+      },
+      ws,
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const created = ws.send.mock.calls
+      .map((c: unknown[]) => JSON.parse(c[0] as string))
+      .find((m: any) => m.type === "system" && m.subtype === "session_created");
+    const sessionId = created.sessionId as string;
+    const session = (bridge as any).sessionManager.get(sessionId);
+    session.claudeSessionId = "thr_codex_error";
+    session.process.readThread.mockRejectedValue(new Error("rpc unavailable"));
+
+    ws.send.mockClear();
+    await (bridge as any).handleClientMessage(
+      {
+        type: "get_history",
+        sessionId,
+      },
+      ws,
+    );
+
+    const sends = ws.send.mock.calls.map((c: unknown[]) =>
+      JSON.parse(c[0] as string),
+    );
+    expect(getCodexSessionHistoryMock).not.toHaveBeenCalled();
+    expect(sends).toEqual([
+      {
+        type: "error",
+        message:
+          "Failed to read Codex thread history: rpc unavailable",
+      },
+    ]);
+
+    bridge.close();
+  });
+
   it("keeps restored image generation results in past history order", async () => {
     getSessionHistoryMock.mockResolvedValue([
       {
@@ -3035,6 +4120,84 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     bridge.close();
   });
 
+  it("rejects codex strict input older than canonical baseline", async () => {
+    codexThreadToSessionHistoryMock.mockReturnValue([
+      {
+        role: "user",
+        uuid: "codex:user-turn:1",
+        content: [{ type: "text", text: "canonical turn" }],
+      },
+    ]);
+
+    const bridge = new BridgeWebSocketServer({ server: httpServer });
+    const ws = {
+      readyState: OPEN_STATE,
+      send: vi.fn(),
+    } as any;
+
+    await (bridge as any).handleClientMessage(
+      {
+        type: "start",
+        projectPath: "/tmp/project-codex",
+        provider: "codex",
+      },
+      ws,
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const created = ws.send.mock.calls
+      .map((c: unknown[]) => JSON.parse(c[0] as string))
+      .find((m: any) => m.type === "system" && m.subtype === "session_created");
+    const sessionId = created.sessionId as string;
+    const session = (bridge as any).sessionManager.get(sessionId);
+    session.claudeSessionId = "thr_codex_base_seq";
+    session.process.readThread.mockResolvedValue({
+      id: "thr_codex_base_seq",
+      turns: [],
+    });
+
+    ws.send.mockClear();
+    await (bridge as any).handleClientMessage(
+      {
+        type: "get_history_delta",
+        sessionId,
+        sinceSeq: 0,
+      },
+      ws,
+    );
+    expect(session.codexCanonicalHistoryRevision).toBe(1);
+
+    ws.send.mockClear();
+    await (bridge as any).handleClientMessage(
+      {
+        type: "input",
+        sessionId,
+        text: "offline input",
+        clientMessageId: "cm-codex-conflict",
+        baseSeq: 0,
+      },
+      ws,
+    );
+
+    const rejected = ws.send.mock.calls
+      .map((c: unknown[]) => JSON.parse(c[0] as string))
+      .find((m: any) => m.type === "input_rejected");
+    expect(rejected).toMatchObject({
+      type: "input_rejected",
+      sessionId,
+      clientMessageId: "cm-codex-conflict",
+      reason: "conflict",
+    });
+    expect(
+      ws.send.mock.calls
+        .map((c: unknown[]) => JSON.parse(c[0] as string))
+        .some((m: any) => m.type === "user_input"),
+    ).toBe(false);
+
+    bridge.close();
+  });
+
   it("codex busy input is queued and included in session_list", async () => {
     const bridge = new BridgeWebSocketServer({ server: httpServer });
     const ws = {
@@ -3832,6 +4995,7 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
       limit: 20,
       cwd: "/tmp/project-codex",
       searchTerm: undefined,
+      sourceKinds: ["cli", "vscode", "appServer"],
     });
     expect(getCodexSessionIndexMetadataMock).toHaveBeenCalledWith([
       "thr_codex_1",

--- a/packages/bridge/src/websocket.ts
+++ b/packages/bridge/src/websocket.ts
@@ -8,6 +8,7 @@ import { promisify } from "node:util";
 import { WebSocketServer, WebSocket } from "ws";
 import {
   SessionManager,
+  type HistoryEntry,
   type SessionInfo,
   type WorktreeOptions,
 } from "./session.js";
@@ -22,11 +23,13 @@ import {
   CodexProcess,
   type CodexModelMetadata,
   type CodexStartOptions,
+  type CodexThreadSourceKind,
   type CodexThreadSummary,
 } from "./codex-process.js";
 import { stopManagedCodexAppServers } from "./codex-transport.js";
 import {
   parseClientMessage,
+  type AssistantContent,
   type ClientMessage,
   type DebugTraceEvent,
   type ImageChange,
@@ -135,6 +138,12 @@ const FALLBACK_CODEX_MODELS: string[] = [
 ];
 
 const FALLBACK_CODEX_REASONING_EFFORTS = ["low", "medium", "high", "xhigh"];
+
+const CODEX_RECENT_THREAD_SOURCE_KINDS: CodexThreadSourceKind[] = [
+  "cli",
+  "vscode",
+  "appServer",
+];
 
 const CODEX_USER_TURN_UUID_RE = /^codex:user-turn:(\d+)$/;
 
@@ -1199,43 +1208,8 @@ export class BridgeWebSocketServer {
         continue;
       }
 
-      const paths = new Set<string>();
-      if (Array.isArray(msg.imagePaths)) {
-        for (const path of msg.imagePaths) {
-          if (typeof path === "string" && path.length > 0) paths.add(path);
-        }
-      }
-
       const content = typeof msg.content === "string" ? msg.content : "";
-      if (this.imageStore && content) {
-        for (const path of this.imageStore.extractImagePaths(content)) {
-          paths.add(path);
-        }
-      }
-
-      const images =
-        this.imageStore && paths.size > 0
-          ? await this.imageStore.registerImages([...paths], session.projectPath)
-          : [];
-      if (this.imageStore && Array.isArray(msg.imageBase64)) {
-        for (const image of msg.imageBase64) {
-          const rawImage = image as Record<string, unknown>;
-          if (
-            typeof rawImage.data !== "string"
-            || typeof rawImage.mimeType !== "string"
-          ) {
-            continue;
-          }
-          const ref = this.imageStore.registerFromBase64(
-            rawImage.data,
-            rawImage.mimeType,
-          );
-          if (ref) images.push(ref);
-        }
-      }
-      const existingImages = Array.isArray(msg.images)
-        ? (msg.images as ImageRef[])
-        : [];
+      const images = await this.registerPastToolResultImages(session, msg);
 
       pastMessages.push({
         role: "tool_result",
@@ -1245,13 +1219,370 @@ export class BridgeWebSocketServer {
             : `past-tool-result-${pastMessages.length}`,
         content,
         ...(typeof msg.toolName === "string" ? { toolName: msg.toolName } : {}),
-        ...(existingImages.length > 0 || images.length > 0
-          ? { images: [...existingImages, ...images] }
-          : {}),
+        ...(images.length > 0 ? { images } : {}),
       });
     }
 
     return { pastMessages, historyMessages };
+  }
+
+  private codexThreadIdForSession(session: SessionInfo): string | undefined {
+    if (session.provider !== "codex") return undefined;
+    if (session.claudeSessionId) return session.claudeSessionId;
+    if (session.process instanceof CodexProcess) {
+      return session.process.sessionId ?? undefined;
+    }
+    return undefined;
+  }
+
+  private async codexCanonicalHistoryEntries(
+    session: SessionInfo,
+  ): Promise<HistoryEntry[] | null> {
+    const threadId = this.codexThreadIdForSession(session);
+    if (!threadId) return null;
+
+    const history = await this.getCodexThreadHistory(
+      threadId,
+      session.projectPath,
+    );
+    session.claudeSessionId = threadId;
+
+    const messages = await this.codexHistoryToServerMessages(session, history);
+    const entries = messages.map((message, index) => ({
+      seq: index + 1,
+      message,
+    }));
+    this.applyCodexCanonicalHistoryBaseline(
+      session,
+      history,
+      entries,
+    );
+    return [...entries, ...session.historyEntries];
+  }
+
+  private applyCodexCanonicalHistoryBaseline(
+    session: SessionInfo,
+    history: SessionHistoryMessage[],
+    canonicalEntries: HistoryEntry[],
+  ): void {
+    const liveEntries = session.historyEntries.map((entry) => ({
+      seq: entry.seq,
+      message: entry.message,
+    }));
+    const canonicalKeys = new Set<string>();
+    const canonicalUserUuids = new Set<string>();
+    for (const entry of canonicalEntries) {
+      for (const key of this.codexHistoryMessageIdentityKeys(entry.message)) {
+        canonicalKeys.add(key);
+      }
+      const message = entry.message;
+      if (message.type === "user_input" && message.userMessageUuid) {
+        canonicalUserUuids.add(message.userMessageUuid);
+      }
+    }
+
+    this.seedCodexCanonicalUserTurnUuidMap(session, history);
+
+    let nextSeq = canonicalEntries.at(-1)?.seq ?? 0;
+    const retainedMessages: ServerMessage[] = [];
+    const retainedEntries: HistoryEntry[] = [];
+    for (const entry of liveEntries) {
+      if (!this.shouldRetainCodexLiveHistoryMessage(entry.message)) continue;
+      const keys = this.codexHistoryMessageIdentityKeys(entry.message);
+      if (keys.some((key) => canonicalKeys.has(key))) continue;
+      const seq = ++nextSeq;
+      (entry.message as Record<string, unknown>).historySeq = seq;
+      retainedMessages.push(entry.message);
+      retainedEntries.push({ seq, message: entry.message });
+    }
+
+    session.pastMessages = history;
+    session.history = retainedMessages;
+    session.historyEntries = retainedEntries;
+    session.historyRevision = nextSeq;
+    session.codexCanonicalHistoryRevision = canonicalEntries.at(-1)?.seq ?? 0;
+    session.historyLowWatermark =
+      retainedEntries[0]?.seq ?? session.historyRevision + 1;
+
+    if (session.pendingCodexUserEchoUuids) {
+      for (const uuid of canonicalUserUuids) {
+        session.pendingCodexUserEchoUuids.delete(uuid);
+      }
+      for (const uuid of [...session.pendingCodexUserEchoUuids]) {
+        const stillLive = retainedMessages.some(
+          (message) =>
+            message.type === "user_input" && message.userMessageUuid === uuid,
+        );
+        if (!stillLive) session.pendingCodexUserEchoUuids.delete(uuid);
+      }
+    }
+  }
+
+  private seedCodexCanonicalUserTurnUuidMap(
+    session: SessionInfo,
+    history: SessionHistoryMessage[],
+  ): void {
+    if (session.provider !== "codex") return;
+    for (const message of history) {
+      if (
+        message.role !== "user" ||
+        !message.rawItemId ||
+        !message.uuid
+      ) {
+        continue;
+      }
+      session.codexUserTurnUuidByRawId ??= new Map<string, string>();
+      session.codexUserTurnUuidByRawId.set(message.rawItemId, message.uuid);
+    }
+  }
+
+  private shouldRetainCodexLiveHistoryMessage(message: ServerMessage): boolean {
+    return !(
+      message.type === "system" &&
+      (message as Record<string, unknown>).subtype === "tip"
+    );
+  }
+
+  private codexHistoryMessageIdentityKeys(message: ServerMessage): string[] {
+    if (message.type === "user_input") {
+      return message.userMessageUuid ? [`user:${message.userMessageUuid}`] : [];
+    }
+    if (message.type === "assistant") {
+      const assistantId = message.messageUuid ?? message.message.id;
+      if (assistantId) return [`assistant:${assistantId}`];
+      return [
+        `assistant-content:${this.historyValueKey(message.message.content)}`,
+      ];
+    }
+    if (message.type === "tool_result") {
+      if (message.toolUseId) {
+        return [`tool-result:${message.toolUseId}:${message.toolName ?? ""}`];
+      }
+      return [
+        `tool-result-content:${message.toolName ?? ""}:${message.content}`,
+      ];
+    }
+    return [];
+  }
+
+  private historyValueKey(value: unknown): string {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return String(value);
+    }
+  }
+
+  private async sendCodexCanonicalHistorySnapshot(
+    ws: WebSocket,
+    sessionId: string,
+    session: SessionInfo,
+    options: { includeCachedCommands?: boolean } = {},
+  ): Promise<boolean> {
+    try {
+      const entries = await this.codexCanonicalHistoryEntries(session);
+      if (!entries) return false;
+      this.send(ws, {
+        type: "history_snapshot",
+        sessionId,
+        fromSeq: entries[0]?.seq ?? 1,
+        toSeq: entries.at(-1)?.seq ?? 0,
+        messages: entries,
+        status: session.status,
+        reason: "reset",
+      } satisfies Extract<ServerMessage, { type: "history_snapshot" }>);
+      this.sendCodexQueueState(ws, sessionId, session);
+      if (options.includeCachedCommands) {
+        this.sendCachedCommands(ws, sessionId, session);
+      }
+      return true;
+    } catch (err) {
+      this.send(ws, {
+        type: "error",
+        message: `Failed to read Codex thread history: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      });
+      return true;
+    }
+  }
+
+  private async sendCodexCanonicalLegacyHistory(
+    ws: WebSocket,
+    sessionId: string,
+    session: SessionInfo,
+  ): Promise<boolean> {
+    try {
+      const entries = await this.codexCanonicalHistoryEntries(session);
+      if (!entries) return false;
+      this.send(ws, {
+        type: "history",
+        messages: entries.map((entry) => entry.message),
+        sessionId,
+      } as Record<string, unknown>);
+      this.send(ws, {
+        type: "status",
+        status: session.status,
+        sessionId,
+      } as Record<string, unknown>);
+      this.sendCodexQueueState(ws, sessionId, session);
+      this.sendCachedCommands(ws, sessionId, session);
+      return true;
+    } catch (err) {
+      this.send(ws, {
+        type: "error",
+        message: `Failed to read Codex thread history: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      });
+      return true;
+    }
+  }
+
+  private shouldResetCodexHistoryDelta(
+    session: SessionInfo,
+    sinceSeq: number,
+    resultKind: "delta" | "snapshot",
+  ): boolean {
+    if (!this.codexThreadIdForSession(session)) return false;
+    if (typeof session.codexCanonicalHistoryRevision !== "number") return true;
+    if (sinceSeq < session.codexCanonicalHistoryRevision) return true;
+    return resultKind === "snapshot";
+  }
+
+  private async codexHistoryToServerMessages(
+    session: SessionInfo,
+    history: SessionHistoryMessage[],
+  ): Promise<ServerMessage[]> {
+    const messages: ServerMessage[] = [];
+    for (const item of history) {
+      const converted = await this.codexHistoryMessageToServerMessage(
+        session,
+        item,
+      );
+      if (converted) messages.push(converted);
+    }
+    return messages;
+  }
+
+  private async codexHistoryMessageToServerMessage(
+    session: SessionInfo,
+    item: SessionHistoryMessage,
+  ): Promise<ServerMessage | null> {
+    if (item.role === "user") {
+      const images = await this.registerPastUserMessageImages(
+        session,
+        item as unknown as Record<string, unknown>,
+      );
+      const text = this.sessionHistoryText(item.content);
+      if (!text && item.imageCount == null && images.length === 0) return null;
+      return {
+        type: "user_input",
+        text,
+        ...(item.uuid ? { userMessageUuid: item.uuid } : {}),
+        ...(item.isMeta ? { isMeta: true } : {}),
+        ...(item.imageCount != null || images.length > 0
+          ? { imageCount: Math.max(item.imageCount ?? 0, images.length) }
+          : {}),
+        ...(item.timestamp ? { timestamp: item.timestamp } : {}),
+        ...(images.length > 0 ? { images } : {}),
+      };
+    }
+
+    if (item.role === "assistant") {
+      const content = this.sessionHistoryAssistantContent(item.content);
+      if (content.length === 0) return null;
+      const messageId =
+        item.uuid ??
+        this.sessionHistorySingleToolUseId(item.content) ??
+        randomUUID();
+      return {
+        type: "assistant",
+        message: {
+          id: messageId,
+          role: "assistant",
+          content,
+          model: session.codexSettings?.model ?? "",
+        },
+        ...(item.uuid ? { messageUuid: item.uuid } : {}),
+      };
+    }
+
+    const images = await this.registerPastToolResultImages(
+      session,
+      item as unknown as Record<string, unknown>,
+    );
+    const content = this.sessionHistoryText(item.content);
+    if (!content && images.length === 0) return null;
+    return {
+      type: "tool_result",
+      toolUseId:
+        item.toolUseId ?? item.uuid ?? `codex-history-tool-${randomUUID()}`,
+      content,
+      ...(item.toolName ? { toolName: item.toolName } : {}),
+      ...(images.length > 0 ? { images } : {}),
+    };
+  }
+
+  private sessionHistoryText(content: SessionHistoryMessage["content"]): string {
+    if (typeof content === "string") return content;
+    if (!Array.isArray(content)) return "";
+    return content
+      .map((item) => {
+        if (item.type === "text" && typeof item.text === "string") {
+          return item.text;
+        }
+        if (item.type === "thinking" && typeof item.thinking === "string") {
+          return item.thinking;
+        }
+        return "";
+      })
+      .filter((text) => text.length > 0)
+      .join("\n");
+  }
+
+  private sessionHistoryAssistantContent(
+    content: SessionHistoryMessage["content"],
+  ): AssistantContent[] {
+    if (typeof content === "string") {
+      return content.trim().length > 0
+        ? [{ type: "text", text: content }]
+        : [];
+    }
+    if (!Array.isArray(content)) return [];
+    const items: AssistantContent[] = [];
+    for (const item of content) {
+      if (item.type === "text" && typeof item.text === "string") {
+        items.push({ type: "text", text: item.text });
+      } else if (
+        item.type === "thinking" &&
+        typeof item.thinking === "string"
+      ) {
+        items.push({ type: "thinking", thinking: item.thinking });
+      } else if (
+        item.type === "tool_use" &&
+        typeof item.id === "string" &&
+        typeof item.name === "string"
+      ) {
+        items.push({
+          type: "tool_use",
+          id: item.id,
+          name: item.name,
+          input: item.input ?? {},
+        });
+      }
+    }
+    return items;
+  }
+
+  private sessionHistorySingleToolUseId(
+    content: SessionHistoryMessage["content"],
+  ): string | undefined {
+    if (!Array.isArray(content) || content.length !== 1) return undefined;
+    const item = content[0];
+    return item.type === "tool_use" && typeof item.id === "string"
+      ? item.id
+      : undefined;
   }
 
   private async registerPastUserMessageImages(
@@ -1264,6 +1595,17 @@ export class BridgeWebSocketServer {
       ? (msg.images as ImageRef[])
       : [];
     const refs: ImageRef[] = [...existingImages];
+
+    if (Array.isArray(msg.imagePaths)) {
+      const paths = msg.imagePaths.filter(
+        (path): path is string => typeof path === "string" && path.length > 0,
+      );
+      if (paths.length > 0) {
+        refs.push(
+          ...(await this.imageStore.registerImages(paths, session.projectPath)),
+        );
+      }
+    }
 
     if (Array.isArray(msg.imageBase64)) {
       for (const image of msg.imageBase64) {
@@ -1313,6 +1655,56 @@ export class BridgeWebSocketServer {
     return refs;
   }
 
+  private async registerPastToolResultImages(
+    session: SessionInfo,
+    msg: Record<string, unknown>,
+  ): Promise<ImageRef[]> {
+    const existingImages = Array.isArray(msg.images)
+      ? (msg.images as ImageRef[])
+      : [];
+    if (!this.imageStore) return [...existingImages];
+
+    const paths = new Set<string>();
+    if (Array.isArray(msg.imagePaths)) {
+      for (const path of msg.imagePaths) {
+        if (typeof path === "string" && path.length > 0) paths.add(path);
+      }
+    }
+
+    const content = typeof msg.content === "string" ? msg.content : "";
+    if (content) {
+      for (const path of this.imageStore.extractImagePaths(content)) {
+        paths.add(path);
+      }
+    }
+
+    const refs: ImageRef[] = [...existingImages];
+    if (paths.size > 0) {
+      refs.push(
+        ...(await this.imageStore.registerImages([...paths], session.projectPath)),
+      );
+    }
+
+    if (Array.isArray(msg.imageBase64)) {
+      for (const image of msg.imageBase64) {
+        const rawImage = image as Record<string, unknown>;
+        if (
+          typeof rawImage.data !== "string" ||
+          typeof rawImage.mimeType !== "string"
+        ) {
+          continue;
+        }
+        const ref = this.imageStore.registerFromBase64(
+          rawImage.data,
+          rawImage.mimeType,
+        );
+        if (ref) refs.push(ref);
+      }
+    }
+
+    return refs;
+  }
+
   private async getCodexThreadHistoryFromRpc(
     threadId: string,
     projectPath?: string,
@@ -1324,11 +1716,22 @@ export class BridgeWebSocketServer {
     try {
       const thread = await process.readThread(threadId, true);
       return codexThreadToSessionHistory(thread);
+    } catch (err) {
+      if (this.isCodexThreadNotMaterializedError(err)) return [];
+      throw err;
     } finally {
       if (isStandalone) {
         process.stop();
       }
     }
+  }
+
+  private isCodexThreadNotMaterializedError(err: unknown): boolean {
+    const message = err instanceof Error ? err.message : String(err);
+    return (
+      message.includes("is not materialized yet") &&
+      message.includes("includeTurns is unavailable before first user message")
+    );
   }
 
   private async getCodexThreadHistory(
@@ -1338,16 +1741,7 @@ export class BridgeWebSocketServer {
     if (!this.getActiveCodexProcess() && process.env.NODE_ENV === "test") {
       return getCodexSessionHistory(threadId);
     }
-    try {
-      return await this.getCodexThreadHistoryFromRpc(threadId, projectPath);
-    } catch (err) {
-      console.warn(
-        `[ws] thread/read failed for ${threadId}; falling back to JSONL: ${
-          err instanceof Error ? err.message : String(err)
-        }`,
-      );
-      return getCodexSessionHistory(threadId);
-    }
+    return this.getCodexThreadHistoryFromRpc(threadId, projectPath);
   }
 
   private codexHistoryFromThreadOrFallback(params: {
@@ -1835,7 +2229,7 @@ export class BridgeWebSocketServer {
         if (
           clientMessageId &&
           baseSeq !== undefined &&
-          this.hasInputConflictSince(session.id, baseSeq)
+          this.hasInputConflictSince(session, baseSeq)
         ) {
           this.send(ws, {
             type: "input_rejected",
@@ -3138,6 +3532,17 @@ export class BridgeWebSocketServer {
       case "get_history": {
         const session = this.sessionManager.get(msg.sessionId);
         if (session) {
+          if (session.provider === "codex") {
+            const handled = await this.sendCodexCanonicalLegacyHistory(
+              ws,
+              msg.sessionId,
+              session,
+            );
+            if (handled) {
+              break;
+            }
+          }
+
           const splitPastHistory =
             session.pastMessages && session.pastMessages.length > 0
               ? await this.splitPastHistoryMessages(session)
@@ -3162,61 +3567,10 @@ export class BridgeWebSocketServer {
             sessionId: msg.sessionId,
           } as Record<string, unknown>);
           if (session.provider === "codex") {
-            const item = session.codexQueuedInput;
-            this.sendConversationQueue(ws, {
-              type: "conversation_queue",
-              sessionId: msg.sessionId,
-              limit: 1,
-              items: item
-                ? [
-                    {
-                      itemId: item.itemId,
-                      text: item.text,
-                      createdAt: item.createdAt,
-                      ...(item.updatedAt ? { updatedAt: item.updatedAt } : {}),
-                      ...(item.imageCount
-                        ? { imageCount: item.imageCount }
-                        : {}),
-                      ...(item.skills?.length ? { skills: item.skills } : {}),
-                      ...(item.mentions?.length
-                        ? { mentions: item.mentions }
-                        : {}),
-                    },
-                  ]
-                : [],
-            } as Record<string, unknown>);
+            this.sendCodexQueueState(ws, msg.sessionId, session);
           }
 
-          // Send cached slash commands so the client can restore them even when
-          // the original init/supported_commands message was evicted from the
-          // in-memory history (MAX_HISTORY_PER_SESSION overflow).
-          const cached = this.sessionManager.getCachedCommands(
-            session.projectPath,
-          );
-          if (
-            cached &&
-            (cached.slashCommands.length > 0 ||
-                cached.skills.length > 0 ||
-                cached.apps.length > 0 ||
-                cached.plugins.length > 0)
-          ) {
-            this.send(ws, {
-              type: "system",
-              subtype: "supported_commands",
-              sessionId: msg.sessionId,
-              slashCommands: cached.slashCommands,
-              skills: cached.skills,
-              ...(cached.skillMetadata
-                ? { skillMetadata: cached.skillMetadata }
-                : {}),
-              apps: cached.apps,
-              ...(cached.appMetadata ? { appMetadata: cached.appMetadata } : {}),
-              plugins: cached.plugins,
-              ...(cached.pluginMetadata
-                ? { pluginMetadata: cached.pluginMetadata }
-                : {}),
-            });
-          }
+          this.sendCachedCommands(ws, msg.sessionId, session);
         } else {
           this.send(ws, {
             type: "error",
@@ -3228,11 +3582,60 @@ export class BridgeWebSocketServer {
 
       case "get_history_delta": {
         const session = this.sessionManager.get(msg.sessionId);
-        const result = this.sessionManager.getHistorySince(
-          msg.sessionId,
-          msg.sinceSeq,
-        );
-        if (session && result) {
+        if (session?.provider === "codex") {
+          const result = this.sessionManager.getHistorySince(
+            msg.sessionId,
+            msg.sinceSeq,
+          );
+          if (!result) {
+            this.send(ws, {
+              type: "error",
+              message: `Session ${msg.sessionId} not found`,
+            });
+            break;
+          }
+
+          if (
+            this.shouldResetCodexHistoryDelta(
+              session,
+              msg.sinceSeq,
+              result.kind,
+            )
+          ) {
+            await this.sendCodexCanonicalHistorySnapshot(
+              ws,
+              msg.sessionId,
+              session,
+            );
+            break;
+          }
+
+          this.send(ws, {
+            type:
+              result.kind === "snapshot" ? "history_snapshot" : "history_delta",
+            sessionId: msg.sessionId,
+            fromSeq: result.fromSeq,
+            toSeq: result.toSeq,
+            messages: result.entries,
+            status: session.status,
+            ...(result.kind === "snapshot" ? { reason: result.reason } : {}),
+          } as ServerMessage);
+          this.sendCodexQueueState(ws, msg.sessionId, session);
+          break;
+        }
+
+        if (session) {
+          const result = this.sessionManager.getHistorySince(
+            msg.sessionId,
+            msg.sinceSeq,
+          );
+          if (!result) {
+            this.send(ws, {
+              type: "error",
+              message: `Session ${msg.sessionId} not found`,
+            });
+            break;
+          }
           if (session.pastMessages && session.pastMessages.length > 0) {
             const splitPastHistory =
               await this.splitPastHistoryMessages(session);
@@ -3257,31 +3660,6 @@ export class BridgeWebSocketServer {
             status: session.status,
             ...(result.kind === "snapshot" ? { reason: result.reason } : {}),
           } as ServerMessage);
-          if (session.provider === "codex") {
-            const item = session.codexQueuedInput;
-            this.sendConversationQueue(ws, {
-              type: "conversation_queue",
-              sessionId: msg.sessionId,
-              limit: 1,
-              items: item
-                ? [
-                    {
-                      itemId: item.itemId,
-                      text: item.text,
-                      createdAt: item.createdAt,
-                      ...(item.updatedAt ? { updatedAt: item.updatedAt } : {}),
-                      ...(item.imageCount
-                        ? { imageCount: item.imageCount }
-                        : {}),
-                      ...(item.skills?.length ? { skills: item.skills } : {}),
-                      ...(item.mentions?.length
-                        ? { mentions: item.mentions }
-                        : {}),
-                    },
-                  ]
-                : [],
-            } as Record<string, unknown>);
-          }
         } else {
           this.send(ws, {
             type: "error",
@@ -5636,25 +6014,41 @@ export class BridgeWebSocketServer {
     const isStandalone = process !== this.getActiveCodexProcess();
 
     try {
-      const result = await process.listThreads({
-        limit: limit + offset,
-        cwd: msg.projectPath,
-        searchTerm: msg.searchQuery,
-      });
       const archivedIds = this.archiveStore.archivedIds();
-      const visibleThreads = result.data
-        .filter((thread) => !archivedIds.has(thread.id))
-        .filter((thread) => !msg.namedOnly || !!thread.name)
-        .slice(offset, offset + limit);
+      const visibleThreads: CodexThreadSummary[] = [];
+      let cursor: string | null | undefined;
+      let hasServerMore = false;
+      const targetCount = offset + limit;
+
+      do {
+        const request: Parameters<CodexProcess["listThreads"]>[0] = {
+          limit: Math.max(limit, 1),
+          cwd: msg.projectPath,
+          searchTerm: msg.searchQuery,
+          sourceKinds: CODEX_RECENT_THREAD_SOURCE_KINDS,
+        };
+        if (cursor != null) request.cursor = cursor;
+
+        const result = await process.listThreads(request);
+        for (const thread of result.data) {
+          if (archivedIds.has(thread.id)) continue;
+          if (msg.namedOnly && !thread.name) continue;
+          visibleThreads.push(thread);
+        }
+        cursor = result.nextCursor;
+        hasServerMore = cursor != null;
+      } while (visibleThreads.length < targetCount && cursor != null);
+
+      const pageThreads = visibleThreads.slice(offset, offset + limit);
       const indexedById = await getCodexSessionIndexMetadata(
-        visibleThreads.map((thread) => thread.id),
+        pageThreads.map((thread) => thread.id),
       );
-      const sessions = visibleThreads.map((thread) =>
+      const sessions = pageThreads.map((thread) =>
         codexThreadToRecentSession(thread, indexedById.get(thread.id)),
       );
       return {
         sessions,
-        hasMore: result.nextCursor != null,
+        hasMore: hasServerMore || visibleThreads.length > offset + limit,
       };
     } finally {
       if (isStandalone) {
@@ -5883,8 +6277,16 @@ export class BridgeWebSocketServer {
     );
   }
 
-  private hasInputConflictSince(sessionId: string, baseSeq: number): boolean {
-    const delta = this.sessionManager.getHistorySince(sessionId, baseSeq);
+  private hasInputConflictSince(session: SessionInfo, baseSeq: number): boolean {
+    if (
+      session.provider === "codex" &&
+      typeof session.codexCanonicalHistoryRevision === "number" &&
+      baseSeq < session.codexCanonicalHistoryRevision
+    ) {
+      return true;
+    }
+
+    const delta = this.sessionManager.getHistorySince(session.id, baseSeq);
     if (!delta) return true;
     if (delta.kind === "snapshot") return true;
 
@@ -5901,6 +6303,64 @@ export class BridgeWebSocketServer {
         );
       }
       return false;
+    });
+  }
+
+  private sendCodexQueueState(
+    ws: WebSocket,
+    sessionId: string,
+    session: SessionInfo,
+  ): void {
+    const item = session.codexQueuedInput;
+    this.sendConversationQueue(ws, {
+      type: "conversation_queue",
+      sessionId,
+      limit: 1,
+      items: item
+        ? [
+            {
+              itemId: item.itemId,
+              text: item.text,
+              createdAt: item.createdAt,
+              ...(item.updatedAt ? { updatedAt: item.updatedAt } : {}),
+              ...(item.imageCount ? { imageCount: item.imageCount } : {}),
+              ...(item.skills?.length ? { skills: item.skills } : {}),
+              ...(item.mentions?.length ? { mentions: item.mentions } : {}),
+            },
+          ]
+        : [],
+    } as Record<string, unknown>);
+  }
+
+  private sendCachedCommands(
+    ws: WebSocket,
+    sessionId: string,
+    session: SessionInfo,
+  ): void {
+    // Restore command metadata when the original init/supported_commands event
+    // has fallen out of the bounded in-memory history.
+    const cached = this.sessionManager.getCachedCommands(session.projectPath);
+    if (
+      !cached ||
+      (cached.slashCommands.length === 0 &&
+        cached.skills.length === 0 &&
+        cached.apps.length === 0 &&
+        cached.plugins.length === 0)
+    ) {
+      return;
+    }
+
+    this.send(ws, {
+      type: "system",
+      subtype: "supported_commands",
+      sessionId,
+      slashCommands: cached.slashCommands,
+      skills: cached.skills,
+      ...(cached.skillMetadata ? { skillMetadata: cached.skillMetadata } : {}),
+      apps: cached.apps,
+      ...(cached.appMetadata ? { appMetadata: cached.appMetadata } : {}),
+      plugins: cached.plugins,
+      ...(cached.pluginMetadata ? { pluginMetadata: cached.pluginMetadata } : {}),
     });
   }
 


### PR DESCRIPTION
## Summary

Use Codex app-server canonical thread history for Bridge `get_history` and
`get_history_delta`, so CC Pocket can restore complete Codex conversations while
preserving Bridge history/delta sequencing during active live streams.

## Why This Is A PR

- Why PR instead of Issue / Prompt Request first: this is a narrow Bridge-only fix that follows documented Codex app-server APIs and includes focused tests.
- Related Issue / Prompt Request: N/A
- Base PR (if stacked on another open PR): N/A

## Changes

- Read Codex history through `thread/read` with `includeTurns: true`.
- Convert canonical Codex turns back into Bridge server messages for `get_history` / `get_history_delta`.
- Preserve legacy `get_history` response shape while using canonical Codex data as the source.
- Keep `get_history_delta` sequence space consistent by applying canonical history as a baseline and retaining live tail entries.
- Treat pre-first-message, unmaterialized Codex threads as empty canonical history instead of surfacing an error.
- Use stable Codex item ids for assistant/tool/user identity, including late live echo suppression for canonical user messages.
- Include Codex `cli`, `vscode`, and `appServer` threads in recent-session lookup.
- Preserve Codex user timestamps, image refs, tool result images, and canonical item ids when replaying history.
- Add bridge test coverage for canonical Codex history replay, live-stream races, empty unmaterialized threads, and duplicate suppression.

## Scope Check

- Single primary goal of this PR: make Bridge history restoration use Codex canonical thread storage without breaking live history sync.
- What is intentionally out of scope: VS Code extension UI hydration, Codex auth handling, and provider-specific behavior such as `codex-lb`.
- Can this be split into smaller PRs? Not usefully; the canonical read path, conversion path, baseline sequencing, duplicate suppression, and recent-thread filter are part of the same history sync fix.

## Test plan

- [x] Bridge Server tests pass (`npm run test:bridge`) - 30 files / 668 tests
- [x] Targeted bridge tests pass (`npm run test --workspace=packages/bridge -- src/websocket.test.ts`) - 88 tests
- [x] Targeted bridge tests pass (`npm run test --workspace=packages/bridge -- src/sessions-index.test.ts src/session.test.ts src/websocket.test.ts`) - 177 tests
- [ ] Flutter tests pass (`cd apps/mobile && flutter test`) - not run; bridge-only change
- [x] Manual testing done
- [x] `npm run build --workspace=packages/bridge`
- [x] `git diff --check`

## Platform validation

- Target platform: Bridge / Codex app-server
- Platform version: Linux aarch64, Codex CLI 0.134.0
- Base validated against: main after `1.101.1+179` / `bridge/v1.63.0`
- What I validated on that platform: local Bridge can read stored Codex threads through app-server and return complete history snapshots.
- Logs / screenshots / notes: N/A

## Notes

This follows the official Codex app-server contract:

- `thread/read` includes turns only when `includeTurns: true`.
- `thread/read` does not resume or load the thread, so it is appropriate for history restoration.
- `thread/list` is for history summaries and supports `modelProviders` / `sourceKinds`.
- `sourceKinds` defaults to interactive sources (`cli`, `vscode`) when omitted, so Bridge explicitly includes `appServer`.
- Codex `ThreadItem` types include stable `id` fields for `userMessage`, `agentMessage`, tool calls, and command execution items.
- `item/started` / `item/completed` use the same item identity as deltas, so Bridge uses these ids for canonical/live duplicate suppression.

References:

- https://developers.openai.com/codex/app-server#read-a-stored-thread-without-resuming
- https://developers.openai.com/codex/app-server#list-threads-with-pagination--filters
- https://developers.openai.com/codex/app-server#items
