### PR TITLE
fix(app): show scoped release render fallback

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -87,6 +87,26 @@ Future<void> _checkShorebirdUpdate(SharedPreferences prefs) async {
   }
 }
 
+@visibleForTesting
+Widget buildReleaseErrorWidget(FlutterErrorDetails details) {
+  return Material(
+    color: Colors.transparent,
+    child: Padding(
+      padding: const EdgeInsets.all(12),
+      child: Text(
+        'Something went wrong rendering this content.',
+        style: const TextStyle(fontSize: 12, color: Colors.redAccent),
+        textAlign: TextAlign.center,
+      ),
+    ),
+  );
+}
+
+void installReleaseErrorWidget({bool isReleaseMode = kReleaseMode}) {
+  if (!isReleaseMode) return;
+  ErrorWidget.builder = buildReleaseErrorWidget;
+}
+
 void main() async {
   if (kDebugMode && !kIsWeb) {
     MarionetteBinding.ensureInitialized();
@@ -105,6 +125,7 @@ void main() async {
       details.stack,
     );
   };
+  installReleaseErrorWidget();
   // Initialize notifications eagerly so the Android notification channel is
   // created before any FCM message arrives. Without this, FCM falls back to
   // the low-importance fcm_fallback_notification_channel and notifications

--- a/apps/mobile/test/main_error_widget_test.dart
+++ b/apps/mobile/test/main_error_widget_test.dart
@@ -1,0 +1,40 @@
+import 'package:ccpocket/main.dart' as app_main;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('does not install the release fallback outside release mode', () {
+    final originalBuilder = ErrorWidget.builder;
+
+    app_main.installReleaseErrorWidget(isReleaseMode: false);
+
+    expect(identical(ErrorWidget.builder, originalBuilder), isTrue);
+  });
+
+  test('installs the release fallback in release mode', () {
+    final originalBuilder = ErrorWidget.builder;
+
+    app_main.installReleaseErrorWidget(isReleaseMode: true);
+
+    expect(identical(ErrorWidget.builder, originalBuilder), isFalse);
+    ErrorWidget.builder = originalBuilder;
+  });
+
+  testWidgets('release fallback renders a scoped error message', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: app_main.buildReleaseErrorWidget(
+          FlutterErrorDetails(exception: StateError('boom')),
+        ),
+      ),
+    );
+
+    expect(
+      find.text('Something went wrong rendering this content.'),
+      findsOneWidget,
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- Install a release-mode ErrorWidget fallback that renders a small scoped message instead of Flutter's blank gray release box.
- Keep debug behavior unchanged so the default red error widget remains visible during development.
- Extract the fallback into testable helpers and cover the install/render behavior.

## Why
A single widget build failure in release can otherwise make the affected area appear blank with no useful recovery cue. This is especially painful inside chat content where one bad bubble should not make the session look empty.

## Tests
- flutter pub get
- dart format lib/main.dart test/main_error_widget_test.dart
- flutter test test/main_error_widget_test.dart
- flutter analyze --no-fatal-infos

Note: plain flutter analyze currently reports the repository's existing 35 prefer_initializing_formals info-level diagnostics; no new errors or warnings are introduced.