### PR TITLE
fix(bridge): queue input before interrupting Claude

### DIFF
--- a/packages/bridge/src/sdk-process.test.ts
+++ b/packages/bridge/src/sdk-process.test.ts
@@ -739,3 +739,67 @@ describe("SdkProcess.approveAlways", () => {
     expect(proc.permissionMode).toBe("acceptEdits");
   });
 });
+
+describe("SdkProcess input dispatch", () => {
+  it("queues and requests interrupt while a turn is running", () => {
+    const proc = new SdkProcess();
+    const resolve = vi.fn();
+    const internal = proc as any;
+    internal._status = "running";
+    internal.userMessageResolve = resolve;
+
+    expect(proc.dispatchInput("follow up")).toEqual({
+      queued: true,
+      shouldInterrupt: true,
+    });
+    expect(resolve).not.toHaveBeenCalled();
+    expect(proc.hasInputQueue).toBe(true);
+  });
+
+  it("queues without interrupting while approval is pending", () => {
+    const proc = new SdkProcess();
+    const resolve = vi.fn();
+    const internal = proc as any;
+    internal._status = "waiting_approval";
+    internal.userMessageResolve = resolve;
+
+    expect(proc.dispatchInput("after approval")).toEqual({
+      queued: true,
+      shouldInterrupt: false,
+    });
+    expect(resolve).not.toHaveBeenCalled();
+  });
+
+  it.each(["starting", "idle"])(
+    "delivers directly through the ready resolver while %s",
+    (status) => {
+      const proc = new SdkProcess();
+      const resolve = vi.fn();
+      const internal = proc as any;
+      internal._status = status;
+      internal.userMessageResolve = resolve;
+
+      expect(proc.dispatchInput("first input")).toEqual({
+        queued: false,
+        shouldInterrupt: false,
+      });
+      expect(resolve).toHaveBeenCalledTimes(1);
+      expect(proc.hasInputQueue).toBe(false);
+    },
+  );
+
+  it("applies the running policy to image input", () => {
+    const proc = new SdkProcess();
+    const resolve = vi.fn();
+    const internal = proc as any;
+    internal._status = "running";
+    internal.userMessageResolve = resolve;
+
+    expect(
+      proc.dispatchInputWithImages("inspect", [
+        { base64: "aW1hZ2U=", mimeType: "image/png" },
+      ]),
+    ).toEqual({ queued: true, shouldInterrupt: true });
+    expect(resolve).not.toHaveBeenCalled();
+  });
+});

--- a/packages/bridge/src/sdk-process.ts
+++ b/packages/bridge/src/sdk-process.ts
@@ -724,14 +724,17 @@ export class SdkProcess extends EventEmitter<SdkProcessEvents> {
     return this.pendingInputQueue.length > 0;
   }
 
-  sendInput(text: string): boolean {
-    if (!this.userMessageResolve) {
+  dispatchInput(text: string): { queued: boolean; shouldInterrupt: boolean } {
+    const shouldInterrupt =
+      this._status === "running" || this._status === "compacting";
+    const mustQueue = shouldInterrupt || this._status === "waiting_approval";
+    if (mustQueue || !this.userMessageResolve) {
       // Queue the message. The async generator (createUserMessageStream)
       // drains pendingInputQueue on each iteration, so it will be
       // delivered once the SDK is ready for the next turn.
       this.pendingInputQueue.push({ text });
       console.log(`[sdk-process] Queued input (queue depth: ${this.pendingInputQueue.length})`);
-      return true;
+      return { queued: true, shouldInterrupt };
     }
     const resolve = this.userMessageResolve;
     this.userMessageResolve = null;
@@ -744,7 +747,11 @@ export class SdkProcess extends EventEmitter<SdkProcessEvents> {
       },
       parent_tool_use_id: null,
     });
-    return false;
+    return { queued: false, shouldInterrupt: false };
+  }
+
+  sendInput(text: string): boolean {
+    return this.dispatchInput(text).queued;
   }
 
   /**
@@ -752,11 +759,17 @@ export class SdkProcess extends EventEmitter<SdkProcessEvents> {
    * @param text - The text message
    * @param images - Array of base64-encoded image data with mime types
    */
-  sendInputWithImages(text: string, images: Array<{ base64: string; mimeType: string }>): boolean {
-    if (!this.userMessageResolve) {
+  dispatchInputWithImages(
+    text: string,
+    images: Array<{ base64: string; mimeType: string }>,
+  ): { queued: boolean; shouldInterrupt: boolean } {
+    const shouldInterrupt =
+      this._status === "running" || this._status === "compacting";
+    const mustQueue = shouldInterrupt || this._status === "waiting_approval";
+    if (mustQueue || !this.userMessageResolve) {
       this.pendingInputQueue.push({ text, images });
       console.log(`[sdk-process] Queued input with ${images.length} image(s) (queue depth: ${this.pendingInputQueue.length})`);
-      return true;
+      return { queued: true, shouldInterrupt };
     }
     const resolve = this.userMessageResolve;
     this.userMessageResolve = null;
@@ -790,7 +803,14 @@ export class SdkProcess extends EventEmitter<SdkProcessEvents> {
       },
       parent_tool_use_id: null,
     });
-    return false;
+    return { queued: false, shouldInterrupt: false };
+  }
+
+  sendInputWithImages(
+    text: string,
+    images: Array<{ base64: string; mimeType: string }>,
+  ): boolean {
+    return this.dispatchInputWithImages(text, images).queued;
   }
 
   /**

--- a/packages/bridge/src/websocket.test.ts
+++ b/packages/bridge/src/websocket.test.ts
@@ -4147,7 +4147,7 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     bridge.close();
   });
 
-  it("claude input uses enqueue result for queued ack and interrupt", async () => {
+  it("claude input uses dispatch result for queued ack and interrupt", async () => {
     const bridge = new BridgeWebSocketServer({ server: httpServer });
     const ws = {
       readyState: OPEN_STATE,
@@ -4170,9 +4170,13 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     const sessionId = created.sessionId as string;
     const session = (bridge as any).sessionManager.get(sessionId);
 
-    // Simulate race: snapshot says idle, but SDK queues the input.
+    // Simulate race: snapshot says idle, but the SDK atomically decides to
+    // queue and interrupt based on its current state.
     session.process.isWaitingForInput = true;
-    session.process.sendInput.mockReturnValue(true);
+    session.process.dispatchInput = vi.fn(() => ({
+      queued: true,
+      shouldInterrupt: true,
+    }));
 
     ws.send.mockClear();
     (bridge as any).handleClientMessage(
@@ -4192,7 +4196,59 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
       sessionId,
       queued: true,
     });
+    expect(session.process.dispatchInput).toHaveBeenCalledWith("race queued");
     expect(session.process.interrupt).toHaveBeenCalledTimes(1);
+
+    bridge.close();
+  });
+
+  it("does not interrupt queued Claude input while approval is pending", async () => {
+    const bridge = new BridgeWebSocketServer({ server: httpServer });
+    const ws = {
+      readyState: OPEN_STATE,
+      send: vi.fn(),
+    } as any;
+
+    (bridge as any).handleClientMessage(
+      {
+        type: "start",
+        projectPath: "/tmp/project-a",
+        provider: "claude",
+      },
+      ws,
+    );
+    await Promise.resolve();
+
+    const created = ws.send.mock.calls
+      .map((c: unknown[]) => JSON.parse(c[0] as string))
+      .find((m: any) => m.type === "system" && m.subtype === "session_created");
+    const sessionId = created.sessionId as string;
+    const session = (bridge as any).sessionManager.get(sessionId);
+    session.process.dispatchInput = vi.fn(() => ({
+      queued: true,
+      shouldInterrupt: false,
+    }));
+
+    ws.send.mockClear();
+    (bridge as any).handleClientMessage(
+      {
+        type: "input",
+        sessionId,
+        text: "after approval",
+      },
+      ws,
+    );
+
+    const inputAck = ws.send.mock.calls
+      .map((c: unknown[]) => JSON.parse(c[0] as string))
+      .find((m: any) => m.type === "input_ack");
+    expect(inputAck).toMatchObject({
+      type: "input_ack",
+      sessionId,
+      queued: true,
+    });
+    expect(session.process.dispatchInput).toHaveBeenCalledWith("after approval");
+    expect(session.process.interrupt).not.toHaveBeenCalled();
 
     bridge.close();
   });

--- a/packages/bridge/src/websocket.ts
+++ b/packages/bridge/src/websocket.ts
@@ -2446,13 +2446,21 @@ export class BridgeWebSocketServer {
         // Claude Code input path — enqueue first, then interrupt if busy
         const claudeProc = session.process as SdkProcess;
         let wasQueued = false;
+        let shouldInterrupt = false;
         if (images.length > 0) {
           console.log(
             `[ws] Sending message with ${images.length} inline Base64 image(s)`,
           );
-          const result = claudeProc.sendInputWithImages(text, images);
-          wasQueued =
-            typeof result === "boolean" ? result : isAgentBusySnapshot;
+          if (typeof claudeProc.dispatchInputWithImages === "function") {
+            const result = claudeProc.dispatchInputWithImages(text, images);
+            wasQueued = result.queued;
+            shouldInterrupt = result.shouldInterrupt;
+          } else {
+            const result = claudeProc.sendInputWithImages(text, images);
+            wasQueued =
+              typeof result === "boolean" ? result : isAgentBusySnapshot;
+            shouldInterrupt = wasQueued;
+          }
         }
         // Legacy imageId mode (backward compatibility)
         else if (msg.imageId && this.galleryStore) {
@@ -2468,43 +2476,64 @@ export class BridgeWebSocketServer {
             .then((imageData) => {
               let queuedAfterResolve = false;
               if (imageData) {
-                const result = claudeProc.sendInputWithImages(text, [
-                  imageData,
-                ]);
-                queuedAfterResolve =
-                  typeof result === "boolean" ? result : isAgentBusySnapshot;
+                if (typeof claudeProc.dispatchInputWithImages === "function") {
+                  const result = claudeProc.dispatchInputWithImages(text, [
+                    imageData,
+                  ]);
+                  queuedAfterResolve = result.queued;
+                  if (result.shouldInterrupt) claudeProc.interrupt();
+                } else {
+                  const result = claudeProc.sendInputWithImages(text, [
+                    imageData,
+                  ]);
+                  queuedAfterResolve =
+                    typeof result === "boolean"
+                      ? result
+                      : isAgentBusySnapshot;
+                  if (queuedAfterResolve) claudeProc.interrupt();
+                }
               } else {
                 console.warn(`[ws] Image not found: ${msg.imageId}`);
-                const result = session.process.sendInput(text);
-                queuedAfterResolve =
-                  typeof result === "boolean" ? result : isAgentBusySnapshot;
-              }
-              if (queuedAfterResolve) {
-                console.log(
-                  `[ws] Agent is busy — will queue input and interrupt current turn`,
-                );
-                claudeProc.interrupt();
+                if (typeof claudeProc.dispatchInput === "function") {
+                  const result = claudeProc.dispatchInput(text);
+                  queuedAfterResolve = result.queued;
+                  if (result.shouldInterrupt) claudeProc.interrupt();
+                } else {
+                  const result = session.process.sendInput(text);
+                  queuedAfterResolve =
+                    typeof result === "boolean"
+                      ? result
+                      : isAgentBusySnapshot;
+                  if (queuedAfterResolve) claudeProc.interrupt();
+                }
               }
             })
             .catch((err) => {
               console.error(`[ws] Failed to load image: ${err}`);
-              const result = session.process.sendInput(text);
-              const queuedAfterResolve =
-                typeof result === "boolean" ? result : isAgentBusySnapshot;
-              if (queuedAfterResolve) {
-                console.log(
-                  `[ws] Agent is busy — will queue input and interrupt current turn`,
-                );
-                claudeProc.interrupt();
+              if (typeof claudeProc.dispatchInput === "function") {
+                const result = claudeProc.dispatchInput(text);
+                if (result.shouldInterrupt) claudeProc.interrupt();
+              } else {
+                const result = session.process.sendInput(text);
+                const queuedAfterResolve =
+                  typeof result === "boolean" ? result : isAgentBusySnapshot;
+                if (queuedAfterResolve) claudeProc.interrupt();
               }
             });
           break;
         }
         // Text-only message
         else {
-          const result = session.process.sendInput(text);
-          wasQueued =
-            typeof result === "boolean" ? result : isAgentBusySnapshot;
+          if (typeof claudeProc.dispatchInput === "function") {
+            const result = claudeProc.dispatchInput(text);
+            wasQueued = result.queued;
+            shouldInterrupt = result.shouldInterrupt;
+          } else {
+            const result = session.process.sendInput(text);
+            wasQueued =
+              typeof result === "boolean" ? result : isAgentBusySnapshot;
+            shouldInterrupt = wasQueued;
+          }
         }
 
         // Acknowledge receipt so the client can mark the message state.
@@ -2518,7 +2547,7 @@ export class BridgeWebSocketServer {
           queued: wasQueued,
         });
 
-        if (wasQueued) {
+        if (shouldInterrupt) {
           console.log(
             `[ws] Agent is busy — will queue input and interrupt current turn`,
           );


### PR DESCRIPTION
## Summary

- atomically decide whether Claude input should be queued and whether the active turn should be interrupted
- queue follow-up input before interrupting a running or compacting turn
- queue input without interrupting while a permission approval is pending
- preserve direct delivery while the SDK input stream is ready

Reimplements #133 with the input routing decision owned by `SdkProcess`, avoiding a WebSocket status snapshot race and preserving pending approval requests.

## Verification

- `npm test -- --run --reporter=dot` (684 tests passed)
- `npx tsc --noEmit -p packages/bridge/tsconfig.json`
- `git diff --check`
- independent self-review: LGTM

Co-authored-by: Edwiv <edwiv@edwiv.com>
