### PR TITLE
fix(bridge): include Codex threads in all recents

### DIFF
--- a/packages/bridge/src/websocket.test.ts
+++ b/packages/bridge/src/websocket.test.ts
@@ -444,6 +444,7 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
         offset: 40,
         projectPath: "/tmp/project",
         requestScope: "project",
+        provider: "claude",
       },
       ws,
     );
@@ -499,6 +500,7 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
         offset: 0,
         projectPath: "/tmp/project",
         requestScope: "project",
+        provider: "claude",
       },
       ws,
     );
@@ -507,6 +509,7 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
         type: "list_recent_sessions",
         limit: 20,
         offset: 0,
+        provider: "claude",
       },
       ws,
     );
@@ -5017,6 +5020,91 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
         model: "gpt-5.3-codex",
       },
     });
+
+    bridge.close();
+  });
+
+  it("uses codex thread/list for all-provider recent sessions", async () => {
+    const bridge = new BridgeWebSocketServer({ server: httpServer });
+    const ws = {
+      readyState: OPEN_STATE,
+      send: vi.fn(),
+    } as any;
+
+    (bridge as any).handleClientMessage(
+      {
+        type: "start",
+        projectPath: "/tmp/project-codex",
+        provider: "codex",
+      },
+      ws,
+    );
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const created = ws.send.mock.calls
+      .map((c: unknown[]) => JSON.parse(c[0] as string))
+      .find((m: any) => m.type === "system" && m.subtype === "session_created");
+    const session = (bridge as any).sessionManager.get(created.sessionId);
+    session.process.listThreads.mockResolvedValue({
+      data: [
+        {
+          id: "thr_codex_all",
+          preview: "Codex all-provider result",
+          createdAt: 1771492643,
+          updatedAt: 1771496243,
+          cwd: "/tmp/project-codex",
+          agentNickname: null,
+          agentRole: null,
+          gitBranch: "main",
+          name: "Codex thread",
+        },
+      ],
+      nextCursor: null,
+    });
+    getAllRecentSessionsMock.mockClear();
+    getAllRecentSessionsMock.mockResolvedValue({
+      sessions: [
+        {
+          sessionId: "claude_recent",
+          provider: "claude",
+          firstPrompt: "Claude result",
+          created: "2026-01-01T00:00:00.000Z",
+          modified: "2026-01-01T00:00:00.000Z",
+          gitBranch: "main",
+          projectPath: "/tmp/project-claude",
+          isSidechain: false,
+        },
+      ],
+      hasMore: false,
+    });
+    getCodexSessionIndexMetadataMock.mockResolvedValue(new Map());
+
+    const payload = await (bridge as any).listRecentSessions({
+      type: "list_recent_sessions",
+      limit: 20,
+    });
+
+    expect(getAllRecentSessionsMock).toHaveBeenCalledTimes(1);
+    expect(getAllRecentSessionsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        limit: 20,
+        offset: 0,
+        provider: "claude",
+      }),
+    );
+    expect(session.process.listThreads).toHaveBeenCalledWith({
+      limit: 20,
+      cwd: undefined,
+      searchTerm: undefined,
+      sourceKinds: ["cli", "vscode", "appServer"],
+    });
+    expect(payload.hasMore).toBe(false);
+    expect(payload.sessions.map((s: any) => s.sessionId)).toEqual([
+      "thr_codex_all",
+      "claude_recent",
+    ]);
 
     bridge.close();
   });

--- a/packages/bridge/src/websocket.ts
+++ b/packages/bridge/src/websocket.ts
@@ -533,6 +533,32 @@ function codexThreadToRecentSession(
   };
 }
 
+function recentSessionModifiedTime(session: unknown): number {
+  const modified = (session as { modified?: unknown })?.modified;
+  return typeof modified === "string" ? new Date(modified).getTime() || 0 : 0;
+}
+
+function recentSessionDedupeKey(session: unknown, fallbackIndex: number): string {
+  const value = session as { provider?: unknown; sessionId?: unknown };
+  return typeof value.provider === "string" && typeof value.sessionId === "string"
+    ? `${value.provider}:${value.sessionId}`
+    : `unknown:${fallbackIndex}`;
+}
+
+function mergeRecentSessionPages(sessions: unknown[]): unknown[] {
+  const seen = new Set<string>();
+  const merged: unknown[] = [];
+  for (const session of sessions) {
+    const key = recentSessionDedupeKey(session, merged.length);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push(session);
+  }
+  return merged.sort(
+    (a, b) => recentSessionModifiedTime(b) - recentSessionModifiedTime(a),
+  );
+}
+
 export interface BridgeServerOptions {
   server: HttpServer;
   apiKey?: string;
@@ -5767,13 +5793,11 @@ export class BridgeWebSocketServer {
     msg: Extract<ClientMessage, { type: "list_recent_sessions" }>,
   ): Promise<{ sessions: unknown[]; hasMore: boolean }> {
     if (msg.provider === "codex") {
-      try {
-        return await this.listRecentCodexThreads(msg);
-      } catch (err) {
-        console.warn(
-          `[ws] Codex thread/list failed, falling back to rollout scan: ${err}`,
-        );
-      }
+      return this.listRecentCodexSessions(msg);
+    }
+
+    if (!msg.provider) {
+      return this.listRecentAllProviderSessions(msg);
     }
 
     return getAllRecentSessions({
@@ -5785,6 +5809,66 @@ export class BridgeWebSocketServer {
       searchQuery: msg.searchQuery,
       archivedSessionIds: this.archiveStore.archivedIds(),
     });
+  }
+
+  private async listRecentAllProviderSessions(
+    msg: Extract<ClientMessage, { type: "list_recent_sessions" }>,
+  ): Promise<{ sessions: unknown[]; hasMore: boolean }> {
+    const limit = msg.limit ?? 20;
+    const offset = msg.offset ?? 0;
+    const sourceLimit = offset + limit;
+
+    const [claudeResult, codexResult] = await Promise.all([
+      getAllRecentSessions({
+        limit: sourceLimit,
+        offset: 0,
+        projectPath: msg.projectPath,
+        provider: "claude",
+        namedOnly: msg.namedOnly,
+        searchQuery: msg.searchQuery,
+        archivedSessionIds: this.archiveStore.archivedIds(),
+      }),
+      this.listRecentCodexSessions({
+        ...msg,
+        provider: "codex",
+        limit: sourceLimit,
+        offset: 0,
+      }),
+    ]);
+
+    const merged = mergeRecentSessionPages([
+      ...claudeResult.sessions,
+      ...codexResult.sessions,
+    ]);
+
+    return {
+      sessions: merged.slice(offset, offset + limit),
+      hasMore:
+        merged.length > offset + limit ||
+        claudeResult.hasMore ||
+        codexResult.hasMore,
+    };
+  }
+
+  private async listRecentCodexSessions(
+    msg: Extract<ClientMessage, { type: "list_recent_sessions" }>,
+  ): Promise<{ sessions: unknown[]; hasMore: boolean }> {
+    try {
+      return await this.listRecentCodexThreads(msg);
+    } catch (err) {
+      console.warn(
+        `[ws] Codex thread/list failed, falling back to rollout scan: ${err}`,
+      );
+      return getAllRecentSessions({
+        limit: msg.limit,
+        offset: msg.offset,
+        projectPath: msg.projectPath,
+        provider: "codex",
+        namedOnly: msg.namedOnly,
+        searchQuery: msg.searchQuery,
+        archivedSessionIds: this.archiveStore.archivedIds(),
+      });
+    }
   }
 
   private async refreshCodexModels(projectPath?: string): Promise<void> {


### PR DESCRIPTION
## Summary

- Use Codex `thread/list` when the app requests all-provider recent sessions, matching the Codex-only filter path.
- Merge Codex thread results with Claude scanner results before applying all-provider pagination.
- Add regression coverage for all-provider recents including Codex app-server threads.

## 🐛 Bug

On a setup like iPhone CC Pocket -> Linux Bridge host -> Codex app-server, the home screen could show fewer sessions under `All AI Tools` than under `Codex`. The all-provider path used the generic session scan, while the Codex filter used canonical Codex `thread/list`, so Codex threads could be missing from the default view.

## Dependencies

This PR is independent and can be reviewed or merged separately.

Fixes #112.

## Validation Passed

- `npx tsc --noEmit -p packages/bridge/tsconfig.json`
- `npm --workspace packages/bridge test -- src/websocket.test.ts`
