### PR TITLE
fix(app): handle IPv6 bridge endpoints consistently

### DIFF
--- a/apps/mobile/lib/features/session_list/session_list_screen.dart
+++ b/apps/mobile/lib/features/session_list/session_list_screen.dart
@@ -8,6 +8,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../l10n/app_localizations.dart';
+import '../../utils/network_endpoint.dart';
 import '../../utils/platform_helper.dart';
 
 import '../../models/messages.dart';
@@ -1725,7 +1726,7 @@ class _SessionListScreenState extends State<SessionListScreen>
     final uri = _bridgeUri(url);
     if (uri == null || uri.host.isEmpty) return null;
     final port = uri.hasPort ? uri.port : 8765;
-    return '${uri.host}:$port';
+    return formatHostPort(uri.host, port);
   }
 
   Uri? _bridgeUri(String? url) {

--- a/apps/mobile/lib/features/session_list/widgets/machine_edit_sheet.dart
+++ b/apps/mobile/lib/features/session_list/widgets/machine_edit_sheet.dart
@@ -4,6 +4,7 @@ import '../../../l10n/app_localizations.dart';
 import '../../../models/machine.dart';
 import '../../../services/ssh_startup_service.dart';
 import '../../../theme/app_theme.dart';
+import '../../../utils/network_endpoint.dart';
 
 /// Bottom sheet for adding or editing a remote machine configuration.
 class MachineEditSheet extends StatefulWidget {
@@ -284,7 +285,7 @@ class _MachineEditSheetState extends State<MachineEditSheet> {
         name: _nameController.text.trim().isNotEmpty
             ? _nameController.text.trim()
             : null,
-        host: _hostController.text.trim(),
+        host: normalizeHostInput(_hostController.text),
         port: int.tryParse(_portController.text) ?? 8765,
         useSsl: _useSsl,
         sshEnabled: _sshEnabled,

--- a/apps/mobile/lib/features/settings/widgets/prompt_history_section.dart
+++ b/apps/mobile/lib/features/settings/widgets/prompt_history_section.dart
@@ -4,6 +4,7 @@ import '../../../l10n/app_localizations.dart';
 import '../../../services/bridge_service.dart';
 import '../../../services/machine_manager_service.dart';
 import '../../../services/prompt_history_service.dart';
+import '../../../utils/network_endpoint.dart';
 
 class PromptHistorySection extends StatefulWidget {
   final BridgeService bridgeService;
@@ -439,8 +440,9 @@ class _StatusTile extends StatelessWidget {
 String? _endpointFromUrl(String url) {
   final uri = Uri.tryParse(url);
   if (uri == null || uri.host.isEmpty) return url.isEmpty ? null : url;
-  final port = uri.hasPort ? ':${uri.port}' : '';
-  return '${uri.host}$port';
+  return uri.hasPort
+      ? formatHostPort(uri.host, uri.port)
+      : bracketIpv6Host(uri.host);
 }
 
 bool _isBridgeIdLike(String value, String bridgeId) {

--- a/apps/mobile/lib/models/machine.dart
+++ b/apps/mobile/lib/models/machine.dart
@@ -1,5 +1,7 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
+import '../utils/network_endpoint.dart';
+
 part 'machine.freezed.dart';
 part 'machine.g.dart';
 
@@ -142,16 +144,24 @@ abstract class Machine with _$Machine {
       _$MachineFromJson(json);
 
   /// Display name (name if set, otherwise host:port)
-  String get displayName => name ?? '$host:$port';
+  String get displayName => name ?? formatHostPort(host, port);
 
   /// WebSocket URL for this machine
-  String get wsUrl => '${useSsl ? 'wss' : 'ws'}://$host:$port';
+  String get wsUrl => formatUriOrigin(
+        scheme: useSsl ? 'wss' : 'ws',
+        host: host,
+        port: port,
+      );
 
   /// HTTP base URL for health checks
-  String get httpUrl => '${useSsl ? 'https' : 'http'}://$host:$port';
+  String get httpUrl => formatUriOrigin(
+        scheme: useSsl ? 'https' : 'http',
+        host: host,
+        port: port,
+      );
 
   /// Unique key for deduplication (host:port)
-  String get uniqueKey => '$host:$port';
+  String get uniqueKey => formatHostPort(host, port);
 
   /// Whether this machine can be started remotely (SSH configured)
   bool get canStartRemotely => sshEnabled && sshUsername != null;

--- a/apps/mobile/lib/services/bridge_service.dart
+++ b/apps/mobile/lib/services/bridge_service.dart
@@ -11,6 +11,7 @@ import '../core/logger.dart';
 import '../models/messages.dart';
 import '../models/offline_pending_action.dart';
 import '../utils/codex_plan_update.dart';
+import '../utils/network_endpoint.dart';
 import 'bridge_service_base.dart';
 import 'session_runtime_store.dart';
 
@@ -308,8 +309,11 @@ class BridgeService implements BridgeServiceBase {
     final uri = Uri.tryParse(url);
     if (uri == null) return null;
     final scheme = uri.scheme == 'wss' ? 'https' : 'http';
-    final port = uri.hasPort ? ':${uri.port}' : '';
-    return '$scheme://${uri.host}$port';
+    return formatUriOrigin(
+      scheme: scheme,
+      host: uri.host,
+      port: uri.hasPort ? uri.port : null,
+    );
   }
 
   static const _prefKeyUrl = 'bridge_url';
@@ -645,7 +649,7 @@ class BridgeService implements BridgeServiceBase {
     final host = uri.host.toLowerCase();
     final port = uri.hasPort ? uri.port : (scheme == 'wss' ? 443 : 80);
     final path = uri.path.isEmpty ? '/' : uri.path;
-    return '$scheme://$host:$port$path';
+    return '${formatUriOrigin(scheme: scheme, host: host, port: port)}$path';
   }
 
   void _clearBridgeScopedState({required bool clearOfflineQueue}) {
@@ -2134,8 +2138,11 @@ class BridgeService implements BridgeServiceBase {
       final uri = Uri.tryParse(wsUrl);
       if (uri == null) return null;
       final scheme = uri.scheme == 'wss' ? 'https' : 'http';
-      final port = uri.hasPort ? ':${uri.port}' : '';
-      final healthUrl = '$scheme://${uri.host}$port/health';
+      final healthUrl = '${formatUriOrigin(
+        scheme: scheme,
+        host: uri.host,
+        port: uri.hasPort ? uri.port : null,
+      )}/health';
       final response = await http
           .get(Uri.parse(healthUrl))
           .timeout(const Duration(seconds: 3));

--- a/apps/mobile/lib/services/connection_url_parser.dart
+++ b/apps/mobile/lib/services/connection_url_parser.dart
@@ -60,7 +60,9 @@ class ConnectionUrlParser {
 
     // Bare host:port
     final hostPortPattern = RegExp(r'^[\w.\-]+:\d+$');
-    if (hostPortPattern.hasMatch(trimmed)) {
+    final bracketedIpv6PortPattern = RegExp(r'^\[[^\]]+\]:\d+$');
+    if (hostPortPattern.hasMatch(trimmed) ||
+        bracketedIpv6PortPattern.hasMatch(trimmed)) {
       return ConnectionParams(serverUrl: 'ws://$trimmed');
     }
 

--- a/apps/mobile/lib/services/machine_manager_service.dart
+++ b/apps/mobile/lib/services/machine_manager_service.dart
@@ -10,6 +10,7 @@ import 'package:uuid/uuid.dart';
 
 import '../constants/app_constants.dart';
 import '../models/machine.dart';
+import '../utils/network_endpoint.dart';
 
 typedef BridgeWsUrlResolver =
     Future<String> Function(
@@ -284,8 +285,11 @@ class MachineManagerService {
 
   /// Find machine by host:port (unique key)
   Machine? findByHostPort(String host, int port) {
+    final normalizedHost = normalizeHostInput(host);
     try {
-      return _machines.firstWhere((m) => m.host == host && m.port == port);
+      return _machines.firstWhere(
+        (m) => normalizeHostInput(m.host) == normalizedHost && m.port == port,
+      );
     } catch (_) {
       return null;
     }
@@ -311,11 +315,13 @@ class MachineManagerService {
     String? name,
     bool? useSsl,
   }) async {
-    var machine = findByHostPort(host, port);
+    final normalizedHost = normalizeHostInput(host);
+    var machine = findByHostPort(normalizedHost, port);
 
     if (machine != null) {
       // Update existing machine
       machine = machine.copyWith(
+        host: normalizedHost,
         lastConnected: DateTime.now(),
         name: name ?? machine.name,
         useSsl: useSsl ?? machine.useSsl,
@@ -328,7 +334,7 @@ class MachineManagerService {
       // Create new machine
       machine = Machine(
         id: _uuid.v4(),
-        host: host,
+        host: normalizedHost,
         port: port,
         name: name,
         useSsl: useSsl ?? false,

--- a/apps/mobile/lib/services/prompt_history_service.dart
+++ b/apps/mobile/lib/services/prompt_history_service.dart
@@ -11,6 +11,7 @@ import '../core/logger.dart';
 import '../models/machine.dart';
 import '../models/messages.dart';
 import '../utils/command_parser.dart';
+import '../utils/network_endpoint.dart';
 import 'bridge_service.dart';
 import 'database_service.dart';
 import 'machine_manager_service.dart';
@@ -330,8 +331,9 @@ class PromptHistoryService {
     if (url == null || url.isEmpty) return null;
     final uri = Uri.tryParse(url);
     if (uri == null) return null;
-    final port = uri.hasPort ? ':${uri.port}' : '';
-    return '${uri.host}$port';
+    return uri.hasPort
+        ? formatHostPort(uri.host, uri.port)
+        : bracketIpv6Host(uri.host);
   }
 
   // ---------------------------------------------------------------------------

--- a/apps/mobile/lib/services/server_discovery_service.dart
+++ b/apps/mobile/lib/services/server_discovery_service.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import '../core/logger.dart';
+import '../utils/network_endpoint.dart';
 
 import 'server_discovery_impl_stub.dart'
     if (dart.library.io) 'server_discovery_impl_io.dart'
@@ -19,7 +20,7 @@ class DiscoveredServer {
     required this.authRequired,
   });
 
-  String get wsUrl => 'ws://$host:$port';
+  String get wsUrl => formatUriOrigin(scheme: 'ws', host: host, port: port);
 
   @override
   bool operator ==(Object other) =>
@@ -48,11 +49,11 @@ class ServerDiscoveryService {
             port: port,
             authRequired: authRequired,
           );
-          _servers['$host:$port'] = server;
+          _servers[formatHostPort(host, port)] = server;
           _emit();
         },
         onLost: (host, port) {
-          _servers.remove('$host:$port');
+          _servers.remove(formatHostPort(host, port));
           _emit();
         },
       );

--- a/apps/mobile/lib/utils/network_endpoint.dart
+++ b/apps/mobile/lib/utils/network_endpoint.dart
@@ -1,0 +1,25 @@
+String bracketIpv6Host(String host) {
+  final trimmed = normalizeHostInput(host);
+  if (trimmed.isEmpty) return trimmed;
+  return trimmed.contains(':') ? '[$trimmed]' : trimmed;
+}
+
+String normalizeHostInput(String host) {
+  final trimmed = host.trim();
+  if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+    return trimmed.substring(1, trimmed.length - 1).trim();
+  }
+  return trimmed;
+}
+
+String formatHostPort(String host, int port) =>
+    '${bracketIpv6Host(host)}:$port';
+
+String formatUriOrigin({
+  required String scheme,
+  required String host,
+  int? port,
+}) {
+  final portPart = port == null ? '' : ':$port';
+  return '$scheme://${bracketIpv6Host(host)}$portPart';
+}

--- a/apps/mobile/test/connection_url_parser_test.dart
+++ b/apps/mobile/test/connection_url_parser_test.dart
@@ -75,6 +75,20 @@ void main() {
         expect(result, isNotNull);
         expect(result!.serverUrl, 'ws://localhost:8765');
       });
+
+      test('parses bracketed IPv6 host:port', () {
+        final result =
+            ConnectionUrlParser.parse(
+                  '[fdbd:dc01:ff:321:254e:39ac:2d5d:1a67]:19000',
+                )
+                as ConnectionParams?;
+
+        expect(result, isNotNull);
+        expect(
+          result!.serverUrl,
+          'ws://[fdbd:dc01:ff:321:254e:39ac:2d5d:1a67]:19000',
+        );
+      });
     });
 
     group('deep link - connect (ccpocket://connect)', () {

--- a/apps/mobile/test/machine_test.dart
+++ b/apps/mobile/test/machine_test.dart
@@ -22,6 +22,27 @@ void main() {
       expect(machine.wsUrl, 'wss://bridge.example.com:443');
       expect(machine.httpUrl, 'https://bridge.example.com:443');
     });
+
+    test('wraps IPv6 hosts in URLs', () {
+      const machine = Machine(
+        id: 'm-ipv6',
+        host: 'fdbd:dc01:ff:321:254e:39ac:2d5d:1a67',
+        port: 19000,
+      );
+
+      expect(
+        machine.wsUrl,
+        'ws://[fdbd:dc01:ff:321:254e:39ac:2d5d:1a67]:19000',
+      );
+      expect(
+        machine.httpUrl,
+        'http://[fdbd:dc01:ff:321:254e:39ac:2d5d:1a67]:19000',
+      );
+      expect(
+        machine.displayName,
+        '[fdbd:dc01:ff:321:254e:39ac:2d5d:1a67]:19000',
+      );
+    });
   });
 
   group('Machine JSON', () {

--- a/apps/mobile/test/network_endpoint_test.dart
+++ b/apps/mobile/test/network_endpoint_test.dart
@@ -1,0 +1,44 @@
+import 'package:ccpocket/utils/network_endpoint.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('network endpoint formatting', () {
+    test('keeps IPv4 and DNS hosts unchanged', () {
+      expect(formatHostPort('192.168.1.1', 9000), '192.168.1.1:9000');
+      expect(
+        formatHostPort('bridge.example.com', 9000),
+        'bridge.example.com:9000',
+      );
+    });
+
+    test('wraps IPv6 hosts for URL authorities', () {
+      expect(
+        formatHostPort('fdbd:dc01:ff:321:254e:39ac:2d5d:1a67', 19000),
+        '[fdbd:dc01:ff:321:254e:39ac:2d5d:1a67]:19000',
+      );
+      expect(
+        formatUriOrigin(
+          scheme: 'ws',
+          host: 'fdbd:dc01:ff:321:254e:39ac:2d5d:1a67',
+          port: 19000,
+        ),
+        'ws://[fdbd:dc01:ff:321:254e:39ac:2d5d:1a67]:19000',
+      );
+    });
+
+    test('does not double-wrap bracketed IPv6 hosts', () {
+      expect(
+        formatHostPort('[fdbd:dc01:ff:321:254e:39ac:2d5d:1a67]', 19000),
+        '[fdbd:dc01:ff:321:254e:39ac:2d5d:1a67]:19000',
+      );
+    });
+
+    test('normalizes bracketed IPv6 input for storage and lookup', () {
+      expect(
+        normalizeHostInput('[fdbd:dc01:ff:321:254e:39ac:2d5d:1a67]'),
+        'fdbd:dc01:ff:321:254e:39ac:2d5d:1a67',
+      );
+      expect(normalizeHostInput(' bridge.example.com '), 'bridge.example.com');
+    });
+  });
+}

--- a/apps/mobile/test/server_discovery_service_test.dart
+++ b/apps/mobile/test/server_discovery_service_test.dart
@@ -1,0 +1,17 @@
+import 'package:ccpocket/services/server_discovery_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('DiscoveredServer', () {
+    test('wraps IPv6 hosts in websocket URLs', () {
+      const server = DiscoveredServer(
+        name: 'bridge',
+        host: 'fdbd:dc01:ff:321:254e:39ac:2d5d:1a67',
+        port: 19000,
+        authRequired: true,
+      );
+
+      expect(server.wsUrl, 'ws://[fdbd:dc01:ff:321:254e:39ac:2d5d:1a67]:19000');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add shared endpoint formatting helpers for IPv6 hosts, host input normalization, and host:port URI formatting.
- Use the helpers across saved machines, bridge health URLs, discovery wsUrl values, and UI endpoint display.
- Accept bare bracketed IPv6 endpoints such as [::1]:8080 in connection URL parsing.

## Why
IPv6 literal hosts need brackets when combined with ports in URLs, but should not be persisted with accidental brackets in the host field. The previous ad hoc formatting produced malformed URLs or inconsistent saved machine identities.

## Tests
- flutter pub get
- dart format apps/mobile/lib/utils/network_endpoint.dart apps/mobile/lib/models/machine.dart apps/mobile/lib/services/server_discovery_service.dart apps/mobile/lib/utils/connection_url_parser.dart apps/mobile/test/network_endpoint_test.dart apps/mobile/test/machine_test.dart apps/mobile/test/connection_url_parser_test.dart apps/mobile/test/server_discovery_service_test.dart
- flutter test test/network_endpoint_test.dart test/machine_test.dart test/connection_url_parser_test.dart test/server_discovery_service_test.dart
- flutter analyze --no-fatal-infos

Note: plain flutter analyze currently exits with the repository's existing 35 prefer_initializing_formals info-level diagnostics; no new errors or warnings are introduced.