### PR TITLE
ci(windows): pin release runner to windows 2022

### DIFF
--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -10,7 +10,9 @@ permissions:
 
 jobs:
   release:
-    runs-on: windows-latest
+    # Pin to VS 2022 for now. windows-latest has moved to VS 2026/MSVC 14.51,
+    # which rejects <experimental/coroutine> used by current Windows plugins.
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 


### PR DESCRIPTION
## Summary

Pins the Windows release workflow to `windows-2022` so it continues using the VS 2022 toolchain.

## Why This Is A PR

- Why PR instead of Issue / Prompt Request first: This is a small CI-only compatibility fix for the Windows release workflow.
- Related Issue / Prompt Request: None
- Base PR (if stacked on another open PR): None

## Changes

- Changes the Windows release runner from `windows-latest` to `windows-2022`
- Adds a short comment explaining that `windows-latest` can use VS 2026 / MSVC 14.51, which rejects `<experimental/coroutine>` used by current Windows plugins

## Scope Check

- Single primary goal of this PR: Keep Windows release builds on a compatible hosted runner image.
- What is intentionally out of scope: Flutter/plugin dependency updates, CMake compatibility changes, artifact upload changes, and app code changes.
- Can this be split into smaller PRs? No, this is already a single workflow-only change.

## Test plan

- [ ] Bridge Server tests pass (`npm run test:bridge`)
- [ ] Flutter tests pass (`cd apps/mobile && flutter test`)
- [x] Manual testing done

## Platform validation

- Target platform: Windows GitHub Actions release workflow
- Platform version: `windows-2022` hosted runner
- What I validated on that platform: The Windows release workflow completed successfully in my fork after pinning the runner image.
- Logs / screenshots / notes: N/A

## Notes

This PR intentionally only includes the runner image pin. Other local CI/workflow changes are not included.