### PR TITLE
fix(app): ignore malformed AskUserQuestion input

### DIFF
--- a/apps/mobile/lib/services/chat_message_handler.dart
+++ b/apps/mobile/lib/services/chat_message_handler.dart
@@ -1,6 +1,7 @@
 import '../core/logger.dart';
 import '../models/messages.dart';
 import '../utils/codex_plan_update.dart';
+import '../utils/request_user_input.dart';
 import '../widgets/slash_command_sheet.dart'
     show
         SlashCommand,
@@ -440,7 +441,13 @@ class ChatMessageHandler {
     bool? inPlanMode;
     for (final content in message.content) {
       if (content is ToolUseContent) {
-        if (content.name == 'AskUserQuestion') {
+        if (content.name == 'AskUserQuestion' &&
+            hasRequestUserInputQuestions(content.input)) {
+          // Only route to the AskUserQuestion UI when the tool input is
+          // well-formed (a non-empty `questions` list). A malformed call (bad
+          // params / tool-call error) otherwise reaches the widget and throws
+          // during build, blanking the whole screen. Treat malformed calls as
+          // ordinary tool uses instead.
           askToolUseId = content.id;
           askInput = content.input;
           effects.add(ChatSideEffect.mediumHaptic);
@@ -652,7 +659,8 @@ class ChatMessageHandler {
         if (m is AssistantServerMessage) {
           for (final content in m.message.content) {
             if (content is ToolUseContent &&
-                content.name == 'AskUserQuestion') {
+                content.name == 'AskUserQuestion' &&
+                hasRequestUserInputQuestions(content.input)) {
               lastAskToolUseId = content.id;
               lastAskInput = content.input;
             }

--- a/apps/mobile/lib/utils/request_user_input.dart
+++ b/apps/mobile/lib/utils/request_user_input.dart
@@ -26,12 +26,26 @@ const _mcpApprovalDeclineLabels = {mcpApprovalDeny, mcpApprovalDecline};
 Map<String, dynamic>? firstRequestUserInputQuestion(
   Map<String, dynamic> input,
 ) {
+  final questions = requestUserInputQuestions(input);
+  return questions.isEmpty ? null : questions.first;
+}
+
+List<Map<String, dynamic>> requestUserInputQuestions(
+  Map<String, dynamic> input,
+) {
   final questions = input['questions'];
-  if (questions is! List || questions.isEmpty) return null;
-  final first = questions.first;
-  return first is Map<String, dynamic>
-      ? first
-      : Map<String, dynamic>.from(first as Map);
+  if (questions is! List) return const [];
+
+  final parsed = <Map<String, dynamic>>[];
+  for (final question in questions) {
+    if (question is! Map) continue;
+    try {
+      parsed.add(Map<String, dynamic>.from(question));
+    } catch (_) {
+      // Ignore malformed entries such as maps with non-string keys.
+    }
+  }
+  return parsed;
 }
 
 List<String> requestUserInputOptionLabels(Map<String, dynamic> input) {
@@ -54,8 +68,7 @@ String? requestUserInputQuestionText(Map<String, dynamic> input) {
 }
 
 bool hasRequestUserInputQuestions(Map<String, dynamic> input) {
-  final questions = input['questions'];
-  return questions is List && questions.isNotEmpty;
+  return requestUserInputQuestions(input).isNotEmpty;
 }
 
 bool _containsAny(Set<String> labels, Set<String> candidates) =>

--- a/apps/mobile/lib/widgets/bubbles/ask_user_question_widget.dart
+++ b/apps/mobile/lib/widgets/bubbles/ask_user_question_widget.dart
@@ -40,8 +40,9 @@ class _AskUserQuestionWidgetState extends State<AskUserQuestionWidget> {
   int _currentPage = 0;
   bool _answered = false;
 
-  List<dynamic> get _questions =>
-      widget.input['questions'] as List<dynamic>? ?? const [];
+  List<Map<String, dynamic>> get _questions {
+    return requestUserInputQuestions(widget.input);
+  }
 
   bool get _isSingleQuestion => _questions.length <= 1;
 
@@ -49,7 +50,7 @@ class _AskUserQuestionWidgetState extends State<AskUserQuestionWidget> {
 
   bool get _singleQuestionIsMultiSelect {
     if (!_isSingleQuestion || _questions.isEmpty) return false;
-    final q = _questions.first as Map<String, dynamic>;
+    final q = _questions.first;
     return q['multiSelect'] as bool? ?? false;
   }
 
@@ -83,7 +84,7 @@ class _AskUserQuestionWidgetState extends State<AskUserQuestionWidget> {
     if (_answered) return;
     final answers = <String, String>{};
     for (var i = 0; i < _questions.length; i++) {
-      final q = _questions[i] as Map<String, dynamic>;
+      final q = _questions[i];
       final question = q['question'] as String? ?? '';
       final multiSelect = q['multiSelect'] as bool? ?? false;
       if (multiSelect) {
@@ -101,7 +102,7 @@ class _AskUserQuestionWidgetState extends State<AskUserQuestionWidget> {
 
   bool get _allQuestionsAnswered {
     for (var i = 0; i < _questions.length; i++) {
-      final q = _questions[i] as Map<String, dynamic>;
+      final q = _questions[i];
       final multiSelect = q['multiSelect'] as bool? ?? false;
       if (multiSelect) {
         final selected = _multiAnswers[i] ?? <String>{};
@@ -124,7 +125,7 @@ class _AskUserQuestionWidgetState extends State<AskUserQuestionWidget> {
 
   void _onAnswerSingle(int questionIndex, String label) {
     HapticFeedback.selectionClick();
-    final q = _questions[questionIndex] as Map<String, dynamic>;
+    final q = _questions[questionIndex];
     final isMulti = q['multiSelect'] as bool? ?? false;
 
     setState(() {
@@ -190,7 +191,7 @@ class _AskUserQuestionWidgetState extends State<AskUserQuestionWidget> {
   }
 
   void _submitCustomText(int questionIndex) {
-    final q = _questions[questionIndex] as Map<String, dynamic>;
+    final q = _questions[questionIndex];
     final isMulti = q['multiSelect'] as bool? ?? false;
     final customText = _customControllers[questionIndex]?.text.trim() ?? '';
 
@@ -237,7 +238,7 @@ class _AskUserQuestionWidgetState extends State<AskUserQuestionWidget> {
 
   void _onCustomTextChanged(int questionIndex, String text) {
     setState(() {
-      final q = _questions[questionIndex] as Map<String, dynamic>;
+      final q = _questions[questionIndex];
       final isMulti = q['multiSelect'] as bool? ?? false;
       if (isMulti) {
         final selected = _multiAnswers[questionIndex] ?? <String>{};
@@ -427,7 +428,7 @@ class _AskUserQuestionWidgetState extends State<AskUserQuestionWidget> {
                       );
                     }
                     return _AskQuestionLayout(
-                      question: questions[index] as Map<String, dynamic>,
+                      question: questions[index],
                       questionIndex: index,
                       isMultiQuestion: true,
                       scrollable: widget.scrollable,
@@ -454,7 +455,7 @@ class _AskUserQuestionWidgetState extends State<AskUserQuestionWidget> {
                 child: SingleChildScrollView(
                   key: const ValueKey('ask_single_question_scroll_view'),
                   child: _AskQuestionLayout(
-                    question: questions.first as Map<String, dynamic>,
+                    question: questions.first,
                     questionIndex: 0,
                     isMultiQuestion: false,
                     scrollable: false,
@@ -865,7 +866,7 @@ class _AskTextInputRow extends StatelessWidget {
 }
 
 class _AskSummaryPage extends StatelessWidget {
-  final List<dynamic> questions;
+  final List<Map<String, dynamic>> questions;
   final bool scrollable;
   final Map<int, String> singleAnswers;
   final ValueChanged<int> onGoToPage;
@@ -897,7 +898,7 @@ class _AskSummaryPage extends StatelessWidget {
         for (var i = 0; i < questions.length; i++) ...[
           _AskSummaryRow(
             index: i,
-            question: questions[i] as Map<String, dynamic>,
+            question: questions[i],
             answer: singleAnswers[i],
             onEdit: () => onGoToPage(i),
           ),

--- a/apps/mobile/test/ask_user_question_widget_test.dart
+++ b/apps/mobile/test/ask_user_question_widget_test.dart
@@ -545,4 +545,82 @@ void main() {
       expect(find.text('Claude is asking'), findsNothing);
     });
   });
+
+  group('AskUserQuestionWidget - malformed input does not crash', () {
+    // Regression: a malformed AskUserQuestion tool call (bad params) used to
+    // throw inside build() via an unguarded `as Map<String, dynamic>` cast,
+    // which, with no ErrorWidget boundary, blanked the entire session screen.
+    // The widget must now render without throwing for any shape of input.
+
+    testWidgets('question items are non-map (String/num/List)', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          AskUserQuestionWidget(
+            toolUseId: 'bad-1',
+            input: {
+              'questions': ['just a string', 123, [], null],
+            },
+            onAnswer: (_, _) {},
+          ),
+        ),
+      );
+      // Must not throw; malformed items are filtered out.
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('questions is not a list', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          AskUserQuestionWidget(
+            toolUseId: 'bad-2',
+            input: {'questions': 'oops not a list'},
+            onAnswer: (_, _) {},
+          ),
+        ),
+      );
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('questions key missing entirely', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          AskUserQuestionWidget(
+            toolUseId: 'bad-3',
+            input: const {},
+            onAnswer: (_, _) {},
+          ),
+        ),
+      );
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('mix of well-formed and malformed items renders the good one', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrap(
+          AskUserQuestionWidget(
+            toolUseId: 'bad-4',
+            input: {
+              'questions': [
+                'garbage',
+                {
+                  'question': 'Pick one',
+                  'header': 'Choice',
+                  'options': [
+                    {'label': 'A', 'description': 'first'},
+                  ],
+                  'multiSelect': false,
+                },
+              ],
+            },
+            onAnswer: (_, _) {},
+          ),
+        ),
+      );
+      expect(tester.takeException(), isNull);
+      // The single well-formed question survives filtering.
+      expect(find.text('Pick one'), findsOneWidget);
+    });
+  });
 }

--- a/apps/mobile/test/chat_message_handler_test.dart
+++ b/apps/mobile/test/chat_message_handler_test.dart
@@ -174,7 +174,11 @@ void main() {
               const ToolUseContent(
                 id: 'tu-ask',
                 name: 'AskUserQuestion',
-                input: {'questions': []},
+                input: {
+                  'questions': [
+                    {'question': 'Which option?'},
+                  ],
+                },
               ),
             ],
             model: 'test',
@@ -184,6 +188,33 @@ void main() {
       );
       expect(update.askToolUseId, 'tu-ask');
       expect(update.sideEffects, contains(ChatSideEffect.mediumHaptic));
+    });
+
+    test('ignores malformed AskUserQuestion tool use', () {
+      final update = handler.handle(
+        AssistantServerMessage(
+          message: AssistantMessage(
+            id: 'msg-1',
+            role: 'assistant',
+            content: [
+              const ToolUseContent(
+                id: 'tu-ask-bad',
+                name: 'AskUserQuestion',
+                input: {
+                  'questions': ['not a question map'],
+                },
+              ),
+            ],
+            model: 'test',
+          ),
+        ),
+        isBackground: false,
+      );
+
+      expect(update.askToolUseId, isNull);
+      expect(update.askInput, isNull);
+      expect(update.pendingToolUseId, 'tu-ask-bad');
+      expect(update.sideEffects, isNot(contains(ChatSideEffect.mediumHaptic)));
     });
 
     test('detects EnterPlanMode', () {
@@ -588,7 +619,11 @@ void main() {
                   const ToolUseContent(
                     id: 'tu-ask',
                     name: 'AskUserQuestion',
-                    input: {'questions': []},
+                    input: {
+                      'questions': [
+                        {'question': 'Which option?'},
+                      ],
+                    },
                   ),
                 ],
                 model: 'test',
@@ -600,6 +635,36 @@ void main() {
         ),
         isBackground: false,
       );
+      expect(update.askToolUseId, isNull);
+      expect(update.askInput, isNull);
+    });
+
+    test('does not restore malformed AskUserQuestion state from history', () {
+      final update = handler.handle(
+        HistoryMessage(
+          messages: [
+            AssistantServerMessage(
+              message: AssistantMessage(
+                id: 'msg-1',
+                role: 'assistant',
+                content: [
+                  const ToolUseContent(
+                    id: 'tu-ask',
+                    name: 'AskUserQuestion',
+                    input: {
+                      'questions': ['not a question map'],
+                    },
+                  ),
+                ],
+                model: 'test',
+              ),
+            ),
+            const StatusMessage(status: ProcessStatus.waitingApproval),
+          ],
+        ),
+        isBackground: false,
+      );
+
       expect(update.askToolUseId, isNull);
       expect(update.askInput, isNull);
     });

--- a/apps/mobile/test/request_user_input_test.dart
+++ b/apps/mobile/test/request_user_input_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:ccpocket/utils/request_user_input.dart';
+
+void main() {
+  group('requestUserInputQuestions', () {
+    test('returns an empty list when questions is missing or not a list', () {
+      expect(requestUserInputQuestions(const {}), isEmpty);
+      expect(
+        requestUserInputQuestions(const {'questions': 'not-a-list'}),
+        isEmpty,
+      );
+    });
+
+    test('keeps only map questions with string keys', () {
+      final questions = requestUserInputQuestions({
+        'questions': [
+          'bad',
+          {1: 'bad-key'},
+          {'question': 'Pick one'},
+        ],
+      });
+
+      expect(questions, [
+        {'question': 'Pick one'},
+      ]);
+      expect(
+        firstRequestUserInputQuestion({
+          'questions': ['bad'],
+        }),
+        isNull,
+      );
+      expect(
+        hasRequestUserInputQuestions({
+          'questions': ['bad'],
+        }),
+        isFalse,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add a shared requestUserInputQuestions parser that filters malformed question entries.
- Use that parser in the chat handler/history restore path and AskUserQuestion widget.
- Treat malformed AskUserQuestion tool calls as ordinary tool uses instead of opening an empty/crashing question UI.

## Why
Malformed tool input could reach the mobile AskUserQuestion widget and throw during build, blanking the session UI. Empty/non-map question lists should not be considered actionable user questions.

## Tests
- flutter pub get
- dart format apps/mobile/lib/utils/request_user_input.dart apps/mobile/lib/services/chat_message_handler.dart apps/mobile/lib/widgets/bubbles/ask_user_question_widget.dart apps/mobile/test/chat_message_handler_test.dart apps/mobile/test/ask_user_question_widget_test.dart apps/mobile/test/request_user_input_test.dart
- flutter test test/chat_message_handler_test.dart test/ask_user_question_widget_test.dart test/request_user_input_test.dart
- flutter analyze --no-fatal-infos

Note: plain flutter analyze currently exits with the repository's existing 35 prefer_initializing_formals info-level diagnostics; no new errors or warnings are introduced.