### PR TITLE
fix(codex): surface real first/last/summary texts in recent sessions

### DIFF
--- a/packages/bridge/src/sessions-index.test.ts
+++ b/packages/bridge/src/sessions-index.test.ts
@@ -1107,6 +1107,16 @@ describe("codex sessions integration", () => {
           type: "event_msg",
           payload: { type: "user_message", message: "wanted" },
         }),
+        JSON.stringify({
+          timestamp: "2026-02-13T12:00:02.000Z",
+          type: "event_msg",
+          payload: { type: "agent_message", message: "done: fixed the bug" },
+        }),
+        JSON.stringify({
+          timestamp: "2026-02-13T12:00:03.000Z",
+          type: "event_msg",
+          payload: { type: "user_message", message: "thanks, now add a test" },
+        }),
       ].join("\n"),
     );
     writeFileSync(
@@ -1135,6 +1145,11 @@ describe("codex sessions integration", () => {
     expect(metadata.get(wantedThreadId)?.codexSettings?.approvalPolicy).toBe(
       "on-request",
     );
+    expect(metadata.get(wantedThreadId)?.firstPrompt).toBe("wanted");
+    expect(metadata.get(wantedThreadId)?.lastPrompt).toBe(
+      "thanks, now add a test",
+    );
+    expect(metadata.get(wantedThreadId)?.summary).toBe("done: fixed the bug");
   });
 
   it("reads codex history from jsonl", async () => {

--- a/packages/bridge/src/sessions-index.ts
+++ b/packages/bridge/src/sessions-index.ts
@@ -1185,6 +1185,14 @@ interface CodexRecentPerfStats {
 export interface CodexSessionIndexMetadata {
   codexSettings?: SessionIndexEntry["codexSettings"];
   resumeCwd?: string;
+  /** First user prompt parsed from the rollout file. The thread/list API
+   *  only exposes a preview blob, so these three text fields let recent-
+   *  session entries carry the real first/last/summary texts. */
+  firstPrompt?: string;
+  /** Last user prompt; omitted when identical to firstPrompt. */
+  lastPrompt?: string;
+  /** Last assistant message text — the closest thing to a session summary. */
+  summary?: string;
 }
 
 interface CodexSessionParseResult {
@@ -1876,6 +1884,9 @@ export async function getCodexSessionIndexMetadata(
         ? { codexSettings: parsed.entry.codexSettings }
         : {}),
       ...(parsed.entry.resumeCwd ? { resumeCwd: parsed.entry.resumeCwd } : {}),
+      ...(parsed.entry.firstPrompt ? { firstPrompt: parsed.entry.firstPrompt } : {}),
+      ...(parsed.entry.lastPrompt ? { lastPrompt: parsed.entry.lastPrompt } : {}),
+      ...(parsed.entry.summary ? { summary: parsed.entry.summary } : {}),
     });
   }
 

--- a/packages/bridge/src/websocket.test.ts
+++ b/packages/bridge/src/websocket.test.ts
@@ -4981,6 +4981,9 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
               model: "gpt-5.3-codex",
             },
             resumeCwd: "/tmp/project-codex-worktree",
+            firstPrompt: "Investigate crash in the parser",
+            lastPrompt: "add a regression test",
+            summary: "Fixed the off-by-one in the tokenizer",
           },
         ],
       ]),
@@ -5014,6 +5017,10 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
       gitBranch: "feat/protocol",
       projectPath: "/tmp/project-codex",
       resumeCwd: "/tmp/project-codex-worktree",
+      // Rollout-parsed texts win over the thread/list preview blob.
+      firstPrompt: "Investigate crash in the parser",
+      lastPrompt: "add a regression test",
+      summary: "Fixed the off-by-one in the tokenizer",
       codexSettings: {
         approvalPolicy: "never",
         sandboxMode: "danger-full-access",

--- a/packages/bridge/src/websocket.ts
+++ b/packages/bridge/src/websocket.ts
@@ -47,6 +47,7 @@ import {
   extractMessageImages,
   getClaudeSessionName,
   getCodexSessionIndexMetadata,
+  type CodexSessionIndexMetadata,
   loadCodexSessionNames,
   renameClaudeSession,
   renameCodexSession,
@@ -513,16 +514,20 @@ function envFlagEnabled(name: string): boolean {
 
 function codexThreadToRecentSession(
   thread: CodexThreadSummary,
-  indexed?: { codexSettings?: Record<string, unknown>; resumeCwd?: string },
+  indexed?: CodexSessionIndexMetadata,
 ): Record<string, unknown> {
+  // thread/list only exposes a single preview blob; prefer the real
+  // first/last/summary texts parsed from the rollout file so display-mode
+  // switches (first prompt / last prompt / summary) show distinct content.
   return {
     sessionId: thread.id,
     provider: "codex",
     ...(thread.name ? { name: thread.name } : {}),
     ...(thread.agentNickname ? { agentNickname: thread.agentNickname } : {}),
     ...(thread.agentRole ? { agentRole: thread.agentRole } : {}),
-    summary: thread.preview || undefined,
-    firstPrompt: thread.preview || "",
+    summary: indexed?.summary || thread.preview || undefined,
+    firstPrompt: indexed?.firstPrompt || thread.preview || "",
+    ...(indexed?.lastPrompt ? { lastPrompt: indexed.lastPrompt } : {}),
     created: threadTimestampToIso(thread.createdAt),
     modified: threadTimestampToIso(thread.updatedAt),
     gitBranch: thread.gitBranch ?? "",


### PR DESCRIPTION
## Problem

For codex sessions, `list_recent_sessions` entries always come back with `summary === firstPrompt` and no `lastPrompt`. The primary path (`listRecentCodexThreads`, via codex's native `thread/list` API) maps the single `thread.preview` blob into **both** `summary` and `firstPrompt`, and never emits `lastPrompt`:

```ts
summary: thread.preview || undefined,
firstPrompt: thread.preview || "",
```

Any client that lets users switch the session list between *first prompt / last prompt / summary* (mobile's `SessionDisplayMode`) shows identical text in all three modes for every codex session. The rollout-scan fallback already extracts all three fields properly, but it only runs when `thread/list` fails.

## Fix

`getCodexSessionIndexMetadata` already parses each paginated thread's rollout file with `parseCodexSessionJsonlFast` (to supplement `codexSettings` / `resumeCwd`). This PR carries the parser's `firstPrompt`, `lastPrompt` (omitted when identical to first) and `summary` (last assistant message) through that same metadata map, and `codexThreadToRecentSession` now prefers them over the preview blob, keeping `thread.preview` as the fallback.

**No extra file reads** — the per-page rollout parse was already happening; it just dropped the text fields on the floor.

## Testing

- Extended `sessions-index.test.ts` (`loads codex index metadata only for requested thread ids`) with a multi-turn rollout asserting all three text fields.
- Extended `websocket.test.ts` (`uses codex app-server thread list for codex recent sessions`) asserting rollout texts win over `thread.preview`.
- Full bridge suite: 30 files, 674 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)