### PR TITLE
perf(bridge): limit file list payloads

### DIFF
--- a/packages/bridge/src/git-operations.test.ts
+++ b/packages/bridge/src/git-operations.test.ts
@@ -19,7 +19,9 @@ import {
   gitCommit,
   getStagedDiff,
   listGitFiles,
+  listGitFilesLimited,
   listFileSystemFiles,
+  listProjectFilesAndDirectoriesForClient,
   listProjectFilesAndDirectories,
   listProjectFiles,
   listBranches,
@@ -628,6 +630,18 @@ describe("listGitFiles", () => {
 
     expect(files).toContain("docs/line\nbreak.md");
   });
+
+  it("can stop after the requested number of files", async () => {
+    writeFileSync(join(repo, "a.md"), "a\n");
+    writeFileSync(join(repo, "b.md"), "b\n");
+    writeFileSync(join(repo, "c.md"), "c\n");
+
+    const result = await listGitFilesLimited(repo, { maxFiles: 2 });
+
+    expect(result.files).toHaveLength(2);
+    expect(result.truncated).toBe(true);
+    expect(result.totalFiles).toBeUndefined();
+  });
 });
 
 describe("listFileSystemFiles", () => {
@@ -723,6 +737,22 @@ describe("listProjectFiles", () => {
 
     expect(files).toContain("tracked.md");
     expect(files).not.toContain("ignored.log");
+  });
+
+  it("limits client file lists after adding directory candidates", async () => {
+    project = createTempRepo();
+    mkdirSync(join(project, "src", "features"), { recursive: true });
+    writeFileSync(join(project, "src", "features", "a.ts"), "a\n");
+    writeFileSync(join(project, "src", "features", "b.ts"), "b\n");
+    writeFileSync(join(project, "src", "features", "c.ts"), "c\n");
+
+    const result = await listProjectFilesAndDirectoriesForClient(project, {
+      maxEntries: 3,
+      maxBytes: 0,
+    });
+
+    expect(result.files).toHaveLength(3);
+    expect(result.truncated).toBe(true);
   });
 });
 

--- a/packages/bridge/src/git-operations.ts
+++ b/packages/bridge/src/git-operations.ts
@@ -1,7 +1,8 @@
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
 import { realpathSync, type Dir, type Dirent } from "node:fs";
 import { opendir } from "node:fs/promises";
 import { join, relative, resolve, sep } from "node:path";
+import { StringDecoder } from "node:string_decoder";
 
 // ---- Types ----
 
@@ -47,6 +48,17 @@ export interface FileSystemFileListOptions {
   maxDepth?: number;
   maxFiles?: number;
   excludedDirs?: ReadonlySet<string> | readonly string[];
+}
+
+export interface ClientFileListOptions extends FileSystemFileListOptions {
+  maxEntries?: number;
+  maxBytes?: number;
+}
+
+export interface ClientFileListResult {
+  files: string[];
+  truncated: boolean;
+  totalFiles?: number;
 }
 
 export const DEFAULT_FILESYSTEM_FILE_LIST_MAX_DEPTH = 8;
@@ -264,6 +276,105 @@ export function listGitFiles(projectPath: string): string[] {
   return output.split("\0").filter(Boolean);
 }
 
+/** Return tracked and untracked Git files with an optional early-stop limit. */
+export function listGitFilesLimited(
+  projectPath: string,
+  options: { maxFiles?: number } = {},
+): Promise<ClientFileListResult> {
+  const cwd = resolveProject(projectPath);
+  const maxFiles = Math.max(0, options.maxFiles ?? 0);
+
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(
+      "git",
+      withGitPathConfig([
+        "ls-files",
+        "-z",
+        "--cached",
+        "--others",
+        "--exclude-standard",
+      ]),
+      { cwd, stdio: ["ignore", "pipe", "pipe"] },
+    );
+
+    const decoder = new StringDecoder("utf8");
+    const files: string[] = [];
+    const stderr: string[] = [];
+    let pending = "";
+    let truncated = false;
+    let settled = false;
+
+    const settle = (result: ClientFileListResult) => {
+      if (settled) return;
+      settled = true;
+      resolvePromise(result);
+    };
+
+    const fail = (err: unknown) => {
+      if (settled) return;
+      settled = true;
+      reject(err);
+    };
+
+    const acceptFile = (file: string): boolean => {
+      if (!file) return true;
+      if (maxFiles > 0 && files.length >= maxFiles) {
+        truncated = true;
+        child.kill("SIGTERM");
+        return false;
+      }
+      files.push(file);
+      if (maxFiles > 0 && files.length >= maxFiles) {
+        truncated = true;
+        child.kill("SIGTERM");
+        return false;
+      }
+      return true;
+    };
+
+    const consume = (text: string) => {
+      pending += text;
+      const parts = pending.split("\0");
+      pending = parts.pop() ?? "";
+      for (const part of parts) {
+        if (!acceptFile(part)) return;
+      }
+    };
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      if (truncated) return;
+      consume(decoder.write(chunk));
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr.push(chunk.toString("utf8"));
+    });
+    child.on("error", fail);
+    child.on("close", (code, signal) => {
+      if (!truncated) {
+        const tail = decoder.end();
+        if (tail) consume(tail);
+        if (pending) acceptFile(pending);
+      }
+
+      if (code === 0 || truncated || signal === "SIGTERM") {
+        settle({
+          files,
+          truncated,
+          totalFiles: truncated ? undefined : files.length,
+        });
+        return;
+      }
+
+      fail(
+        new Error(
+          stderr.join("").trim() ||
+            `git ls-files failed with exit code ${code ?? signal}`,
+        ),
+      );
+    });
+  });
+}
+
 /** Return project files, using Git when available and filesystem fallback otherwise. */
 export async function listProjectFiles(
   projectPath: string,
@@ -279,12 +390,85 @@ export async function listProjectFiles(
   }
 }
 
+async function listProjectFilesLimited(
+  projectPath: string,
+  options: ClientFileListOptions = {},
+): Promise<ClientFileListResult> {
+  const maxFiles =
+    options.maxFiles ??
+    options.maxEntries ??
+    DEFAULT_FILESYSTEM_FILE_LIST_MAX_FILES;
+
+  try {
+    return await listGitFilesLimited(projectPath, { maxFiles });
+  } catch (err) {
+    if (!isGitFileListingUnavailable(err)) {
+      throw err;
+    }
+    const files = await listFileSystemFiles(projectPath, {
+      ...options,
+      maxFiles,
+    });
+    const reachedLimit = maxFiles > 0 && files.length >= maxFiles;
+    return {
+      files,
+      truncated: reachedLimit,
+      totalFiles: reachedLimit ? undefined : files.length,
+    };
+  }
+}
+
 /** Return project file paths plus directory mention candidates. */
 export async function listProjectFilesAndDirectories(
   projectPath: string,
   options: FileSystemFileListOptions = {},
 ): Promise<string[]> {
   return withDirectoryCandidates(await listProjectFiles(projectPath, options));
+}
+
+export async function listProjectFilesAndDirectoriesForClient(
+  projectPath: string,
+  options: ClientFileListOptions = {},
+): Promise<ClientFileListResult> {
+  const listed = await listProjectFilesLimited(projectPath, options);
+  const filesAndDirs = withDirectoryCandidates(listed.files);
+  const limited = limitClientFileList(filesAndDirs, options);
+  return {
+    files: limited.files,
+    truncated: listed.truncated || limited.truncated,
+    totalFiles: listed.truncated ? undefined : filesAndDirs.length,
+  };
+}
+
+function limitClientFileList(
+  files: readonly string[],
+  options: ClientFileListOptions,
+): ClientFileListResult {
+  const maxEntries = Math.max(0, options.maxEntries ?? 0);
+  const maxBytes = Math.max(0, options.maxBytes ?? 0);
+  if (maxEntries === 0 && maxBytes === 0) {
+    return { files: [...files], truncated: false, totalFiles: files.length };
+  }
+
+  const limited: string[] = [];
+  let bytes = 0;
+  for (const file of files) {
+    if (maxEntries > 0 && limited.length >= maxEntries) break;
+
+    const nextBytes = Buffer.byteLength(file, "utf8") + 1;
+    if (maxBytes > 0 && limited.length > 0 && bytes + nextBytes > maxBytes) {
+      break;
+    }
+
+    limited.push(file);
+    bytes += nextBytes;
+  }
+
+  return {
+    files: limited,
+    truncated: limited.length < files.length,
+    totalFiles: files.length,
+  };
 }
 
 export function withDirectoryCandidates(files: readonly string[]): string[] {

--- a/packages/bridge/src/parser.ts
+++ b/packages/bridge/src/parser.ts
@@ -531,7 +531,12 @@ export type ServerMessage =
       mimeType?: string;
       sizeBytes?: number;
     }
-  | { type: "file_list"; files: string[] }
+  | {
+      type: "file_list";
+      files: string[];
+      totalFiles?: number;
+      truncated?: boolean;
+    }
   | { type: "project_history"; projects: string[] }
   | {
       type: "diff_result";

--- a/packages/bridge/src/websocket.test.ts
+++ b/packages/bridge/src/websocket.test.ts
@@ -695,6 +695,47 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     bridge.close();
   });
 
+  it("limits file list payloads before sending them to clients", async () => {
+    const repo = mkdtempSync(resolve(tmpdir(), "ccpocket-file-list-"));
+    try {
+      execFileSync("git", ["init"], { cwd: repo });
+      mkdirSync(resolve(repo, "src"), { recursive: true });
+      writeFileSync(resolve(repo, "src", "a.ts"), "a\n");
+      writeFileSync(resolve(repo, "src", "b.ts"), "b\n");
+      writeFileSync(resolve(repo, "src", "c.ts"), "c\n");
+
+      const bridge = new BridgeWebSocketServer({ server: httpServer });
+      (bridge as any).fileListMaxEntries = 2;
+      (bridge as any).fileListMaxBytes = 0;
+      const ws = {
+        readyState: OPEN_STATE,
+        send: vi.fn(),
+      } as any;
+
+      await (bridge as any).handleClientMessage(
+        { type: "list_files", projectPath: repo },
+        ws,
+      );
+
+      for (let i = 0; i < 20 && ws.send.mock.calls.length === 0; i++) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+
+      const message = ws.send.mock.calls
+        .map((call: unknown[]) => JSON.parse(call[0] as string))
+        .find((sent: any) => sent.type === "file_list");
+      expect(message).toMatchObject({
+        type: "file_list",
+        truncated: true,
+      });
+      expect(message.files).toHaveLength(2);
+
+      bridge.close();
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
   it("rejects start when selected codex profile does not exist", async () => {
     const bridge = new BridgeWebSocketServer({ server: httpServer });
     const ws = {

--- a/packages/bridge/src/websocket.ts
+++ b/packages/bridge/src/websocket.ts
@@ -72,7 +72,7 @@ import {
   unstageHunks,
   gitCommit,
   gitPush,
-  listProjectFilesAndDirectories,
+  listProjectFilesAndDirectoriesForClient,
   listBranches,
   createBranch,
   checkoutBranch,
@@ -512,6 +512,13 @@ function envFlagEnabled(name: string): boolean {
   return value === "1" || value === "true" || value === "yes" || value === "on";
 }
 
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name]?.trim();
+  if (!raw) return fallback;
+  const value = Number.parseInt(raw, 10);
+  return Number.isFinite(value) ? value : fallback;
+}
+
 function codexThreadToRecentSession(
   thread: CodexThreadSummary,
   indexed?: CodexSessionIndexMetadata,
@@ -582,6 +589,8 @@ export interface BridgeServerOptions {
 export class BridgeWebSocketServer {
   private static readonly MAX_DEBUG_EVENTS = 800;
   private static readonly MAX_HISTORY_SUMMARY_ITEMS = 300;
+  private static readonly DEFAULT_FILE_LIST_MAX_ENTRIES = 5000;
+  private static readonly DEFAULT_FILE_LIST_MAX_BYTES = 512 * 1024;
 
   private wss: WebSocketServer;
   private sessionManager: SessionManager;
@@ -625,6 +634,20 @@ export class BridgeWebSocketServer {
     "BRIDGE_FAIL_SET_PERMISSION_MODE",
   );
   private failSetSandboxMode = envFlagEnabled("BRIDGE_FAIL_SET_SANDBOX_MODE");
+  private fileListMaxEntries = Math.max(
+    0,
+    envInt(
+      "BRIDGE_FILE_LIST_MAX_ENTRIES",
+      BridgeWebSocketServer.DEFAULT_FILE_LIST_MAX_ENTRIES,
+    ),
+  );
+  private fileListMaxBytes = Math.max(
+    0,
+    envInt(
+      "BRIDGE_FILE_LIST_MAX_BYTES",
+      BridgeWebSocketServer.DEFAULT_FILE_LIST_MAX_BYTES,
+    ),
+  );
   private platform: NodeJS.Platform;
   private clientSupportedServerMessages = new WeakMap<WebSocket, Set<string>>();
 
@@ -4451,13 +4474,19 @@ export class BridgeWebSocketServer {
         }
         void (async () => {
           try {
-            const files = await listProjectFilesAndDirectories(
+            const result = await listProjectFilesAndDirectoriesForClient(
               msg.projectPath,
+              {
+                maxEntries: this.fileListMaxEntries,
+                maxBytes: this.fileListMaxBytes,
+              },
             );
-            this.send(ws, { type: "file_list", files } as Record<
-              string,
-              unknown
-            >);
+            this.send(ws, {
+              type: "file_list",
+              files: result.files,
+              totalFiles: result.totalFiles,
+              truncated: result.truncated,
+            } as Record<string, unknown>);
           } catch (err) {
             const message = err instanceof Error ? err.message : String(err);
             this.send(ws, {


### PR DESCRIPTION
## Summary
- Add a client-facing file-list path that limits entries and approximate payload bytes before responding to mobile clients.
- Use a streaming git ls-files reader with an early-stop file limit, instead of always buffering the complete Git file list.
- Include optional file_list metadata (truncated, totalFiles when known) while preserving the existing files array for compatibility.

## Why
Large repositories can produce very large file-list payloads for autocomplete/explorer views. Limiting the payload at the bridge reduces mobile memory/network pressure and avoids doing unnecessary Git output buffering once the client-facing limit has been reached.

## Notes
When the bridge stops early, totalFiles is intentionally omitted because the full count is unknown. truncated=true tells clients the list was capped.

## Tests
- npm ci --ignore-scripts
- npm run test --workspace=packages/bridge -- src/git-operations.test.ts
- npm run test --workspace=packages/bridge -- src/websocket.test.ts -t "limits file list payloads"
- npx tsc --noEmit -p packages/bridge/tsconfig.json