### PR TITLE
perf(bridge): avoid standalone Codex metadata refresh on connect

### DIFF
--- a/packages/bridge/src/websocket.test.ts
+++ b/packages/bridge/src/websocket.test.ts
@@ -727,6 +727,53 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     bridge.close();
   });
 
+  it("does not spawn standalone codex metadata refreshes on connect without an active codex session", () => {
+    const bridge = new BridgeWebSocketServer({ server: httpServer });
+    const refreshCodexProfiles = vi
+      .spyOn(bridge as any, "refreshCodexProfiles")
+      .mockResolvedValue(undefined);
+    const refreshCodexModels = vi
+      .spyOn(bridge as any, "refreshCodexModels")
+      .mockResolvedValue(undefined);
+    const refreshClaudeModels = vi
+      .spyOn(bridge as any, "refreshClaudeModels")
+      .mockResolvedValue(undefined);
+
+    (bridge as any).refreshConnectionMetadata();
+
+    expect(refreshCodexProfiles).not.toHaveBeenCalled();
+    expect(refreshCodexModels).not.toHaveBeenCalled();
+    expect(refreshClaudeModels).toHaveBeenCalledTimes(1);
+
+    bridge.close();
+  });
+
+  it("refreshes codex metadata on connect only when a codex session is active", () => {
+    const bridge = new BridgeWebSocketServer({ server: httpServer });
+    const manager = (bridge as any).sessionManager;
+    manager.create(
+      "/tmp/project-a",
+      undefined,
+      undefined,
+      undefined,
+      "codex",
+    );
+    const refreshCodexProfiles = vi
+      .spyOn(bridge as any, "refreshCodexProfiles")
+      .mockResolvedValue(undefined);
+    const refreshCodexModels = vi
+      .spyOn(bridge as any, "refreshCodexModels")
+      .mockResolvedValue(undefined);
+    vi.spyOn(bridge as any, "refreshClaudeModels").mockResolvedValue(undefined);
+
+    (bridge as any).refreshConnectionMetadata();
+
+    expect(refreshCodexProfiles).toHaveBeenCalledTimes(1);
+    expect(refreshCodexModels).toHaveBeenCalledTimes(1);
+
+    bridge.close();
+  });
+
   it("forwards selected codex profile on start", async () => {
     const bridge = new BridgeWebSocketServer({ server: httpServer });
     const ws = {
@@ -752,6 +799,34 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     expect(session.codexOptions).toMatchObject({
       profile: "ccpocket",
     });
+
+    bridge.close();
+  });
+
+  it("refreshes codex profiles after the first codex session starts", async () => {
+    const bridge = new BridgeWebSocketServer({ server: httpServer });
+    const ws = {
+      readyState: OPEN_STATE,
+      send: vi.fn(),
+    } as any;
+    const refreshCodexProfiles = vi
+      .spyOn(bridge as any, "refreshCodexProfiles")
+      .mockResolvedValue(undefined);
+    vi.spyOn(bridge as any, "refreshCodexModels").mockResolvedValue(undefined);
+
+    await (bridge as any).handleClientMessage(
+      {
+        type: "start",
+        projectPath: "/tmp/project-a",
+        provider: "codex",
+      },
+      ws,
+    );
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(refreshCodexProfiles).toHaveBeenCalledWith("/tmp/project-a");
 
     bridge.close();
   });

--- a/packages/bridge/src/websocket.ts
+++ b/packages/bridge/src/websocket.ts
@@ -512,6 +512,13 @@ function envFlagEnabled(name: string): boolean {
   return value === "1" || value === "true" || value === "yes" || value === "on";
 }
 
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name]?.trim();
+  if (!raw) return fallback;
+  const value = Number.parseInt(raw, 10);
+  return Number.isFinite(value) ? value : fallback;
+}
+
 function codexThreadToRecentSession(
   thread: CodexThreadSummary,
   indexed?: CodexSessionIndexMetadata,
@@ -582,6 +589,8 @@ export interface BridgeServerOptions {
 export class BridgeWebSocketServer {
   private static readonly MAX_DEBUG_EVENTS = 800;
   private static readonly MAX_HISTORY_SUMMARY_ITEMS = 300;
+  private static readonly DEFAULT_CONNECT_METADATA_REFRESH_COOLDOWN_MS =
+    5 * 60 * 1000;
 
   private wss: WebSocketServer;
   private sessionManager: SessionManager;
@@ -625,6 +634,15 @@ export class BridgeWebSocketServer {
     "BRIDGE_FAIL_SET_PERMISSION_MODE",
   );
   private failSetSandboxMode = envFlagEnabled("BRIDGE_FAIL_SET_SANDBOX_MODE");
+  private connectMetadataRefreshCooldownMs = Math.max(
+    0,
+    envInt(
+      "BRIDGE_CONNECT_METADATA_REFRESH_COOLDOWN_MS",
+      BridgeWebSocketServer.DEFAULT_CONNECT_METADATA_REFRESH_COOLDOWN_MS,
+    ),
+  );
+  private lastConnectClaudeMetadataRefreshAt = 0;
+  private lastConnectCodexMetadataRefreshAt = 0;
   private platform: NodeJS.Platform;
   private clientSupportedServerMessages = new WeakMap<WebSocket, Set<string>>();
 
@@ -1864,9 +1882,7 @@ export class BridgeWebSocketServer {
 
   private handleConnection(ws: WebSocket): void {
     // Send session list and project history on connect
-    void this.refreshCodexProfiles();
-    void this.refreshCodexModels();
-    void this.refreshClaudeModels();
+    this.refreshConnectionMetadata();
     this.sendSessionList(ws);
     const projects = this.projectHistory?.getProjects() ?? [];
     this.send(ws, { type: "project_history", projects });
@@ -1908,6 +1924,30 @@ export class BridgeWebSocketServer {
     ws.on("error", (err) => {
       console.error("[ws] Client error:", err.message);
     });
+  }
+
+  private refreshConnectionMetadata(): void {
+    const now = Date.now();
+    const shouldRefresh = (lastRefreshAt: number) =>
+      this.connectMetadataRefreshCooldownMs <= 0 ||
+      now - lastRefreshAt >= this.connectMetadataRefreshCooldownMs;
+
+    if (shouldRefresh(this.lastConnectClaudeMetadataRefreshAt)) {
+      this.lastConnectClaudeMetadataRefreshAt = now;
+      void this.refreshClaudeModels();
+    }
+
+    // Avoid spawning standalone Codex app-server processes on every mobile
+    // reconnect. Fallback model metadata is already available at startup; when
+    // a Codex session is active, these refreshes use that active process.
+    if (
+      this.getActiveCodexProcess() &&
+      shouldRefresh(this.lastConnectCodexMetadataRefreshAt)
+    ) {
+      this.lastConnectCodexMetadataRefreshAt = now;
+      void this.refreshCodexProfiles();
+      void this.refreshCodexModels();
+    }
   }
 
   private async handleClientMessage(
@@ -2162,6 +2202,7 @@ export class BridgeWebSocketServer {
             );
             this.broadcastSessionList();
             if (provider === "codex") {
+              void this.refreshCodexProfiles(projectPath);
               void this.refreshCodexModels(projectPath);
             } else {
               void this.refreshClaudeModels(projectPath);


### PR DESCRIPTION
## Summary
- Avoid spawning standalone Codex metadata refreshes on every mobile reconnect when no Codex session is active.
- Keep Claude metadata refresh behavior and add a cooldown for connection-triggered refreshes.
- Refresh Codex profiles/models when a Codex session starts so first-session metadata is still populated.

## Why
A mobile reconnect should not launch extra Codex work in repositories where the user is only using Claude or no Codex session is active.

## Tests
- npm ci --ignore-scripts
- npm run test --workspace=packages/bridge -- src/websocket.test.ts
- npx tsc --noEmit -p packages/bridge/tsconfig.json