### PR TITLE
fix(bridge): validate server port before startup

### DIFF
--- a/packages/bridge/src/bridge-port.test.ts
+++ b/packages/bridge/src/bridge-port.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { DEFAULT_BRIDGE_PORT, parseBridgePort } from "./bridge-port.js";
+
+const originalBridgePort = process.env.BRIDGE_PORT;
+
+describe("parseBridgePort", () => {
+  afterEach(() => {
+    if (originalBridgePort === undefined) {
+      delete process.env.BRIDGE_PORT;
+    } else {
+      process.env.BRIDGE_PORT = originalBridgePort;
+    }
+  });
+
+  it("uses the default bridge port when no value is configured", () => {
+    delete process.env.BRIDGE_PORT;
+
+    expect(parseBridgePort()).toBe(DEFAULT_BRIDGE_PORT);
+  });
+
+  it("reads BRIDGE_PORT from the environment", () => {
+    process.env.BRIDGE_PORT = "9876";
+
+    expect(parseBridgePort()).toBe(9876);
+  });
+
+  it.each([
+    ["1", 1],
+    ["8765", 8765],
+    ["65535", 65535],
+    [" 8765 ", 8765],
+  ])("accepts %s", (rawPort, expected) => {
+    expect(parseBridgePort(rawPort)).toBe(expected);
+  });
+
+  it.each(["", "0", "-1", "65536", "123abc", "8.5", "NaN"])(
+    "rejects %s",
+    (rawPort) => {
+      expect(() => parseBridgePort(rawPort)).toThrow(
+        `Invalid BRIDGE_PORT "${rawPort}"`,
+      );
+    },
+  );
+});

--- a/packages/bridge/src/bridge-port.ts
+++ b/packages/bridge/src/bridge-port.ts
@@ -1,0 +1,27 @@
+export const DEFAULT_BRIDGE_PORT = 8765;
+
+const MIN_BRIDGE_PORT = 1;
+const MAX_BRIDGE_PORT = 65535;
+
+function invalidBridgePortMessage(rawPort: string): string {
+  return `Invalid BRIDGE_PORT "${rawPort}": expected an integer between ${MIN_BRIDGE_PORT} and ${MAX_BRIDGE_PORT}.`;
+}
+
+export function parseBridgePort(
+  rawPort = process.env.BRIDGE_PORT ?? String(DEFAULT_BRIDGE_PORT),
+): number {
+  const normalized = rawPort.trim();
+  if (!/^\d+$/.test(normalized)) {
+    throw new Error(invalidBridgePortMessage(rawPort));
+  }
+
+  const port = Number(normalized);
+  if (
+    !Number.isSafeInteger(port) ||
+    port < MIN_BRIDGE_PORT ||
+    port > MAX_BRIDGE_PORT
+  ) {
+    throw new Error(invalidBridgePortMessage(rawPort));
+  }
+  return port;
+}

--- a/packages/bridge/src/cli.test.ts
+++ b/packages/bridge/src/cli.test.ts
@@ -1,0 +1,26 @@
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("ccpocket-bridge CLI", () => {
+  it("rejects an invalid --port value before server startup", () => {
+    const tsxBin = resolve(
+      process.cwd(),
+      "../../node_modules/.bin",
+      process.platform === "win32" ? "tsx.cmd" : "tsx",
+    );
+    const env = { ...process.env };
+    delete env.BRIDGE_PORT;
+
+    const result = spawnSync(tsxBin, ["src/cli.ts", "--port", "abc"], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env,
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      '[bridge] Failed to start: Invalid BRIDGE_PORT "abc"',
+    );
+  });
+});

--- a/packages/bridge/src/cli.ts
+++ b/packages/bridge/src/cli.ts
@@ -46,6 +46,10 @@ BRIDGE_DISABLE_MDNS. Codex app-server configuration can be provided with
 BRIDGE_CODEX_APP_SERVER_MODE and BRIDGE_CODEX_SHARED_APP_SERVER_URL.`);
 }
 
+function startupErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
 if (parsed.helpRequested) {
   printHelp();
 } else if (parsed.versionRequested) {
@@ -128,7 +132,7 @@ if (parsed.helpRequested) {
   const codexAppServerPort = parseFlag(parsed, "codex-app-server-port");
   const codexAppServerUrl = parseFlag(parsed, "codex-app-server-url");
 
-  if (port) process.env.BRIDGE_PORT = port;
+  if (port !== undefined) process.env.BRIDGE_PORT = port;
   if (host) process.env.BRIDGE_HOST = host;
   if (apiKey) process.env.BRIDGE_API_KEY = apiKey;
   if (publicWsUrl) process.env.BRIDGE_PUBLIC_WS_URL = publicWsUrl;
@@ -145,5 +149,8 @@ if (parsed.helpRequested) {
   }
   if (hasFlag(parsed, "no-mdns")) process.env.BRIDGE_DISABLE_MDNS = "1";
 
-  startServer();
+  startServer().catch((err) => {
+    console.error(`[bridge] Failed to start: ${startupErrorMessage(err)}`);
+    process.exit(1);
+  });
 }

--- a/packages/bridge/src/index.ts
+++ b/packages/bridge/src/index.ts
@@ -20,9 +20,14 @@ import {
   PromptHistoryStore,
 } from "./prompt-history-store.js";
 import { resolvePlatformPath } from "./path-utils.js";
+import { parseBridgePort } from "./bridge-port.js";
+
+function startupErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
 
 export async function startServer() {
-  const PORT = parseInt(process.env.BRIDGE_PORT ?? "8765", 10);
+  const PORT = parseBridgePort();
   const HOST = process.env.BRIDGE_HOST ?? "0.0.0.0";
   const API_KEY = process.env.BRIDGE_API_KEY;
 
@@ -209,12 +214,6 @@ export async function startServer() {
     promptHistoryStore,
   });
 
-  httpServer.listen(PORT, HOST, () => {
-    console.log(`[bridge] Ready. Listening on http://${HOST}:${PORT} (HTTP + WebSocket)`);
-    mdns?.start(PORT, API_KEY);
-    printStartupInfo(PORT, HOST, API_KEY);
-  });
-
   function shutdown() {
     console.log("\n[bridge] Shutting down gracefully...");
     mdns?.stop();
@@ -225,6 +224,21 @@ export async function startServer() {
 
   process.on("SIGINT", shutdown);
   process.on("SIGTERM", shutdown);
+
+  await new Promise<void>((resolve, reject) => {
+    const onError = (err: Error) => {
+      wsServer?.close();
+      reject(err);
+    };
+    httpServer.once("error", onError);
+    httpServer.listen(PORT, HOST, () => {
+      httpServer.off("error", onError);
+      console.log(`[bridge] Ready. Listening on http://${HOST}:${PORT} (HTTP + WebSocket)`);
+      mdns?.start(PORT, API_KEY);
+      printStartupInfo(PORT, HOST, API_KEY);
+      resolve();
+    });
+  });
 }
 
 // Auto-start when executed directly (node dist/index.js, tsx src/index.ts)
@@ -235,7 +249,7 @@ const isDirectExecution =
 if (isDirectExecution) {
   setupProxy();
   startServer().catch((err) => {
-    console.error("[bridge] Failed to start:", err);
+    console.error(`[bridge] Failed to start: ${startupErrorMessage(err)}`);
     process.exit(1);
   });
 }


### PR DESCRIPTION
## Summary
- add strict Bridge port parsing for `BRIDGE_PORT` / `--port`, accepting only integers from 1 to 65535
- make CLI startup catch invalid port and async server startup failures with a clear error and exit code 1
- make `startServer()` resolve only after the HTTP server is listening and reject listen errors such as invalid bind failures

## Tests
- `npm run test --workspace=@ccpocket/bridge -- src/bridge-port.test.ts src/cli.test.ts`
- `npm run build --workspace=@ccpocket/bridge`
