### PR TITLE
fix(bridge): preserve input during Claude resume

### DIFF
--- a/packages/bridge/src/websocket.test.ts
+++ b/packages/bridge/src/websocket.test.ts
@@ -977,6 +977,240 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     bridge.close();
   });
 
+  it("queues input addressed to a Claude session while resume history loads", async () => {
+    let resolveHistory!: (messages: unknown[]) => void;
+    getSessionHistoryMock.mockReturnValue(
+      new Promise<unknown[]>((resolve) => {
+        resolveHistory = resolve;
+      }),
+    );
+    const bridge = new BridgeWebSocketServer({ server: httpServer });
+    const ws = {
+      readyState: OPEN_STATE,
+      send: vi.fn(),
+    } as any;
+
+    void (bridge as any).handleClientMessage(
+      {
+        type: "resume_session",
+        sessionId: "claude-session-pending",
+        projectPath: "/tmp/project-a",
+        provider: "claude",
+      },
+      ws,
+    );
+    await (bridge as any).handleClientMessage(
+      {
+        type: "input",
+        sessionId: "claude-session-pending",
+        text: "hello while resuming",
+        clientMessageId: "cm-pending",
+      },
+      ws,
+    );
+    await (bridge as any).handleClientMessage(
+      {
+        type: "input",
+        sessionId: "claude-session-pending",
+        text: "second queued input",
+        clientMessageId: "cm-pending-2",
+      },
+      ws,
+    );
+
+    expect((bridge as any).sessionManager.get("s-1")).toBeUndefined();
+    expect(ws.send).not.toHaveBeenCalledWith(
+      expect.stringContaining("No active session"),
+    );
+
+    resolveHistory([]);
+    await vi.waitFor(() => {
+      const session = (bridge as any).sessionManager.get("s-1");
+      expect(session.process.sendInput).toHaveBeenCalledWith(
+        "hello while resuming",
+      );
+    });
+    expect(
+      (bridge as any).sessionManager.get("s-1").process.sendInput.mock.calls,
+    ).toEqual([
+      ["hello while resuming"],
+      ["second queued input"],
+    ]);
+
+    const sends = ws.send.mock.calls.map((call: unknown[]) =>
+      JSON.parse(call[0] as string),
+    );
+    const createdIndex = sends.findIndex(
+      (message: any) =>
+        message.type === "system" && message.subtype === "session_created",
+    );
+    const ackIndex = sends.findIndex(
+      (message: any) =>
+        message.type === "input_ack" &&
+        message.clientMessageId === "cm-pending",
+    );
+    expect(createdIndex).toBeGreaterThanOrEqual(0);
+    expect(ackIndex).toBeGreaterThan(createdIndex);
+    expect(sends[ackIndex]).toMatchObject({
+      sessionId: "s-1",
+      clientMessageId: "cm-pending",
+    });
+    expect(
+      sends.findIndex(
+        (message: any) =>
+          message.type === "input_ack" &&
+          message.clientMessageId === "cm-pending-2",
+      ),
+    ).toBeGreaterThan(ackIndex);
+
+    bridge.close();
+  });
+
+  it("prefers an existing bridge session id over a pending resume alias", async () => {
+    let resolveHistory!: (messages: unknown[]) => void;
+    getSessionHistoryMock.mockReturnValue(
+      new Promise<unknown[]>((resolve) => {
+        resolveHistory = resolve;
+      }),
+    );
+    const bridge = new BridgeWebSocketServer({ server: httpServer });
+    const ws = {
+      readyState: OPEN_STATE,
+      send: vi.fn(),
+    } as any;
+
+    await (bridge as any).handleClientMessage(
+      { type: "start", projectPath: "/tmp/existing", provider: "claude" },
+      ws,
+    );
+    void (bridge as any).handleClientMessage(
+      {
+        type: "resume_session",
+        sessionId: "s-1",
+        projectPath: "/tmp/resumed",
+        provider: "claude",
+      },
+      ws,
+    );
+    await (bridge as any).handleClientMessage(
+      { type: "input", sessionId: "s-1", text: "existing session input" },
+      ws,
+    );
+
+    const existing = (bridge as any).sessionManager.get("s-1");
+    expect(existing.process.sendInput).toHaveBeenCalledWith(
+      "existing session input",
+    );
+
+    resolveHistory([]);
+    await vi.waitFor(() => {
+      expect((bridge as any).sessionManager.get("s-2")).toBeDefined();
+    });
+    const resumed = (bridge as any).sessionManager.get("s-2");
+    expect(resumed.process.sendInput).not.toHaveBeenCalled();
+
+    bridge.close();
+  });
+
+  it("does not deliver queued resume input after the client disconnects", async () => {
+    let resolveHistory!: (messages: unknown[]) => void;
+    getSessionHistoryMock.mockReturnValue(
+      new Promise<unknown[]>((resolve) => {
+        resolveHistory = resolve;
+      }),
+    );
+    const bridge = new BridgeWebSocketServer({ server: httpServer });
+    const ws = {
+      readyState: OPEN_STATE,
+      send: vi.fn(),
+    } as any;
+
+    void (bridge as any).handleClientMessage(
+      {
+        type: "resume_session",
+        sessionId: "claude-session-disconnected",
+        projectPath: "/tmp/project-a",
+        provider: "claude",
+      },
+      ws,
+    );
+    await (bridge as any).handleClientMessage(
+      {
+        type: "input",
+        sessionId: "claude-session-disconnected",
+        text: "must not run after disconnect",
+        clientMessageId: "cm-disconnected",
+      },
+      ws,
+    );
+
+    (bridge as any).clearPendingClaudeResumeInputs(ws);
+    resolveHistory([]);
+    await vi.waitFor(() => {
+      expect((bridge as any).sessionManager.get("s-1")).toBeDefined();
+    });
+    expect(
+      (bridge as any).sessionManager.get("s-1").process.sendInput,
+    ).not.toHaveBeenCalled();
+
+    bridge.close();
+  });
+
+  it("rejects queued input and clears it when Claude resume fails", async () => {
+    let rejectHistory!: (error: Error) => void;
+    getSessionHistoryMock.mockReturnValue(
+      new Promise<unknown[]>((_, reject) => {
+        rejectHistory = reject;
+      }),
+    );
+    const bridge = new BridgeWebSocketServer({ server: httpServer });
+    const ws = {
+      readyState: OPEN_STATE,
+      send: vi.fn(),
+    } as any;
+
+    void (bridge as any).handleClientMessage(
+      {
+        type: "resume_session",
+        sessionId: "claude-session-failed",
+        projectPath: "/tmp/project-a",
+        provider: "claude",
+      },
+      ws,
+    );
+    await (bridge as any).handleClientMessage(
+      {
+        type: "input",
+        sessionId: "claude-session-failed",
+        text: "input that cannot be delivered",
+        clientMessageId: "cm-failed",
+      },
+      ws,
+    );
+
+    rejectHistory(new Error("history unavailable"));
+    await vi.waitFor(() => {
+      const sends = ws.send.mock.calls.map((call: unknown[]) =>
+        JSON.parse(call[0] as string),
+      );
+      expect(sends).toContainEqual(
+        expect.objectContaining({
+          type: "input_rejected",
+          sessionId: "claude-session-failed",
+          clientMessageId: "cm-failed",
+          reason: "Session resume failed",
+        }),
+      );
+    });
+    expect(
+      (bridge as any).pendingClaudeResumeInputs
+        .get(ws)
+        ?.has("claude-session-failed"),
+    ).toBe(false);
+
+    bridge.close();
+  });
+
   it("serves get_history_delta with sequenced messages", async () => {
     const bridge = new BridgeWebSocketServer({ server: httpServer });
     const ws = {

--- a/packages/bridge/src/websocket.ts
+++ b/packages/bridge/src/websocket.ts
@@ -101,6 +101,7 @@ import {
 } from "./path-utils.js";
 
 type SystemServerMessage = Extract<ServerMessage, { type: "system" }>;
+type InputClientMessage = Extract<ClientMessage, { type: "input" }>;
 type ClaudePermissionMode =
   | "default"
   | "auto"
@@ -627,6 +628,10 @@ export class BridgeWebSocketServer {
   private failSetSandboxMode = envFlagEnabled("BRIDGE_FAIL_SET_SANDBOX_MODE");
   private platform: NodeJS.Platform;
   private clientSupportedServerMessages = new WeakMap<WebSocket, Set<string>>();
+  private pendingClaudeResumeInputs = new WeakMap<
+    WebSocket,
+    Map<string, InputClientMessage[]>
+  >();
 
   constructor(options: BridgeServerOptions) {
     const {
@@ -1903,6 +1908,7 @@ export class BridgeWebSocketServer {
 
     ws.on("close", () => {
       console.log("[ws] Client disconnected");
+      this.clearPendingClaudeResumeInputs(ws);
     });
 
     ws.on("error", (err) => {
@@ -2205,6 +2211,13 @@ export class BridgeWebSocketServer {
       case "input": {
         const session = this.resolveSession(msg.sessionId);
         if (!session) {
+          const pendingInputs = msg.sessionId
+            ? this.pendingClaudeResumeInputs.get(ws)?.get(msg.sessionId)
+            : undefined;
+          if (pendingInputs) {
+            pendingInputs.push(msg);
+            return;
+          }
           this.send(ws, {
             type: "error",
             message: "No active session. Send 'start' first.",
@@ -4090,6 +4103,19 @@ export class BridgeWebSocketServer {
 
         const claudeSessionId = sessionRefId;
         const cached = this.sessionManager.getCachedCommands(resumeProjectPath);
+        let pendingResumes = this.pendingClaudeResumeInputs.get(ws);
+        if (!pendingResumes) {
+          pendingResumes = new Map();
+          this.pendingClaudeResumeInputs.set(ws, pendingResumes);
+        }
+        if (pendingResumes.has(claudeSessionId)) {
+          this.send(ws, {
+            type: "error",
+            message: `Session resume already in progress: ${claudeSessionId}`,
+          });
+          break;
+        }
+        pendingResumes.set(claudeSessionId, []);
 
         // Look up worktree mapping for this Claude session
         const wtMapping = this.worktreeStore.get(claudeSessionId);
@@ -4144,12 +4170,7 @@ export class BridgeWebSocketServer {
               worktreeOptions: worktreeOpts,
             });
             const createdSession = this.sessionManager.get(sessionId);
-            void this.loadAndSetSessionName(
-              createdSession,
-              "claude",
-              resumeProjectPath,
-              claudeSessionId,
-            ).then(() => {
+            const finishResume = () => {
               this.send(ws, {
                 ...this.buildSessionCreatedMessage({
                   sessionId,
@@ -4180,6 +4201,11 @@ export class BridgeWebSocketServer {
                 }),
                 claudeSessionId,
               });
+              const queuedInputs = pendingResumes.get(claudeSessionId) ?? [];
+              pendingResumes.delete(claudeSessionId);
+              for (const input of queuedInputs) {
+                void this.handleClientMessage({ ...input, sessionId }, ws);
+              }
               this.broadcastSessionList();
               if (autoFallbackUsed) {
                 this.sendTip(
@@ -4189,6 +4215,15 @@ export class BridgeWebSocketServer {
                   createdSession,
                 );
               }
+            };
+            void this.loadAndSetSessionName(
+              createdSession,
+              "claude",
+              resumeProjectPath,
+              claudeSessionId,
+            ).then(finishResume, (err) => {
+              console.error("[ws] Failed to load resumed session name:", err);
+              finishResume();
             });
             this.debugEvents.set(sessionId, []);
             this.recordDebugEvent(sessionId, {
@@ -4200,6 +4235,18 @@ export class BridgeWebSocketServer {
             this.projectHistory?.addProject(resumeProjectPath);
           })
           .catch((err) => {
+            const queuedInputs = pendingResumes.get(claudeSessionId) ?? [];
+            pendingResumes.delete(claudeSessionId);
+            for (const input of queuedInputs) {
+              if (input.clientMessageId) {
+                this.send(ws, {
+                  type: "input_rejected",
+                  sessionId: claudeSessionId,
+                  clientMessageId: input.clientMessageId,
+                  reason: "Session resume failed",
+                });
+              }
+            }
             this.send(ws, {
               type: "error",
               message: `Failed to load session history: ${err}`,
@@ -5573,6 +5620,11 @@ export class BridgeWebSocketServer {
         break;
       }
     }
+  }
+
+  private clearPendingClaudeResumeInputs(ws: WebSocket): void {
+    this.pendingClaudeResumeInputs.get(ws)?.clear();
+    this.pendingClaudeResumeInputs.delete(ws);
   }
 
   /**


### PR DESCRIPTION
## Summary

- Queue Claude input addressed to the provider session ID while resume history is loading.
- Replay queued input through the normal Bridge session path after `session_created`.
- Reject and clear queued input when resume fails, and discard it on disconnect.
- Keep the fallback scoped to input and the originating WebSocket to avoid cross-session permission or interrupt routing.

## Validation

- `npm run test:bridge` (677 tests)
- `npx vitest run src/websocket.test.ts` (93 tests)
- `npx tsc --noEmit -p packages/bridge/tsconfig.json`
- Independent self-review: LGTM

Reimplements #135 with narrower routing and additional race coverage.
