### PR TITLE
fix(bridge): detect Claude busy turns from session status

### DIFF
--- a/packages/bridge/src/websocket.test.ts
+++ b/packages/bridge/src/websocket.test.ts
@@ -3963,6 +3963,63 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     bridge.close();
   });
 
+  it("claude busy snapshot uses session.status, not isWaitingForInput", async () => {
+    const bridge = new BridgeWebSocketServer({ server: httpServer });
+    const ws = {
+      readyState: OPEN_STATE,
+      send: vi.fn(),
+    } as any;
+
+    (bridge as any).handleClientMessage(
+      {
+        type: "start",
+        projectPath: "/tmp/project-a",
+        provider: "claude",
+      },
+      ws,
+    );
+    await Promise.resolve();
+
+    const created = ws.send.mock.calls
+      .map((c: unknown[]) => JSON.parse(c[0] as string))
+      .find((m: any) => m.type === "system" && m.subtype === "session_created");
+    const sessionId = created.sessionId as string;
+    const session = (bridge as any).sessionManager.get(sessionId);
+
+    // The SDK is mid-turn (status running) but already holds a resolver for the
+    // next input (isWaitingForInput true). The old logic read this as idle and
+    // skipped the interrupt. sendInput returns a non-boolean here so the ack
+    // must fall back to isAgentBusySnapshot, which now derives from status.
+    session.status = "running";
+    session.process.isWaitingForInput = true;
+    session.process.sendInput.mockReturnValue(undefined);
+
+    ws.send.mockClear();
+    (bridge as any).handleClientMessage(
+      {
+        type: "input",
+        sessionId,
+        text: "interrupt while running",
+      },
+      ws,
+    );
+
+    const inputAck = ws.send.mock.calls
+      .map((c: unknown[]) => JSON.parse(c[0] as string))
+      .find((m: any) => m.type === "input_ack");
+    expect(inputAck).toMatchObject({
+      type: "input_ack",
+      sessionId,
+      queued: true,
+    });
+    expect(session.process.sendInput).toHaveBeenCalledWith(
+      "interrupt while running",
+    );
+    expect(session.process.interrupt).toHaveBeenCalledTimes(1);
+
+    bridge.close();
+  });
+
   it("echoes clientMessageId and acceptedSeq on input_ack", async () => {
     const bridge = new BridgeWebSocketServer({ server: httpServer });
     const ws = {

--- a/packages/bridge/src/websocket.ts
+++ b/packages/bridge/src/websocket.ts
@@ -2220,8 +2220,13 @@ export class BridgeWebSocketServer {
         // Snapshot busy state before dispatch. We prefer the actual enqueue
         // result returned by SdkProcess sendInput* below, but keep this as a
         // fallback for test doubles and async paths.
+        // NOTE: use session.status, not isWaitingForInput. The Claude SDK may
+        // already hold a resolver for the next input (isWaitingForInput===true)
+        // while still streaming output / running tools, which made us misread a
+        // busy turn as idle and skip the interrupt. session.status is "running"
+        // / "waiting_approval" / "starting" whenever the turn is in flight.
         const isAgentBusySnapshot =
-          session.provider === "claude" && !session.process.isWaitingForInput;
+          session.provider === "claude" && session.status !== "idle";
 
         // Normalize images: support new `images` array and legacy single-image fields
         let images: Array<{ base64: string; mimeType: string }> = [];


### PR DESCRIPTION
## Summary
- Treat Claude sessions as busy based on process/session status, not only input iterator state.
- Queue/interrupt follow-up input correctly while a turn is still running.
- Add websocket regression coverage for busy-session input handling.

## Why
The app can send another input while Claude is running. If the bridge misses that busy state, the input path can act as though the session is idle and fail to interrupt/queue consistently.

## Tests
- npm ci --ignore-scripts
- npm run test --workspace=packages/bridge -- src/websocket.test.ts
- npx tsc --noEmit -p packages/bridge/tsconfig.json