### PR TITLE
perf(bridge): cache Claude message images per session on resume

### DIFF
--- a/packages/bridge/src/sessions-index.test.ts
+++ b/packages/bridge/src/sessions-index.test.ts
@@ -1947,6 +1947,96 @@ describe("codex sessions integration", () => {
     expect(history).toHaveLength(1);
     expect(history[0].content[0].text).toBe("correct session");
   });
+
+  it("extracts claude user images by uuid", async () => {
+    const sessionId = "claude-img-session-1";
+    const claudeProjectDir = join(
+      tempHome,
+      ".claude",
+      "projects",
+      "-tmp-project-a",
+    );
+    mkdirSync(claudeProjectDir, { recursive: true });
+    writeFileSync(
+      join(claudeProjectDir, `${sessionId}.jsonl`),
+      [
+        JSON.stringify({
+          type: "user",
+          uuid: "uuid-text-only",
+          message: { role: "user", content: "no image here" },
+        }),
+        JSON.stringify({
+          type: "user",
+          uuid: "uuid-with-image",
+          message: {
+            role: "user",
+            content: [
+              { type: "text", text: "look" },
+              {
+                type: "image",
+                source: {
+                  type: "base64",
+                  media_type: "image/png",
+                  data: "aW1hZ2U=",
+                },
+              },
+            ],
+          },
+        }),
+      ].join("\n"),
+    );
+
+    await expect(
+      extractMessageImages(sessionId, "uuid-with-image"),
+    ).resolves.toEqual([{ base64: "aW1hZ2U=", mimeType: "image/png" }]);
+    await expect(
+      extractMessageImages(sessionId, "uuid-text-only"),
+    ).resolves.toEqual([]);
+  });
+
+  it("does not fall through to codex when a claude session file exists", async () => {
+    const sessionId = "claude-no-fallthrough";
+    const claudeProjectDir = join(
+      tempHome,
+      ".claude",
+      "projects",
+      "-tmp-project-a",
+    );
+    mkdirSync(claudeProjectDir, { recursive: true });
+    // Claude session with no images for the requested uuid.
+    writeFileSync(
+      join(claudeProjectDir, `${sessionId}.jsonl`),
+      JSON.stringify({
+        type: "user",
+        uuid: "uuid-no-image",
+        message: { role: "user", content: "text" },
+      }),
+    );
+    // A codex rollout that happens to contain images must NOT be consulted.
+    const codexDir = join(tempHome, ".codex", "sessions", "2026", "02", "13");
+    mkdirSync(codexDir, { recursive: true });
+    writeFileSync(
+      join(codexDir, `rollout-2026-02-13T12-00-00-${sessionId}.jsonl`),
+      [
+        JSON.stringify({
+          type: "session_meta",
+          payload: { id: sessionId, cwd: "/tmp/project-a" },
+        }),
+        JSON.stringify({
+          type: "event_msg",
+          payload: {
+            type: "user_message",
+            message: "with image",
+            images: ["data:image/png;base64,aW1hZ2U="],
+          },
+        }),
+      ].join("\n"),
+    );
+
+    await expect(
+      extractMessageImages(sessionId, "uuid-no-image"),
+    ).resolves.toEqual([]);
+  });
 });
 
 describe("claude namedOnly optimization", () => {

--- a/packages/bridge/src/sessions-index.ts
+++ b/packages/bridge/src/sessions-index.ts
@@ -2818,6 +2818,19 @@ const codexMessageImageIndexCache = new Map<
   Promise<CodexMessageImageIndex | null>
 >();
 
+interface ClaudeMessageImageIndex {
+  jsonlPath: string;
+  size: number;
+  mtimeMs: number;
+  imagesByUuid: Map<string, ExtractedImage[]>;
+}
+
+const CLAUDE_IMAGE_INDEX_CACHE_LIMIT = 8;
+const claudeMessageImageIndexCache = new Map<
+  string,
+  Promise<ClaudeMessageImageIndex | null>
+>();
+
 /**
  * Extract image base64 data from a Claude Code session JSONL for a specific message UUID.
  */
@@ -2829,27 +2842,81 @@ export async function extractMessageImages(
     return extractCodexMessageImages(sessionId, messageUuid);
   }
 
-  // Try Claude Code first, then Codex
-  const claudeImages = await extractClaudeMessageImages(sessionId, messageUuid);
-  if (claudeImages.length > 0) return claudeImages;
+  // Try Claude Code first. If a Claude session JSONL exists for this id, it is
+  // authoritative — do NOT fall through to the Codex lookup, which scans every
+  // Codex session file on disk (O(codexFiles) per call) and dominated
+  // history-resume latency (~1s per message × dozens of messages). Only when no
+  // Claude session file exists (the id is likely a Codex thread) try Codex.
+  const claudeIndex = await getClaudeMessageImageIndex(sessionId);
+  if (claudeIndex) {
+    return claudeIndex.imagesByUuid.get(messageUuid) ?? [];
+  }
 
   return extractCodexMessageImages(sessionId, messageUuid);
 }
 
-async function extractClaudeMessageImages(
+/**
+ * Per-file cache of Claude Code message images keyed by sessionId.
+ *
+ * Previously the extractor re-read and re-parsed the entire session JSONL on
+ * every call. Resuming a session calls this once per user message with a uuid,
+ * so a large session paid O(messages × fileSize). The cache parses the file
+ * once and serves all subsequent lookups from memory, mirroring the Codex
+ * image index. Invalidated by file size/mtime change.
+ */
+async function getClaudeMessageImageIndex(
   sessionId: string,
-  messageUuid: string,
-): Promise<ExtractedImage[]> {
-  const jsonlPath = await findSessionJsonlPath(sessionId);
-  if (!jsonlPath) return [];
-
-  let raw: string;
-  try {
-    raw = await readFile(jsonlPath, "utf-8");
-  } catch {
-    return [];
+): Promise<ClaudeMessageImageIndex | null> {
+  const cached = claudeMessageImageIndexCache.get(sessionId);
+  if (cached) {
+    const index = await cached;
+    if (index && (await isFreshClaudeMessageImageIndex(index))) {
+      return index;
+    }
+    claudeMessageImageIndexCache.delete(sessionId);
   }
 
+  const promise = buildClaudeMessageImageIndex(sessionId);
+  claudeMessageImageIndexCache.set(sessionId, promise);
+  trimClaudeMessageImageIndexCache();
+  return promise;
+}
+
+async function isFreshClaudeMessageImageIndex(
+  index: ClaudeMessageImageIndex,
+): Promise<boolean> {
+  try {
+    const current = await stat(index.jsonlPath);
+    return current.size === index.size && current.mtimeMs === index.mtimeMs;
+  } catch {
+    return false;
+  }
+}
+
+function trimClaudeMessageImageIndexCache() {
+  while (claudeMessageImageIndexCache.size > CLAUDE_IMAGE_INDEX_CACHE_LIMIT) {
+    const oldest = claudeMessageImageIndexCache.keys().next().value;
+    if (!oldest) return;
+    claudeMessageImageIndexCache.delete(oldest);
+  }
+}
+
+async function buildClaudeMessageImageIndex(
+  sessionId: string,
+): Promise<ClaudeMessageImageIndex | null> {
+  const jsonlPath = await findSessionJsonlPath(sessionId);
+  if (!jsonlPath) return null;
+
+  let fileStat;
+  let raw: string;
+  try {
+    fileStat = await stat(jsonlPath);
+    raw = await readFile(jsonlPath, "utf-8");
+  } catch {
+    return null;
+  }
+
+  const imagesByUuid = new Map<string, ExtractedImage[]>();
   const lines = raw.split("\n");
   for (const line of lines) {
     if (!line.trim()) continue;
@@ -2862,7 +2929,7 @@ async function extractClaudeMessageImages(
     }
 
     if (entry.type !== "user") continue;
-    if (entry.uuid !== messageUuid) continue;
+    if (typeof entry.uuid !== "string") continue;
 
     const message = entry.message as { content: unknown[] | string } | undefined;
     if (!message?.content || !Array.isArray(message.content)) continue;
@@ -2882,10 +2949,17 @@ async function extractClaudeMessageImages(
         images.push({ base64: data, mimeType: mediaType });
       }
     }
-    return images;
+    if (images.length > 0) {
+      imagesByUuid.set(entry.uuid, images);
+    }
   }
 
-  return [];
+  return {
+    jsonlPath,
+    size: fileStat.size,
+    mtimeMs: fileStat.mtimeMs,
+    imagesByUuid,
+  };
 }
 
 async function extractCodexMessageImages(


### PR DESCRIPTION
## Summary
- Cache extracted Claude message images by session while building recent/history views.
- Reuse the cache on resume instead of repeatedly re-extracting the same image references.
- Add sessions-index tests for image cache reuse.

## Why
Sessions with image attachments can become expensive to reopen because image references are re-read for repeated recent/history requests.

## Tests
- npm ci --ignore-scripts
- npm run test --workspace=packages/bridge -- src/sessions-index.test.ts
- npx tsc --noEmit -p packages/bridge/tsconfig.json