### PR TITLE
fix(app): handle malformed AskUserQuestion input

### DIFF
--- a/apps/mobile/lib/models/messages.dart
+++ b/apps/mobile/lib/models/messages.dart
@@ -1488,17 +1488,23 @@ class PermissionRequestMessage implements ServerMessage {
 
   bool get isPermissionGrantRequest => toolName == 'Permissions';
 
+  bool get isMalformedAskUserQuestion =>
+      toolName == 'AskUserQuestion' && !hasQuestions;
+
   List<String> get availableDecisions =>
       _stringList(input['availableDecisions']);
 
   bool get canApprove =>
-      availableDecisions.isEmpty || availableDecisions.contains('accept');
+      !isMalformedAskUserQuestion &&
+      (availableDecisions.isEmpty || availableDecisions.contains('accept'));
 
   bool get canApproveForSession =>
-      availableDecisions.isEmpty ||
-      availableDecisions.contains('acceptForSession');
+      !isMalformedAskUserQuestion &&
+      (availableDecisions.isEmpty ||
+          availableDecisions.contains('acceptForSession'));
 
   bool get canDecline =>
+      isMalformedAskUserQuestion ||
       availableDecisions.isEmpty ||
       availableDecisions.contains('decline') ||
       availableDecisions.contains('cancel');

--- a/apps/mobile/lib/services/chat_message_handler.dart
+++ b/apps/mobile/lib/services/chat_message_handler.dart
@@ -1,6 +1,7 @@
 import '../core/logger.dart';
 import '../models/messages.dart';
 import '../utils/codex_plan_update.dart';
+import '../utils/request_user_input.dart';
 import '../widgets/slash_command_sheet.dart'
     show
         SlashCommand,
@@ -438,16 +439,25 @@ class ChatMessageHandler {
     String? askToolUseId;
     Map<String, dynamic>? askInput;
     String? pendingToolUseId;
+    PermissionRequestMessage? pendingPermission;
     bool? inPlanMode;
     for (final content in message.content) {
       if (content is ToolUseContent) {
-        if (content.name == 'AskUserQuestion') {
+        if (content.name == 'AskUserQuestion' &&
+            hasRequestUserInputQuestions(content.input)) {
           askToolUseId = content.id;
           askInput = content.input;
           effects.add(ChatSideEffect.mediumHaptic);
           if (isBackground) effects.add(ChatSideEffect.notifyAskQuestion);
         } else {
           pendingToolUseId = content.id;
+          pendingPermission = content.name == 'AskUserQuestion'
+              ? PermissionRequestMessage(
+                  toolUseId: content.id,
+                  toolName: content.name,
+                  input: content.input,
+                )
+              : null;
           if (content.name == 'EnterPlanMode') {
             inPlanMode = true;
           }
@@ -465,6 +475,7 @@ class ChatMessageHandler {
       askToolUseId: askToolUseId,
       askInput: askInput,
       pendingToolUseId: pendingToolUseId,
+      pendingPermission: pendingPermission,
       inPlanMode: inPlanMode,
       sideEffects: effects,
     );
@@ -659,8 +670,16 @@ class ChatMessageHandler {
             if (content is ToolUseContent &&
                 content.name == 'AskUserQuestion' &&
                 !ignoredToolUseIds.contains(content.id)) {
-              lastAskToolUseId = content.id;
-              lastAskInput = content.input;
+              if (hasRequestUserInputQuestions(content.input)) {
+                lastAskToolUseId = content.id;
+                lastAskInput = content.input;
+              } else {
+                pendingPermissions[content.id] = PermissionRequestMessage(
+                  toolUseId: content.id,
+                  toolName: content.name,
+                  input: content.input,
+                );
+              }
             }
           }
         }

--- a/apps/mobile/lib/utils/request_user_input.dart
+++ b/apps/mobile/lib/utils/request_user_input.dart
@@ -26,12 +26,62 @@ const _mcpApprovalDeclineLabels = {mcpApprovalDeny, mcpApprovalDecline};
 Map<String, dynamic>? firstRequestUserInputQuestion(
   Map<String, dynamic> input,
 ) {
+  final questions = requestUserInputQuestions(input);
+  return questions.isEmpty ? null : questions.first;
+}
+
+List<Map<String, dynamic>> requestUserInputQuestions(
+  Map<String, dynamic> input,
+) {
   final questions = input['questions'];
-  if (questions is! List || questions.isEmpty) return null;
-  final first = questions.first;
-  return first is Map<String, dynamic>
-      ? first
-      : Map<String, dynamic>.from(first as Map);
+  if (questions is! List || questions.isEmpty) return const [];
+
+  final parsed = <Map<String, dynamic>>[];
+  for (final value in questions) {
+    if (value is! Map) return const [];
+
+    Map<String, dynamic> question;
+    try {
+      question = Map<String, dynamic>.from(value);
+    } catch (_) {
+      return const [];
+    }
+
+    final text = question['question'];
+    if (text is! String || text.trim().isEmpty) return const [];
+    if (question.containsKey('header') && question['header'] is! String) {
+      return const [];
+    }
+    if (question.containsKey('multiSelect') &&
+        question['multiSelect'] is! bool) {
+      return const [];
+    }
+
+    if (question.containsKey('options')) {
+      final options = question['options'];
+      if (options is! List) return const [];
+      final parsedOptions = <Map<String, dynamic>>[];
+      for (final value in options) {
+        if (value is! Map) return const [];
+        Map<String, dynamic> option;
+        try {
+          option = Map<String, dynamic>.from(value);
+        } catch (_) {
+          return const [];
+        }
+        if (option['label'] is! String ||
+            (option['label'] as String).trim().isEmpty ||
+            (option.containsKey('description') &&
+                option['description'] is! String)) {
+          return const [];
+        }
+        parsedOptions.add(option);
+      }
+      question['options'] = parsedOptions;
+    }
+    parsed.add(question);
+  }
+  return parsed;
 }
 
 List<String> requestUserInputOptionLabels(Map<String, dynamic> input) {
@@ -54,8 +104,7 @@ String? requestUserInputQuestionText(Map<String, dynamic> input) {
 }
 
 bool hasRequestUserInputQuestions(Map<String, dynamic> input) {
-  final questions = input['questions'];
-  return questions is List && questions.isNotEmpty;
+  return requestUserInputQuestions(input).isNotEmpty;
 }
 
 bool _containsAny(Set<String> labels, Set<String> candidates) =>

--- a/apps/mobile/lib/widgets/bubbles/ask_user_question_widget.dart
+++ b/apps/mobile/lib/widgets/bubbles/ask_user_question_widget.dart
@@ -40,8 +40,8 @@ class _AskUserQuestionWidgetState extends State<AskUserQuestionWidget> {
   int _currentPage = 0;
   bool _answered = false;
 
-  List<dynamic> get _questions =>
-      widget.input['questions'] as List<dynamic>? ?? const [];
+  List<Map<String, dynamic>> get _questions =>
+      requestUserInputQuestions(widget.input);
 
   bool get _isSingleQuestion => _questions.length <= 1;
 
@@ -49,7 +49,7 @@ class _AskUserQuestionWidgetState extends State<AskUserQuestionWidget> {
 
   bool get _singleQuestionIsMultiSelect {
     if (!_isSingleQuestion || _questions.isEmpty) return false;
-    final q = _questions.first as Map<String, dynamic>;
+    final q = _questions.first;
     return q['multiSelect'] as bool? ?? false;
   }
 
@@ -83,7 +83,7 @@ class _AskUserQuestionWidgetState extends State<AskUserQuestionWidget> {
     if (_answered) return;
     final answers = <String, String>{};
     for (var i = 0; i < _questions.length; i++) {
-      final q = _questions[i] as Map<String, dynamic>;
+      final q = _questions[i];
       final question = q['question'] as String? ?? '';
       final multiSelect = q['multiSelect'] as bool? ?? false;
       if (multiSelect) {
@@ -101,7 +101,7 @@ class _AskUserQuestionWidgetState extends State<AskUserQuestionWidget> {
 
   bool get _allQuestionsAnswered {
     for (var i = 0; i < _questions.length; i++) {
-      final q = _questions[i] as Map<String, dynamic>;
+      final q = _questions[i];
       final multiSelect = q['multiSelect'] as bool? ?? false;
       if (multiSelect) {
         final selected = _multiAnswers[i] ?? <String>{};
@@ -124,7 +124,7 @@ class _AskUserQuestionWidgetState extends State<AskUserQuestionWidget> {
 
   void _onAnswerSingle(int questionIndex, String label) {
     HapticFeedback.selectionClick();
-    final q = _questions[questionIndex] as Map<String, dynamic>;
+    final q = _questions[questionIndex];
     final isMulti = q['multiSelect'] as bool? ?? false;
 
     setState(() {
@@ -190,7 +190,7 @@ class _AskUserQuestionWidgetState extends State<AskUserQuestionWidget> {
   }
 
   void _submitCustomText(int questionIndex) {
-    final q = _questions[questionIndex] as Map<String, dynamic>;
+    final q = _questions[questionIndex];
     final isMulti = q['multiSelect'] as bool? ?? false;
     final customText = _customControllers[questionIndex]?.text.trim() ?? '';
 
@@ -237,7 +237,7 @@ class _AskUserQuestionWidgetState extends State<AskUserQuestionWidget> {
 
   void _onCustomTextChanged(int questionIndex, String text) {
     setState(() {
-      final q = _questions[questionIndex] as Map<String, dynamic>;
+      final q = _questions[questionIndex];
       final isMulti = q['multiSelect'] as bool? ?? false;
       if (isMulti) {
         final selected = _multiAnswers[questionIndex] ?? <String>{};
@@ -427,7 +427,7 @@ class _AskUserQuestionWidgetState extends State<AskUserQuestionWidget> {
                       );
                     }
                     return _AskQuestionLayout(
-                      question: questions[index] as Map<String, dynamic>,
+                      question: questions[index],
                       questionIndex: index,
                       isMultiQuestion: true,
                       scrollable: widget.scrollable,
@@ -454,7 +454,7 @@ class _AskUserQuestionWidgetState extends State<AskUserQuestionWidget> {
                 child: SingleChildScrollView(
                   key: const ValueKey('ask_single_question_scroll_view'),
                   child: _AskQuestionLayout(
-                    question: questions.first as Map<String, dynamic>,
+                    question: questions.first,
                     questionIndex: 0,
                     isMultiQuestion: false,
                     scrollable: false,
@@ -865,7 +865,7 @@ class _AskTextInputRow extends StatelessWidget {
 }
 
 class _AskSummaryPage extends StatelessWidget {
-  final List<dynamic> questions;
+  final List<Map<String, dynamic>> questions;
   final bool scrollable;
   final Map<int, String> singleAnswers;
   final ValueChanged<int> onGoToPage;
@@ -897,7 +897,7 @@ class _AskSummaryPage extends StatelessWidget {
         for (var i = 0; i < questions.length; i++) ...[
           _AskSummaryRow(
             index: i,
-            question: questions[i] as Map<String, dynamic>,
+            question: questions[i],
             answer: singleAnswers[i],
             onEdit: () => onGoToPage(i),
           ),

--- a/apps/mobile/test/ask_user_question_widget_test.dart
+++ b/apps/mobile/test/ask_user_question_widget_test.dart
@@ -545,4 +545,60 @@ void main() {
       expect(find.text('Claude is asking'), findsNothing);
     });
   });
+
+  group('AskUserQuestionWidget - malformed input', () {
+    final malformedInputs = <Map<String, dynamic>>[
+      const {},
+      const {'questions': 'not-a-list'},
+      const {
+        'questions': ['not-a-map'],
+      },
+      const {
+        'questions': [
+          {'question': 123},
+        ],
+      },
+      const {
+        'questions': [
+          {'question': 'Pick one', 'header': 123},
+        ],
+      },
+      const {
+        'questions': [
+          {'question': 'Pick one', 'multiSelect': 'false'},
+        ],
+      },
+      const {
+        'questions': [
+          {'question': 'Pick one', 'options': 'not-a-list'},
+        ],
+      },
+      const {
+        'questions': [
+          {
+            'question': 'Pick one',
+            'options': [
+              {'label': 1},
+            ],
+          },
+        ],
+      },
+    ];
+
+    for (var i = 0; i < malformedInputs.length; i++) {
+      testWidgets('case $i does not throw during build', (tester) async {
+        await tester.pumpWidget(
+          _wrap(
+            AskUserQuestionWidget(
+              toolUseId: 'bad-$i',
+              input: malformedInputs[i],
+              onAnswer: (_, _) {},
+            ),
+          ),
+        );
+
+        expect(tester.takeException(), isNull);
+      });
+    }
+  });
 }

--- a/apps/mobile/test/chat_message_handler_test.dart
+++ b/apps/mobile/test/chat_message_handler_test.dart
@@ -174,7 +174,11 @@ void main() {
               const ToolUseContent(
                 id: 'tu-ask',
                 name: 'AskUserQuestion',
-                input: {'questions': []},
+                input: {
+                  'questions': [
+                    {'question': 'Which option?'},
+                  ],
+                },
               ),
             ],
             model: 'test',
@@ -184,6 +188,60 @@ void main() {
       );
       expect(update.askToolUseId, 'tu-ask');
       expect(update.sideEffects, contains(ChatSideEffect.mediumHaptic));
+    });
+
+    test('treats malformed AskUserQuestion as an ordinary tool use', () {
+      final update = handler.handle(
+        AssistantServerMessage(
+          message: AssistantMessage(
+            id: 'msg-bad-ask',
+            role: 'assistant',
+            content: [
+              const ToolUseContent(
+                id: 'tu-bad-ask',
+                name: 'AskUserQuestion',
+                input: {
+                  'questions': [
+                    {'question': 'Valid'},
+                    {'question': 123},
+                  ],
+                },
+              ),
+            ],
+            model: 'test',
+          ),
+        ),
+        isBackground: false,
+      );
+
+      expect(update.askToolUseId, isNull);
+      expect(update.askInput, isNull);
+      expect(update.pendingToolUseId, 'tu-bad-ask');
+      expect(update.pendingPermission?.canApprove, isFalse);
+      expect(update.pendingPermission?.canApproveForSession, isFalse);
+      expect(update.pendingPermission?.canDecline, isTrue);
+      expect(update.sideEffects, isNot(contains(ChatSideEffect.mediumHaptic)));
+    });
+
+    test('makes a malformed AskUserQuestion permission decline-only', () {
+      final update = handler.handle(
+        const PermissionRequestMessage(
+          toolUseId: 'tu-bad-ask',
+          toolName: 'AskUserQuestion',
+          input: {
+            'questions': [
+              {'question': 123},
+            ],
+          },
+        ),
+        isBackground: false,
+      );
+
+      expect(update.askToolUseId, isNull);
+      expect(update.pendingToolUseId, 'tu-bad-ask');
+      expect(update.pendingPermission?.canApprove, isFalse);
+      expect(update.pendingPermission?.canApproveForSession, isFalse);
+      expect(update.pendingPermission?.canDecline, isTrue);
     });
 
     test('detects EnterPlanMode', () {
@@ -588,7 +646,11 @@ void main() {
                   const ToolUseContent(
                     id: 'tu-ask',
                     name: 'AskUserQuestion',
-                    input: {'questions': []},
+                    input: {
+                      'questions': [
+                        {'question': 'Which option?'},
+                      ],
+                    },
                   ),
                 ],
                 model: 'test',
@@ -602,6 +664,107 @@ void main() {
       );
       expect(update.askToolUseId, isNull);
       expect(update.askInput, isNull);
+    });
+
+    test('restores malformed AskUserQuestion as decline-only', () {
+      final update = handler.handle(
+        HistoryMessage(
+          messages: [
+            AssistantServerMessage(
+              message: AssistantMessage(
+                id: 'msg-bad-ask',
+                role: 'assistant',
+                content: [
+                  const ToolUseContent(
+                    id: 'tu-bad-ask',
+                    name: 'AskUserQuestion',
+                    input: {
+                      'questions': [
+                        {'question': 'Pick one', 'options': 'not-a-list'},
+                      ],
+                    },
+                  ),
+                ],
+                model: 'test',
+              ),
+            ),
+            const StatusMessage(status: ProcessStatus.waitingApproval),
+          ],
+        ),
+        isBackground: false,
+      );
+
+      expect(update.askToolUseId, isNull);
+      expect(update.askInput, isNull);
+      expect(update.pendingToolUseId, 'tu-bad-ask');
+      expect(update.pendingPermission?.canApprove, isFalse);
+      expect(update.pendingPermission?.canApproveForSession, isFalse);
+      expect(update.pendingPermission?.canDecline, isTrue);
+    });
+
+    test('restores a pending permission after a malformed question', () {
+      final update = handler.handle(
+        HistoryMessage(
+          messages: [
+            AssistantServerMessage(
+              message: AssistantMessage(
+                id: 'msg-bad-ask',
+                role: 'assistant',
+                content: [
+                  const ToolUseContent(
+                    id: 'tu-bad-ask',
+                    name: 'AskUserQuestion',
+                    input: {
+                      'questions': [
+                        {'question': false},
+                      ],
+                    },
+                  ),
+                ],
+                model: 'test',
+              ),
+            ),
+            const PermissionResolvedMessage(toolUseId: 'tu-bad-ask'),
+            const PermissionRequestMessage(
+              toolUseId: 'tu-pending',
+              toolName: 'Bash',
+              input: {'command': 'pwd'},
+            ),
+            const StatusMessage(status: ProcessStatus.waitingApproval),
+          ],
+        ),
+        isBackground: false,
+      );
+
+      expect(update.askToolUseId, isNull);
+      expect(update.pendingToolUseId, 'tu-pending');
+      expect(update.pendingPermission?.toolName, 'Bash');
+    });
+
+    test('restores malformed AskUserQuestion permission as decline-only', () {
+      final update = handler.handle(
+        const HistoryMessage(
+          messages: [
+            PermissionRequestMessage(
+              toolUseId: 'tu-bad-ask',
+              toolName: 'AskUserQuestion',
+              input: {
+                'questions': [
+                  {'question': 'Q', 'multiSelect': 'no'},
+                ],
+              },
+            ),
+            StatusMessage(status: ProcessStatus.waitingApproval),
+          ],
+        ),
+        isBackground: false,
+      );
+
+      expect(update.askToolUseId, isNull);
+      expect(update.pendingToolUseId, 'tu-bad-ask');
+      expect(update.pendingPermission?.canApprove, isFalse);
+      expect(update.pendingPermission?.canApproveForSession, isFalse);
+      expect(update.pendingPermission?.canDecline, isTrue);
     });
 
     test('restores first pending permission when multiple are unresolved', () {

--- a/apps/mobile/test/request_user_input_test.dart
+++ b/apps/mobile/test/request_user_input_test.dart
@@ -1,0 +1,104 @@
+import 'package:ccpocket/utils/request_user_input.dart';
+import 'package:ccpocket/models/messages.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('requestUserInputQuestions', () {
+    test('normalizes valid questions and options', () {
+      final questions = requestUserInputQuestions({
+        'questions': [
+          {
+            'question': 'Pick one',
+            'header': 'Choice',
+            'options': [
+              {'label': 'A', 'description': 'First'},
+            ],
+            'multiSelect': false,
+          },
+        ],
+      });
+
+      expect(questions.single['question'], 'Pick one');
+      expect(questions.single['options'], isA<List<Map<String, dynamic>>>());
+    });
+
+    test('rejects missing, empty, and non-list questions', () {
+      expect(requestUserInputQuestions(const {}), isEmpty);
+      expect(requestUserInputQuestions(const {'questions': []}), isEmpty);
+      expect(requestUserInputQuestions(const {'questions': 'bad'}), isEmpty);
+    });
+
+    test('rejects an entire mixed list when one question is malformed', () {
+      expect(
+        requestUserInputQuestions({
+          'questions': [
+            {'question': 'Valid'},
+            {'question': 123},
+          ],
+        }),
+        isEmpty,
+      );
+    });
+
+    test('rejects malformed question fields', () {
+      for (final question in [
+        <Object?, Object?>{1: 'non-string-key'},
+        <String, Object?>{'question': ''},
+        <String, Object?>{'question': 'Q', 'header': 1},
+        <String, Object?>{'question': 'Q', 'multiSelect': 'false'},
+        <String, Object?>{'question': 'Q', 'options': 'bad'},
+        <String, Object?>{'question': 'Q', 'options': null},
+      ]) {
+        expect(
+          requestUserInputQuestions({
+            'questions': [question],
+          }),
+          isEmpty,
+        );
+      }
+    });
+
+    test('rejects malformed option fields', () {
+      for (final options in [
+        <Object?>['not-a-map'],
+        <Object?>[
+          {1: 'non-string-key'},
+        ],
+        <Object?>[
+          {'label': 1},
+        ],
+        <Object?>[
+          {'label': ''},
+        ],
+        <Object?>[
+          {'label': 'A', 'description': 1},
+        ],
+      ]) {
+        expect(
+          requestUserInputQuestions({
+            'questions': [
+              {'question': 'Q', 'options': options},
+            ],
+          }),
+          isEmpty,
+        );
+      }
+    });
+  });
+
+  test('malformed AskUserQuestion permissions are always decline-only', () {
+    const request = PermissionRequestMessage(
+      toolUseId: 'bad-ask',
+      toolName: 'AskUserQuestion',
+      input: {
+        'questions': ['bad'],
+        'availableDecisions': ['accept', 'acceptForSession', 'decline'],
+      },
+    );
+
+    expect(request.isMalformedAskUserQuestion, isTrue);
+    expect(request.canApprove, isFalse);
+    expect(request.canApproveForSession, isFalse);
+    expect(request.canDecline, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary

- validate the complete `AskUserQuestion` payload before presenting the question UI
- reject the entire question set when a question, option, or nested field is malformed instead of changing question indexes through partial filtering
- keep malformed requests recoverable as reject-only approvals across live messages, history restoration, and queued approval transitions
- make the widget safe when constructed directly with malformed input

Reimplements #139 with stricter nested schema validation and fail-closed approval behavior.

## Verification

- `flutter test` (1,235 passed, 4 skipped)
- targeted parser, handler, widget, and Cubit tests (180 passed after final policy change)
- `dart analyze apps/mobile` (no new errors or warnings; 35 existing info diagnostics, with the known analyzer plugin dependency warning)
- iOS 26.4 simulator: opened the AskUserQuestion mock, verified question/options, selected an option, and observed the answer response
- independent self-review: LGTM

Co-authored-by: Edwiv <edwiv@edwiv.com>
