### PR TITLE
fix(codex): derive permissions display from runtime settings

### DIFF
--- a/apps/mobile/lib/models/messages.dart
+++ b/apps/mobile/lib/models/messages.dart
@@ -231,16 +231,17 @@ CodexPermissionsMode codexPermissionsModeFromSettings({
   final explicit = codexPermissionsModeFromRaw(codexPermissionsMode);
   if (explicit != null) return explicit;
   final normalizedSandbox = switch (sandboxMode) {
-    'danger-full-access' || 'off' => SandboxMode.off,
-    'workspace-write' || 'read-only' || 'on' => SandboxMode.on,
+    'danger-full-access' || 'off' => 'off',
+    'workspace-write' || 'on' => 'workspace-write',
+    'read-only' => 'read-only',
     _ => null,
   };
   if (approvalPolicy == CodexApprovalPolicy.never.value &&
-      (normalizedSandbox == null || normalizedSandbox == SandboxMode.off)) {
+      (normalizedSandbox == null || normalizedSandbox == 'off')) {
     return CodexPermissionsMode.fullAccess;
   }
   if (approvalPolicy == CodexApprovalPolicy.onRequest.value &&
-      (normalizedSandbox == null || normalizedSandbox == SandboxMode.on)) {
+      (normalizedSandbox == null || normalizedSandbox == 'workspace-write')) {
     return isCodexAutoReviewApprovalsReviewer(approvalsReviewer)
         ? CodexPermissionsMode.autoReview
         : CodexPermissionsMode.defaultPermissions;
@@ -327,6 +328,26 @@ String? resolveCodexApprovalPolicy({
       : (executionMode?.isNotEmpty == true
             ? codexApprovalPolicyFromLegacyExecutionModeValue(executionMode)
             : null);
+}
+
+String? _resolveCodexPermissionsMode(Map<String, dynamic>? codexSettings) {
+  if (codexSettings == null) return null;
+  final explicit = codexPermissionsModeFromRaw(
+    codexSettings['codexPermissionsMode'] as String?,
+  );
+  if (explicit != null) return explicit.value;
+
+  final hasPermissionSettings =
+      codexSettings['approvalPolicy'] != null ||
+      codexSettings['approvalsReviewer'] != null ||
+      codexSettings['sandboxMode'] != null;
+  if (!hasPermissionSettings) return null;
+
+  return codexPermissionsModeFromSettings(
+    approvalPolicy: codexSettings['approvalPolicy'] as String?,
+    approvalsReviewer: codexSettings['approvalsReviewer'] as String?,
+    sandboxMode: codexSettings['sandboxMode'] as String?,
+  ).value;
 }
 
 PermissionMode legacyPermissionModeFromModes(
@@ -3181,7 +3202,7 @@ class RecentSession {
         executionMode: json['executionMode'] as String?,
       ),
       codexApprovalsReviewer: codexSettings?['approvalsReviewer'] as String?,
-      codexPermissionsMode: codexSettings?['codexPermissionsMode'] as String?,
+      codexPermissionsMode: _resolveCodexPermissionsMode(codexSettings),
       executionMode:
           json['executionMode'] as String? ??
           deriveExecutionMode(
@@ -3476,7 +3497,7 @@ class SessionInfo {
         executionMode: json['executionMode'] as String?,
       ),
       codexApprovalsReviewer: codexSettings?['approvalsReviewer'] as String?,
-      codexPermissionsMode: codexSettings?['codexPermissionsMode'] as String?,
+      codexPermissionsMode: _resolveCodexPermissionsMode(codexSettings),
       codexSandboxMode: codexSettings?['sandboxMode'] as String?,
       codexModel: sanitizeCodexModelName(codexSettings?['model'] as String?),
       codexProfile: codexSettings?['profile'] as String?,

--- a/apps/mobile/test/messages_test.dart
+++ b/apps/mobile/test/messages_test.dart
@@ -13,6 +13,106 @@ void main() {
     });
   });
 
+  group('Codex permissions mode', () {
+    test('derives display mode from concrete Codex settings', () {
+      expect(
+        codexPermissionsModeFromSettings(
+          approvalPolicy: 'on-request',
+          sandboxMode: 'workspace-write',
+        ),
+        CodexPermissionsMode.defaultPermissions,
+      );
+      expect(
+        codexPermissionsModeFromSettings(
+          approvalPolicy: 'on-request',
+          approvalsReviewer: 'auto_review',
+          sandboxMode: 'workspace-write',
+        ),
+        CodexPermissionsMode.autoReview,
+      );
+      expect(
+        codexPermissionsModeFromSettings(
+          approvalPolicy: 'never',
+          sandboxMode: 'danger-full-access',
+        ),
+        CodexPermissionsMode.fullAccess,
+      );
+      expect(
+        codexPermissionsModeFromSettings(
+          approvalPolicy: 'on-request',
+          sandboxMode: 'read-only',
+        ),
+        CodexPermissionsMode.custom,
+      );
+      expect(
+        codexPermissionsModeFromSettings(
+          approvalPolicy: 'never',
+          sandboxMode: 'workspace-write',
+        ),
+        CodexPermissionsMode.custom,
+      );
+    });
+
+    test(
+      'RecentSession derives missing permissions mode from codexSettings',
+      () {
+        final session = RecentSession.fromJson({
+          'sessionId': 's-read-only',
+          'provider': 'codex',
+          'firstPrompt': 'resume',
+          'created': '2026-02-13T00:00:00Z',
+          'modified': '2026-02-13T00:00:00Z',
+          'gitBranch': 'main',
+          'projectPath': '/tmp/project',
+          'isSidechain': false,
+          'codexSettings': {
+            'approvalPolicy': 'on-request',
+            'sandboxMode': 'read-only',
+          },
+        });
+
+        expect(session.codexPermissionsMode, CodexPermissionsMode.custom.value);
+      },
+    );
+
+    test('SessionInfo derives missing permissions mode from codexSettings', () {
+      final session = SessionInfo.fromJson({
+        'id': 's-auto',
+        'provider': 'codex',
+        'projectPath': '/tmp/project',
+        'status': 'idle',
+        'createdAt': '',
+        'lastActivityAt': '',
+        'codexSettings': {
+          'approvalPolicy': 'on-request',
+          'approvalsReviewer': 'auto_review',
+          'sandboxMode': 'workspace-write',
+        },
+      });
+
+      expect(
+        session.codexPermissionsMode,
+        CodexPermissionsMode.autoReview.value,
+      );
+    });
+
+    test('does not invent a permissions mode for metadata-only settings', () {
+      final session = RecentSession.fromJson({
+        'sessionId': 's-model-only',
+        'provider': 'codex',
+        'firstPrompt': 'resume',
+        'created': '2026-02-13T00:00:00Z',
+        'modified': '2026-02-13T00:00:00Z',
+        'gitBranch': 'main',
+        'projectPath': '/tmp/project',
+        'isSidechain': false,
+        'codexSettings': {'model': 'gpt-5.3-codex'},
+      });
+
+      expect(session.codexPermissionsMode, isNull);
+    });
+  });
+
   group('SystemMessage', () {
     test('parses Codex CLI join target', () {
       final msg = ServerMessage.fromJson({

--- a/packages/bridge/src/session.test.ts
+++ b/packages/bridge/src/session.test.ts
@@ -149,6 +149,75 @@ describe("SessionManager codex path", () => {
     expect(session?.provider).toBe("codex");
   });
 
+  it("derives codex permissions mode from explicit runtime settings", () => {
+    const manager = new SessionManager(() => {});
+    const readOnlyId = manager.create(
+      "/tmp/project-codex-read-only",
+      undefined,
+      undefined,
+      undefined,
+      "codex",
+      {
+        approvalPolicy: "on-request",
+        sandboxMode: "read-only",
+      },
+    );
+    const autoReviewId = manager.create(
+      "/tmp/project-codex-auto-review",
+      undefined,
+      undefined,
+      undefined,
+      "codex",
+      {
+        approvalPolicy: "on-request",
+        approvalsReviewer: "auto_review",
+        sandboxMode: "workspace-write",
+      },
+    );
+    const fullAccessId = manager.create(
+      "/tmp/project-codex-full-access",
+      undefined,
+      undefined,
+      undefined,
+      "codex",
+      {
+        approvalPolicy: "never",
+        sandboxMode: "danger-full-access",
+      },
+    );
+    const modelOnlyId = manager.create(
+      "/tmp/project-codex-model-only",
+      undefined,
+      undefined,
+      undefined,
+      "codex",
+      {
+        model: "gpt-5.3-codex",
+      },
+    );
+
+    const summariesById = new Map(manager.list().map((s) => [s.id, s]));
+    expect(summariesById.get(readOnlyId)?.codexSettings).toMatchObject({
+      approvalPolicy: "on-request",
+      sandboxMode: "read-only",
+      codexPermissionsMode: "custom",
+    });
+    expect(summariesById.get(autoReviewId)?.codexSettings).toMatchObject({
+      approvalPolicy: "on-request",
+      approvalsReviewer: "auto_review",
+      sandboxMode: "workspace-write",
+      codexPermissionsMode: "autoReview",
+    });
+    expect(summariesById.get(fullAccessId)?.codexSettings).toMatchObject({
+      approvalPolicy: "never",
+      sandboxMode: "danger-full-access",
+      codexPermissionsMode: "fullAccess",
+    });
+    expect(
+      summariesById.get(modelOnlyId)?.codexSettings?.codexPermissionsMode,
+    ).toBeUndefined();
+  });
+
   it("caches codex plugin completion metadata", () => {
     const manager = new SessionManager(() => {});
     manager.create(
@@ -372,6 +441,7 @@ describe("SessionManager codex path", () => {
       model: "gpt-5.4",
       approvalPolicy: "never",
       sandboxMode: "workspace-write",
+      codexPermissionsMode: "custom",
       networkAccessEnabled: false,
     });
   });

--- a/packages/bridge/src/session.ts
+++ b/packages/bridge/src/session.ts
@@ -24,6 +24,7 @@ import type {
   AssistantToolUseContent,
   Provider,
   QueuedInputItem,
+  CodexPermissionsMode,
 } from "./parser.js";
 import type { ImageRef, ImageStore } from "./image-store.js";
 import type { GalleryStore, GalleryImageMeta } from "./gallery-store.js";
@@ -168,6 +169,83 @@ const MAX_HISTORY_PER_SESSION = 100;
 export type GalleryImageCallback = (meta: GalleryImageMeta) => void;
 export type SessionUpdatedCallback = (sessionId: string) => void;
 
+function normalizeCodexPermissionsMode(
+  value?: string,
+): CodexPermissionsMode | undefined {
+  switch (value) {
+    case "default":
+    case "autoReview":
+    case "fullAccess":
+    case "custom":
+      return value;
+    default:
+      return undefined;
+  }
+}
+
+function normalizeCodexSandboxMode(
+  value?: string,
+): "danger-full-access" | "workspace-write" | "read-only" | undefined {
+  switch (value) {
+    case "danger-full-access":
+    case "off":
+      return "danger-full-access";
+    case "workspace-write":
+    case "on":
+      return "workspace-write";
+    case "read-only":
+      return "read-only";
+    default:
+      return undefined;
+  }
+}
+
+function isCodexAutoReviewApprovalsReviewer(value?: string): boolean {
+  return value === "auto_review" || value === "guardian_subagent";
+}
+
+function deriveCodexPermissionsMode(
+  settings: SessionInfo["codexSettings"],
+): CodexPermissionsMode | undefined {
+  if (!settings) return undefined;
+  const explicit = normalizeCodexPermissionsMode(settings.codexPermissionsMode);
+  if (explicit) return explicit;
+
+  const hasPermissionSettings =
+    settings.approvalPolicy !== undefined ||
+    settings.approvalsReviewer !== undefined ||
+    settings.sandboxMode !== undefined;
+  if (!hasPermissionSettings) return undefined;
+
+  const sandboxMode = normalizeCodexSandboxMode(settings.sandboxMode);
+  if (
+    settings.approvalPolicy === "never" &&
+    (sandboxMode === undefined || sandboxMode === "danger-full-access")
+  ) {
+    return "fullAccess";
+  }
+
+  if (
+    settings.approvalPolicy === "on-request" &&
+    (sandboxMode === undefined || sandboxMode === "workspace-write")
+  ) {
+    return isCodexAutoReviewApprovalsReviewer(settings.approvalsReviewer)
+      ? "autoReview"
+      : "default";
+  }
+
+  return "custom";
+}
+
+function codexSettingsWithDerivedPermissionsMode(
+  settings: SessionInfo["codexSettings"],
+): SessionInfo["codexSettings"] {
+  const mode = deriveCodexPermissionsMode(settings);
+  return mode && settings
+    ? { ...settings, codexPermissionsMode: mode }
+    : settings;
+}
+
 function mergeCodexSettings(
   current: SessionInfo["codexSettings"],
   msg: Extract<ServerMessage, { type: "system" }>,
@@ -201,7 +279,7 @@ function mergeCodexSettings(
   };
 
   return Object.values(next).some((value) => value !== undefined)
-    ? next
+    ? codexSettingsWithDerivedPermissionsMode(next)
     : current;
 }
 
@@ -627,7 +705,7 @@ export class SessionManager {
     }
 
     if (effectiveProvider === "codex" && codexOptions) {
-      session.codexSettings = {
+      session.codexSettings = codexSettingsWithDerivedPermissionsMode({
         profile: codexOptions.profile,
         approvalPolicy: codexOptions.approvalPolicy,
         approvalsReviewer: codexOptions.approvalsReviewer,
@@ -638,7 +716,7 @@ export class SessionManager {
         networkAccessEnabled: codexOptions.networkAccessEnabled,
         webSearchMode: codexOptions.webSearchMode,
         additionalWritableRoots: codexOptions.additionalWritableRoots,
-      };
+      });
       // Resume starts know the thread id up front.
       if (codexOptions.threadId) {
         session.claudeSessionId = codexOptions.threadId;
@@ -723,6 +801,17 @@ export class SessionManager {
 
   list(): SessionSummary[] {
     return Array.from(this.sessions.values()).map((s) => {
+      const rawCodexSettings =
+        s.process instanceof CodexProcess
+          ? s.codexSettings ??
+            (s.process.codexPermissionsMode
+              ? { codexPermissionsMode: s.process.codexPermissionsMode }
+              : undefined)
+          : s.codexSettings;
+      const codexSettings =
+        s.process instanceof CodexProcess
+          ? codexSettingsWithDerivedPermissionsMode(rawCodexSettings)
+          : s.codexSettings;
       const processWithPending = s.process as {
         getPendingPermission?: () =>
           | {
@@ -744,8 +833,7 @@ export class SessionManager {
               ? "acceptEdits"
               : "default"
           : s.process instanceof CodexProcess
-            ? (s.codexSettings?.approvalPolicy ?? s.process.approvalPolicy) ===
-              "never"
+            ? codexSettings?.approvalPolicy === "never"
               ? "fullAccess"
               : "default"
             : undefined;
@@ -774,15 +862,14 @@ export class SessionManager {
             : s.process instanceof CodexProcess
               ? s.process.collaborationMode === "plan"
                 ? "plan"
-                : (s.codexSettings?.approvalPolicy ??
-                    s.process.approvalPolicy) === "never"
+                : codexSettings?.approvalPolicy === "never"
                   ? "bypassPermissions"
                   : "acceptEdits"
               : undefined,
         executionMode,
         planMode,
         model: s.process instanceof SdkProcess ? s.process.model : undefined,
-        codexSettings: s.codexSettings,
+        codexSettings,
         agentNickname:
           s.process instanceof CodexProcess
             ? (s.process.agentNickname ?? undefined)


### PR DESCRIPTION
## Summary
- derive `codexSettings.codexPermissionsMode` from concrete Codex runtime settings when the bridge has approval/sandbox metadata
- classify `read-only` sandbox and mismatched approval/sandbox combinations as `custom` instead of showing default/full-access presets
- let mobile session/recent-session parsing infer a missing Codex permissions mode from `codexSettings` without inventing one for metadata-only settings

## Tests
- `npm run test --workspace=@ccpocket/bridge -- src/session.test.ts`
- `npm run build --workspace=@ccpocket/bridge`
- `flutter test test/messages_test.dart`
- `flutter analyze lib/models/messages.dart test/messages_test.dart`
