### PR TITLE
fix(app): prevent answered approvals from replaying

### DIFF
--- a/apps/mobile/lib/features/chat_session/state/chat_session_cubit.dart
+++ b/apps/mobile/lib/features/chat_session/state/chat_session_cubit.dart
@@ -40,10 +40,17 @@ class ChatSessionCubit extends Cubit<ChatSessionState> {
   /// can preserve them while replacing in-memory history entries.
   int _pastEntryCount = 0;
 
-  /// Tool use IDs that have been approved or rejected locally.
-  /// Cleared when corresponding [ToolResultMessage] arrives or session
-  /// completes ([ResultMessage]).
+  /// Tool use IDs that have already been answered locally.
+  static const _maxRespondedToolUseIds = 512;
   final _respondedToolUseIds = <String>{};
+
+  void _markToolUseResponded(String toolUseId) {
+    _bridge.markToolUseResponded(sessionId, toolUseId);
+    _respondedToolUseIds.add(toolUseId);
+    if (_respondedToolUseIds.length > _maxRespondedToolUseIds) {
+      _respondedToolUseIds.remove(_respondedToolUseIds.first);
+    }
+  }
 
   PermissionMode? _pendingPermissionRollback;
   ExecutionMode? _pendingExecutionRollback;
@@ -148,6 +155,7 @@ class ChatSessionCubit extends Cubit<ChatSessionState> {
            projectPath: initialProjectPath,
          ),
        ) {
+    _respondedToolUseIds.addAll(_bridge.respondedToolUseIds(sessionId));
     // Subscribe to messages for this session
     _subscription = _bridge.messagesForSession(sessionId).listen(_onMessage);
 
@@ -185,6 +193,7 @@ class ChatSessionCubit extends Cubit<ChatSessionState> {
         history,
         isBackground: true,
         isCodex: isCodex,
+        ignoredToolUseIds: _respondedToolUseIds,
       );
       _applyUpdate(update, history);
     } catch (e, st) {
@@ -231,7 +240,12 @@ class ChatSessionCubit extends Cubit<ChatSessionState> {
     }
 
     try {
-      final update = _handler.handle(msg, isBackground: true, isCodex: isCodex);
+      final update = _handler.handle(
+        msg,
+        isBackground: true,
+        isCodex: isCodex,
+        ignoredToolUseIds: _respondedToolUseIds,
+      );
       _applyUpdate(update, msg);
     } catch (e, st) {
       logger.error(
@@ -475,14 +489,6 @@ class ChatSessionCubit extends Cubit<ChatSessionState> {
       didModifyEntries = result.didChange;
     }
 
-    // --- Cleanup responded tool use IDs ---
-    if (originalMsg is ToolResultMessage) {
-      _respondedToolUseIds.remove(originalMsg.toolUseId);
-    }
-    if (originalMsg is ResultMessage) {
-      _respondedToolUseIds.clear();
-    }
-
     // --- Build new approval state ---
     ApprovalState approval = current.approval;
     if (update.resetPending && update.resetAsk) {
@@ -498,16 +504,22 @@ class ChatSessionCubit extends Cubit<ChatSessionState> {
     }
 
     if (update.pendingPermission != null) {
-      approval = ApprovalState.permission(
-        toolUseId: update.pendingToolUseId!,
-        request: update.pendingPermission!,
-      );
+      final toolUseId = update.pendingToolUseId;
+      if (toolUseId != null && !_respondedToolUseIds.contains(toolUseId)) {
+        approval = ApprovalState.permission(
+          toolUseId: toolUseId,
+          request: update.pendingPermission!,
+        );
+      }
     }
     if (update.askToolUseId != null) {
-      approval = ApprovalState.askUser(
-        toolUseId: update.askToolUseId!,
-        input: update.askInput ?? {},
-      );
+      final toolUseId = update.askToolUseId!;
+      if (!_respondedToolUseIds.contains(toolUseId)) {
+        approval = ApprovalState.askUser(
+          toolUseId: toolUseId,
+          input: update.askInput ?? {},
+        );
+      }
     }
 
     // Stop status refresh timer when status changes from starting
@@ -1255,7 +1267,7 @@ class ChatSessionCubit extends Cubit<ChatSessionState> {
       '[session:$sessionId] approve toolUseId=$toolUseId'
       '${clearContext ? ' clearContext' : ''}',
     );
-    _respondedToolUseIds.add(toolUseId);
+    _markToolUseResponded(toolUseId);
     _bridge.send(
       ClientMessage.approve(
         toolUseId,
@@ -1272,7 +1284,7 @@ class ChatSessionCubit extends Cubit<ChatSessionState> {
   /// Approve a tool and always allow it in the future.
   void approveAlways(String toolUseId) {
     final isExitPlanApproval = _isExitPlanApproval(toolUseId);
-    _respondedToolUseIds.add(toolUseId);
+    _markToolUseResponded(toolUseId);
     _bridge.send(ClientMessage.approveAlways(toolUseId, sessionId: sessionId));
     _emitNextApprovalOrNone(
       toolUseId,
@@ -1370,7 +1382,7 @@ class ChatSessionCubit extends Cubit<ChatSessionState> {
       '[session:$sessionId] reject toolUseId=$toolUseId'
       '${message != null ? ' msg=$message' : ''}',
     );
-    _respondedToolUseIds.add(toolUseId);
+    _markToolUseResponded(toolUseId);
     _bridge.send(
       ClientMessage.reject(toolUseId, message: message, sessionId: sessionId),
     );
@@ -1381,6 +1393,7 @@ class ChatSessionCubit extends Cubit<ChatSessionState> {
 
   /// Answer an AskUserQuestion.
   void answer(String toolUseId, String result) {
+    _markToolUseResponded(toolUseId);
     _bridge.send(ClientMessage.answer(toolUseId, result, sessionId: sessionId));
     emit(state.copyWith(approval: const ApprovalState.none()));
   }

--- a/apps/mobile/lib/features/session_list/session_list_screen.dart
+++ b/apps/mobile/lib/features/session_list/session_list_screen.dart
@@ -2022,6 +2022,7 @@ class _SessionListScreenState extends State<SessionListScreen>
               onApprovePermission:
                   (sessionId, toolUseId, {bool clearContext = false}) {
                     final bridge = context.read<BridgeService>();
+                    bridge.markToolUseResponded(sessionId, toolUseId);
                     bridge.send(
                       ClientMessage.approve(
                         toolUseId,
@@ -2033,6 +2034,7 @@ class _SessionListScreenState extends State<SessionListScreen>
                   },
               onApproveAlways: (sessionId, toolUseId) {
                 final bridge = context.read<BridgeService>();
+                bridge.markToolUseResponded(sessionId, toolUseId);
                 bridge.send(
                   ClientMessage.approveAlways(toolUseId, sessionId: sessionId),
                 );
@@ -2040,6 +2042,7 @@ class _SessionListScreenState extends State<SessionListScreen>
               },
               onRejectPermission: (sessionId, toolUseId, {message}) {
                 final bridge = context.read<BridgeService>();
+                bridge.markToolUseResponded(sessionId, toolUseId);
                 bridge.send(
                   ClientMessage.reject(
                     toolUseId,
@@ -2051,6 +2054,7 @@ class _SessionListScreenState extends State<SessionListScreen>
               },
               onAnswerQuestion: (sessionId, toolUseId, result) {
                 final bridge = context.read<BridgeService>();
+                bridge.markToolUseResponded(sessionId, toolUseId);
                 bridge.send(
                   ClientMessage.answer(toolUseId, result, sessionId: sessionId),
                 );

--- a/apps/mobile/lib/services/bridge_service.dart
+++ b/apps/mobile/lib/services/bridge_service.dart
@@ -118,6 +118,7 @@ class BridgeService implements BridgeServiceBase {
   final Set<String> _visibleInFlightPendingKeys = {};
   final Map<String, _DeliveryPendingInputState> _deliveryPendingInputs = {};
   final Map<String, Timer> _deliveryPendingVisibilityTimers = {};
+  final Map<String, Set<String>> _respondedToolUseIds = {};
   List<OfflinePendingAction> _offlinePendingActions = const [];
 
   // Diff image cache: survives screen navigation, cleared on session stop.
@@ -668,6 +669,7 @@ class BridgeService implements BridgeServiceBase {
     _promptHistoryBridgeId = null;
     _lastUsageResult = null;
     _pendingHistoryDeltaSinceSeq.clear();
+    _respondedToolUseIds.clear();
     _deliveryPendingInputs.clear();
     for (final timer in _deliveryPendingVisibilityTimers.values) {
       timer.cancel();
@@ -1616,6 +1618,15 @@ class BridgeService implements BridgeServiceBase {
     return _runtimeStore.messages(sessionId);
   }
 
+  Set<String> respondedToolUseIds(String sessionId) =>
+      Set.unmodifiable(_respondedToolUseIds[sessionId] ?? const {});
+
+  void markToolUseResponded(String sessionId, String toolUseId) {
+    final ids = _respondedToolUseIds.putIfAbsent(sessionId, () => <String>{});
+    ids.add(toolUseId);
+    if (ids.length > 512) ids.remove(ids.first);
+  }
+
   @override
   int cachedSessionHistorySeq(String sessionId) {
     return _runtimeStore.cachedHistorySeq(sessionId);
@@ -1653,6 +1664,7 @@ class BridgeService implements BridgeServiceBase {
 
   void clearExplorerHistory(String sessionId) {
     _runtimeStore.clearSession(sessionId);
+    _respondedToolUseIds.remove(sessionId);
   }
 
   /// Rename a session. For running sessions, [sessionId] is the bridge id.

--- a/apps/mobile/lib/services/chat_message_handler.dart
+++ b/apps/mobile/lib/services/chat_message_handler.dart
@@ -173,6 +173,7 @@ class ChatMessageHandler {
     ServerMessage msg, {
     required bool isBackground,
     bool isCodex = false,
+    Set<String> ignoredToolUseIds = const {},
   }) {
     switch (msg) {
       case StatusMessage(:final status):
@@ -192,7 +193,7 @@ class ChatMessageHandler {
       case PastHistoryMessage(:final claudeSessionId, :final messages):
         return _handlePastHistory(messages, claudeSessionId: claudeSessionId);
       case HistoryMessage(:final messages):
-        return _handleHistory(messages);
+        return _handleHistory(messages, ignoredToolUseIds: ignoredToolUseIds);
       case ConversationQueueMessage(:final items):
         return ChatStateUpdate(
           queuedInput: items.isNotEmpty ? items.first : null,
@@ -540,7 +541,10 @@ class ChatMessageHandler {
     );
   }
 
-  ChatStateUpdate _handleHistory(List<ServerMessage> messages) {
+  ChatStateUpdate _handleHistory(
+    List<ServerMessage> messages, {
+    Set<String> ignoredToolUseIds = const {},
+  }) {
     final entries = <ChatEntry>[];
     ProcessStatus? lastStatus;
     List<SlashCommand>? commands;
@@ -640,6 +644,7 @@ class ChatMessageHandler {
         }
         // Track pending permission request
         if (m is PermissionRequestMessage) {
+          if (ignoredToolUseIds.contains(m.toolUseId)) continue;
           if (m.usesAskUserUi) {
             // Codex may send question-based prompts directly as permission_request.
             lastAskToolUseId = m.toolUseId;
@@ -652,7 +657,8 @@ class ChatMessageHandler {
         if (m is AssistantServerMessage) {
           for (final content in m.message.content) {
             if (content is ToolUseContent &&
-                content.name == 'AskUserQuestion') {
+                content.name == 'AskUserQuestion' &&
+                !ignoredToolUseIds.contains(content.id)) {
               lastAskToolUseId = content.id;
               lastAskInput = content.input;
             }

--- a/apps/mobile/test/chat_session_cubit_test.dart
+++ b/apps/mobile/test/chat_session_cubit_test.dart
@@ -992,6 +992,180 @@ void main() {
       expect(mockBridge.sentMessages, hasLength(1));
     });
 
+    test('approved permission is not restored by stale history', () async {
+      final cubit = createCubit('s1');
+      addTearDown(cubit.close);
+      await Future.microtask(() {});
+      const permission = PermissionRequestMessage(
+        toolUseId: 'tool-1',
+        toolName: 'bash',
+        input: {'command': 'ls'},
+      );
+
+      mockBridge.emitMessage(permission, sessionId: 's1');
+      await Future.microtask(() {});
+      cubit.approve('tool-1');
+      mockBridge.emitMessage(
+        const HistoryMessage(
+          messages: [
+            permission,
+            StatusMessage(status: ProcessStatus.waitingApproval),
+          ],
+        ),
+        sessionId: 's1',
+      );
+      await Future.microtask(() {});
+
+      expect(cubit.state.approval, isA<ApprovalNone>());
+    });
+
+    test(
+      'tool result does not allow stale approval history to replay',
+      () async {
+        final cubit = createCubit('s1');
+        addTearDown(cubit.close);
+        await Future.microtask(() {});
+        const permission = PermissionRequestMessage(
+          toolUseId: 'tool-1',
+          toolName: 'bash',
+          input: {'command': 'ls'},
+        );
+
+        mockBridge.emitMessage(permission, sessionId: 's1');
+        await Future.microtask(() {});
+        cubit.reject('tool-1');
+        mockBridge.emitMessage(
+          const ToolResultMessage(toolUseId: 'tool-1', content: 'rejected'),
+          sessionId: 's1',
+        );
+        mockBridge.emitMessage(
+          const HistoryMessage(
+            messages: [
+              permission,
+              StatusMessage(status: ProcessStatus.waitingApproval),
+            ],
+          ),
+          sessionId: 's1',
+        );
+        await Future.microtask(() {});
+
+        expect(cubit.state.approval, isA<ApprovalNone>());
+      },
+    );
+
+    test('answered question is not restored by stale history', () async {
+      final cubit = createCubit('s1');
+      addTearDown(cubit.close);
+      await Future.microtask(() {});
+      final ask = AssistantServerMessage(
+        message: AssistantMessage(
+          id: 'ask-message',
+          role: 'assistant',
+          content: [
+            const ToolUseContent(
+              id: 'ask-1',
+              name: 'AskUserQuestion',
+              input: {
+                'questions': [
+                  {'question': 'Which option?'},
+                ],
+              },
+            ),
+          ],
+          model: 'claude',
+        ),
+      );
+
+      mockBridge.emitMessage(ask, sessionId: 's1');
+      await Future.microtask(() {});
+      cubit.answer('ask-1', 'A');
+      mockBridge.emitMessage(
+        HistoryMessage(
+          messages: [
+            ask,
+            const StatusMessage(status: ProcessStatus.waitingApproval),
+          ],
+        ),
+        sessionId: 's1',
+      );
+      await Future.microtask(() {});
+
+      expect(cubit.state.approval, isA<ApprovalNone>());
+    });
+
+    test(
+      'stale answered permission does not hide a later pending one',
+      () async {
+        final cubit = createCubit('s1');
+        addTearDown(cubit.close);
+        await Future.microtask(() {});
+        const answered = PermissionRequestMessage(
+          toolUseId: 'tool-answered',
+          toolName: 'bash',
+          input: {'command': 'first'},
+        );
+        const pending = PermissionRequestMessage(
+          toolUseId: 'tool-pending',
+          toolName: 'bash',
+          input: {'command': 'second'},
+        );
+
+        mockBridge.emitMessage(answered, sessionId: 's1');
+        await Future.microtask(() {});
+        cubit.approve('tool-answered');
+        mockBridge.emitMessage(
+          const HistoryMessage(
+            messages: [
+              answered,
+              pending,
+              StatusMessage(status: ProcessStatus.waitingApproval),
+            ],
+          ),
+          sessionId: 's1',
+        );
+        await Future.microtask(() {});
+
+        expect(cubit.state.approval, isA<ApprovalPermission>());
+        expect(
+          (cubit.state.approval as ApprovalPermission).toolUseId,
+          'tool-pending',
+        );
+      },
+    );
+
+    test(
+      'answered permission remains suppressed after cubit recreation',
+      () async {
+        final firstCubit = createCubit('s1');
+        await Future.microtask(() {});
+        const permission = PermissionRequestMessage(
+          toolUseId: 'tool-answered',
+          toolName: 'bash',
+          input: {'command': 'ls'},
+        );
+        mockBridge.emitMessage(permission, sessionId: 's1');
+        await Future.microtask(() {});
+        firstCubit.approve('tool-answered');
+        await firstCubit.close();
+
+        final recreatedCubit = createCubit('s1');
+        addTearDown(recreatedCubit.close);
+        await Future.microtask(() {});
+        mockBridge.emitMessage(
+          const HistoryMessage(
+            messages: [
+              permission,
+              StatusMessage(status: ProcessStatus.waitingApproval),
+            ],
+          ),
+          sessionId: 's1',
+        );
+        await Future.microtask(() {});
+
+        expect(recreatedCubit.state.approval, isA<ApprovalNone>());
+      },
+    );
+
     test('approving ExitPlanMode also clears plan mode state', () async {
       final cubit = createCubit('s1', provider: Provider.codex);
       addTearDown(cubit.close);
@@ -1127,10 +1301,7 @@ void main() {
       final cubit = createCubit('s1', provider: Provider.claude);
       addTearDown(cubit.close);
 
-      cubit.setCodexModel(
-        'gpt-5.4-mini',
-        reasoningEffort: ReasoningEffort.low,
-      );
+      cubit.setCodexModel('gpt-5.4-mini', reasoningEffort: ReasoningEffort.low);
 
       expect(cubit.state.codexModel, isNull);
       expect(cubit.state.codexModelReasoningEffort, isNull);


### PR DESCRIPTION
## Summary

- Prevent stale cached/history messages from restoring approvals or questions already answered locally.
- Keep answered IDs at Bridge session scope so navigation and Cubit recreation do not lose the guard.
- Skip answered history entries while still selecting later unanswered approvals.
- Cover Chat and Session List approval, reject, always-allow, and answer paths.
- Bound remembered IDs and clear them on Bridge switch or session cleanup.

## Validation

- Focused ChatSessionCubit/handler/home tests: 188 passed
- Full `flutter test`: passed
- `dart analyze apps/mobile`: no new warning/error; existing 35 info diagnostics and local analyzer-plugin setup warning remain
- iOS Simulator + Marionette: Approval Flow reject and AskUserQuestion rendering verified
- Independent self-review: LGTM

Reimplements #140 with stale-history and navigation race coverage.
