### PR TITLE
fix(bridge): allow idle permission mode changes

### DIFF
--- a/packages/bridge/src/sdk-process.test.ts
+++ b/packages/bridge/src/sdk-process.test.ts
@@ -739,3 +739,40 @@ describe("SdkProcess.approveAlways", () => {
     expect(proc.permissionMode).toBe("acceptEdits");
   });
 });
+
+describe("SdkProcess.setPermissionMode", () => {
+  it("records the mode and emits an update when the query instance is idle", async () => {
+    const proc = new SdkProcess();
+    const internal = proc as any;
+    internal._sessionId = "test-session";
+    expect(internal.queryInstance).toBeNull();
+
+    const messages: ServerMessage[] = [];
+    proc.on("message", (msg) => messages.push(msg));
+
+    await expect(
+      proc.setPermissionMode("bypassPermissions"),
+    ).resolves.toBeUndefined();
+
+    expect(proc.permissionMode).toBe("bypassPermissions");
+    expect(messages).toContainEqual(
+      expect.objectContaining({
+        type: "system",
+        subtype: "set_permission_mode",
+        permissionMode: "bypassPermissions",
+        sessionId: "test-session",
+      }),
+    );
+  });
+
+  it("applies the mode to a live query instance", async () => {
+    const proc = new SdkProcess();
+    const setPermissionMode = vi.fn(async () => {});
+    (proc as any).queryInstance = { setPermissionMode };
+
+    await proc.setPermissionMode("acceptEdits");
+
+    expect(setPermissionMode).toHaveBeenCalledWith("acceptEdits");
+    expect(proc.permissionMode).toBe("acceptEdits");
+  });
+});

--- a/packages/bridge/src/sdk-process.ts
+++ b/packages/bridge/src/sdk-process.ts
@@ -625,7 +625,7 @@ export class SdkProcess extends EventEmitter<SdkProcessEvents> {
         cwd: projectPath,
         resume: options?.sessionId,
         continue: options?.continueMode,
-        permissionMode: options?.permissionMode ?? "default",
+        permissionMode: this._permissionMode ?? options?.permissionMode ?? "default",
         ...(options?.model ? { model: options.model } : {}),
         ...buildThinkingOptions(options?.model),
         ...(options?.effort ? { effort: options.effort } : {}),
@@ -915,13 +915,15 @@ export class SdkProcess extends EventEmitter<SdkProcessEvents> {
 
   /**
    * Update permission mode for the current session.
-   * Only available while the query instance is active.
+   *
+   * When the SDK query iterator is live, apply the change in place. When the
+   * iterator is idle, record the desired mode so it is used on the next query
+   * start and still notify clients immediately.
    */
   async setPermissionMode(mode: PermissionMode): Promise<void> {
-    if (!this.queryInstance) {
-      throw new Error("No active query instance");
+    if (this.queryInstance) {
+      await this.queryInstance.setPermissionMode(mode);
     }
-    await this.queryInstance.setPermissionMode(mode);
     this._permissionMode = mode;
     this.emitMessage({
       type: "system",


### PR DESCRIPTION
## Summary
- Let permission mode changes update bridge state even when the Claude SDK query iterator is idle.
- Apply the selected mode to the next turn instead of throwing from an idle process.
- Add SDK process coverage for idle permission mode changes.

## Why
Users can change permission mode between turns. That should be recorded immediately and used by the next query, not rejected because no query is currently active.

## Tests
- npm ci --ignore-scripts
- npm run test --workspace=packages/bridge -- src/sdk-process.test.ts
- npx tsc --noEmit -p packages/bridge/tsconfig.json