### PR TITLE
fix(app): prevent answered approvals from replaying

### DIFF
--- a/apps/mobile/lib/features/chat_session/state/chat_session_cubit.dart
+++ b/apps/mobile/lib/features/chat_session/state/chat_session_cubit.dart
@@ -498,16 +498,22 @@ class ChatSessionCubit extends Cubit<ChatSessionState> {
     }
 
     if (update.pendingPermission != null) {
-      approval = ApprovalState.permission(
-        toolUseId: update.pendingToolUseId!,
-        request: update.pendingPermission!,
-      );
+      final toolUseId = update.pendingToolUseId;
+      if (toolUseId != null && !_respondedToolUseIds.contains(toolUseId)) {
+        approval = ApprovalState.permission(
+          toolUseId: toolUseId,
+          request: update.pendingPermission!,
+        );
+      }
     }
     if (update.askToolUseId != null) {
-      approval = ApprovalState.askUser(
-        toolUseId: update.askToolUseId!,
-        input: update.askInput ?? {},
-      );
+      final toolUseId = update.askToolUseId!;
+      if (!_respondedToolUseIds.contains(toolUseId)) {
+        approval = ApprovalState.askUser(
+          toolUseId: toolUseId,
+          input: update.askInput ?? {},
+        );
+      }
     }
 
     // Stop status refresh timer when status changes from starting
@@ -1381,6 +1387,7 @@ class ChatSessionCubit extends Cubit<ChatSessionState> {
 
   /// Answer an AskUserQuestion.
   void answer(String toolUseId, String result) {
+    _respondedToolUseIds.add(toolUseId);
     _bridge.send(ClientMessage.answer(toolUseId, result, sessionId: sessionId));
     emit(state.copyWith(approval: const ApprovalState.none()));
   }

--- a/apps/mobile/test/chat_session_cubit_test.dart
+++ b/apps/mobile/test/chat_session_cubit_test.dart
@@ -992,6 +992,84 @@ void main() {
       expect(mockBridge.sentMessages, hasLength(1));
     });
 
+    test('approved permission is not restored by replayed history', () async {
+      final cubit = createCubit('s1');
+      addTearDown(cubit.close);
+      await Future.microtask(() {});
+
+      const permMsg = PermissionRequestMessage(
+        toolUseId: 'tool-1',
+        toolName: 'bash',
+        input: {'command': 'ls'},
+      );
+      mockBridge.emitMessage(permMsg, sessionId: 's1');
+      await Future.microtask(() {});
+
+      expect(cubit.state.approval, isA<ApprovalPermission>());
+      cubit.approve('tool-1');
+      expect(cubit.state.approval, isA<ApprovalNone>());
+
+      mockBridge.emitMessage(
+        const HistoryMessage(
+          messages: [
+            permMsg,
+            StatusMessage(status: ProcessStatus.waitingApproval),
+          ],
+        ),
+        sessionId: 's1',
+      );
+      await Future.microtask(() {});
+
+      expect(cubit.state.approval, isA<ApprovalNone>());
+    });
+
+    test(
+      'answered AskUserQuestion is not restored by replayed history',
+      () async {
+        final cubit = createCubit('s1');
+        addTearDown(cubit.close);
+        await Future.microtask(() {});
+
+        final askMessage = AssistantServerMessage(
+          message: AssistantMessage(
+            id: 'msg-ask',
+            role: 'assistant',
+            content: [
+              const ToolUseContent(
+                id: 'ask-1',
+                name: 'AskUserQuestion',
+                input: {
+                  'questions': [
+                    {'question': 'Which option?'},
+                  ],
+                },
+              ),
+            ],
+            model: 'claude',
+          ),
+        );
+        mockBridge.emitMessage(askMessage, sessionId: 's1');
+        await Future.microtask(() {});
+
+        expect(cubit.state.approval, isA<ApprovalAskUser>());
+        cubit.answer('ask-1', 'A');
+        expect(cubit.state.approval, isA<ApprovalNone>());
+
+        mockBridge.emitMessage(
+          HistoryMessage(
+            messages: [
+              askMessage,
+              const StatusMessage(status: ProcessStatus.waitingApproval),
+            ],
+          ),
+          sessionId: 's1',
+        );
+        await Future.microtask(() {});
+
+        expect(cubit.state.approval, isA<ApprovalNone>());
+      },
+    );
+
     test('approving ExitPlanMode also clears plan mode state', () async {
       final cubit = createCubit('s1', provider: Provider.codex);
       addTearDown(cubit.close);


### PR DESCRIPTION
## Summary
- Track answered AskUserQuestion toolUseIds the same way local approve/reject responses are tracked.
- Ignore replayed permission/AskUserQuestion updates for toolUseIds already answered in the current session.
- Add ChatSessionCubit regression tests for replayed history after approval and question answers.

## Why
Foreground/reconnect history refreshes can replay pending approval/question messages before their resolving tool_result arrives. Without a local idempotency guard, the UI can reopen an approval/question that the user already handled.

## Tests
- flutter pub get
- dart format lib/features/chat_session/state/chat_session_cubit.dart test/chat_session_cubit_test.dart
- flutter test test/chat_session_cubit_test.dart
- flutter analyze --no-fatal-infos

Note: plain flutter analyze currently exits with the repository's existing 35 prefer_initializing_formals info-level diagnostics; no new errors or warnings are introduced.