### PR TITLE
fix(bridge): require explicit unrestricted path opt-in

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,8 +24,8 @@ Please include:
 
 CC Pocket's Bridge Server exposes filesystem operations over WebSocket. Key security measures include:
 
-- **`BRIDGE_ALLOWED_DIRS`**: Restricts which directories can be accessed
+- **`BRIDGE_ALLOWED_DIRS`**: Restricts which directories can be accessed; defaults to `$HOME` and accepts the exact value `*` only for intentional unrestricted access
 - **`BRIDGE_API_KEY`**: Optional API key authentication for connections
-- **Path validation**: All paths are resolved and checked against allowed directories before any operation
+- **Path validation**: Unless explicitly unrestricted, all paths are resolved and checked against allowed directories before any operation
 - **Network security**: Tailscale or local network recommended for remote access; no data is sent to external servers
 - **Credential storage**: API keys and SSH keys are stored using platform-native encrypted storage (iOS Keychain / Android Keystore)

--- a/packages/bridge/README.md
+++ b/packages/bridge/README.md
@@ -38,7 +38,7 @@ ccpocket-bridge --version
 | `BRIDGE_PORT` | `8765` | WebSocket port |
 | `BRIDGE_HOST` | `0.0.0.0` | Bind address |
 | `BRIDGE_API_KEY` | (none) | API key authentication (enabled when set) |
-| `BRIDGE_ALLOWED_DIRS` | `$HOME` | Comma-separated list of project directories the Bridge may access |
+| `BRIDGE_ALLOWED_DIRS` | `$HOME` | Comma-separated list of project directories the Bridge may access; set exactly to `*` to allow any directory |
 | `BRIDGE_PUBLIC_WS_URL` | (none) | Public `ws://` / `wss://` URL used for startup deep link and QR code |
 | `BRIDGE_CODEX_APP_SERVER_MODE` | `private` | Experimental Codex app-server mode: `private`, `managed`, or `external` |
 | `BRIDGE_CODEX_SHARED_APP_SERVER_URL` | `ws://127.0.0.1:8767` in `managed` mode | Experimental shared Codex app-server URL for Codex CLI co-presence |

--- a/packages/bridge/src/index.ts
+++ b/packages/bridge/src/index.ts
@@ -19,20 +19,19 @@ import {
   promptHistoryStoreFileForPort,
   PromptHistoryStore,
 } from "./prompt-history-store.js";
-import { resolvePlatformPath } from "./path-utils.js";
+import { parseAllowedDirectories } from "./path-utils.js";
 
 export async function startServer() {
   const PORT = parseInt(process.env.BRIDGE_PORT ?? "8765", 10);
   const HOST = process.env.BRIDGE_HOST ?? "0.0.0.0";
   const API_KEY = process.env.BRIDGE_API_KEY;
 
-  // Parse allowed project directories (default: $HOME)
-  const ALLOWED_DIRS: string[] = process.env.BRIDGE_ALLOWED_DIRS
-    ? process.env.BRIDGE_ALLOWED_DIRS
-      .split(",")
-      .map((d) => resolvePlatformPath(d.trim()))
-      .filter(Boolean)
-    : [homedir()];
+  // Unrestricted access requires the exact value "*".
+  const ALLOWED_DIRS = parseAllowedDirectories(
+    process.env.BRIDGE_ALLOWED_DIRS,
+    process.platform,
+    [homedir()],
+  );
 
   console.log("[bridge] Starting ccpocket bridge server...");
 
@@ -44,7 +43,11 @@ export async function startServer() {
     console.log("[bridge] mDNS advertisement disabled");
   }
 
-  console.log(`[bridge] Allowed dirs: ${ALLOWED_DIRS.join(", ")}`);
+  console.log(
+    `[bridge] Allowed dirs: ${
+      ALLOWED_DIRS.length > 0 ? ALLOWED_DIRS.join(", ") : "(unrestricted)"
+    }`,
+  );
 
   // Initialize Firebase Anonymous Auth for push notifications
   let firebaseAuth: FirebaseAuthClient | undefined;

--- a/packages/bridge/src/path-utils.test.ts
+++ b/packages/bridge/src/path-utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   isPathWithinAllowedDirectory,
   normalizePlatformPath,
+  parseAllowedDirectories,
   resolvePlatformPath,
   resolvePlatformPathFrom,
   stripWindowsExtendedPathPrefix,
@@ -58,5 +59,33 @@ describe("path-utils", () => {
     expect(
       resolvePlatformPathFrom("D:\\Users\\alice\\repo", "..\\shared", "win32"),
     ).toBe("D:\\Users\\alice\\shared");
+  });
+
+  it("uses default allowed directories when unset or blank", () => {
+    expect(parseAllowedDirectories(undefined, "linux", ["/home/alice"]))
+      .toEqual(["/home/alice"]);
+    expect(parseAllowedDirectories("  ", "linux", ["/home/alice"]))
+      .toEqual(["/home/alice"]);
+  });
+
+  it("allows unrestricted access only with an exact star", () => {
+    expect(parseAllowedDirectories("*", "linux", ["/home/alice"]))
+      .toEqual([]);
+    expect(() => parseAllowedDirectories("*, /opt/project", "linux"))
+      .toThrow("must be either '*'");
+  });
+
+  it("rejects non-empty configurations without a path", () => {
+    expect(() => parseAllowedDirectories(",", "linux", ["/home/alice"]))
+      .toThrow("at least one path");
+    expect(() => parseAllowedDirectories(" , , ", "linux"))
+      .toThrow("at least one path");
+  });
+
+  it("parses and resolves configured allowed directories", () => {
+    expect(parseAllowedDirectories("/home/alice, /opt/project", "linux"))
+      .toEqual(["/home/alice", "/opt/project"]);
+    expect(parseAllowedDirectories("C:\\Users\\alice", "win32"))
+      .toEqual(["C:\\Users\\alice"]);
   });
 });

--- a/packages/bridge/src/path-utils.ts
+++ b/packages/bridge/src/path-utils.ts
@@ -49,6 +49,29 @@ export function resolvePlatformPathFrom(
   );
 }
 
+export function parseAllowedDirectories(
+  input: string | undefined,
+  platform: NodeJS.Platform = process.platform,
+  defaultDirs: string[] = [],
+): string[] {
+  const raw = input?.trim();
+  if (!raw) {
+    return defaultDirs.map((dir) => resolvePlatformPath(dir, platform));
+  }
+  if (raw === "*") return [];
+
+  const entries = raw.split(",").map((dir) => dir.trim()).filter(Boolean);
+  if (entries.length === 0) {
+    throw new Error("BRIDGE_ALLOWED_DIRS must contain at least one path");
+  }
+  if (entries.includes("*")) {
+    throw new Error(
+      "BRIDGE_ALLOWED_DIRS must be either '*' or a comma-separated path list",
+    );
+  }
+  return entries.map((dir) => resolvePlatformPath(dir, platform));
+}
+
 export function isPathWithinAllowedDirectory(
   targetPath: string,
   allowedDir: string,


### PR DESCRIPTION
## Summary

- keep Bridge filesystem access scoped to `$HOME` when `BRIDGE_ALLOWED_DIRS` is unset or blank
- allow unrestricted access only when the exact value is `*`
- fail startup for mixed wildcard/path or delimiter-only configurations
- document the explicit unrestricted opt-in

Reimplements #131 with fail-fast validation so no malformed non-wildcard value can become an unrestricted empty allowlist.

## Verification

- `npm test -- --run --reporter=dot` (687 tests passed)
- `npx vitest run src/path-utils.test.ts --reporter=dot` (10 tests passed)
- `npx tsc --noEmit -p packages/bridge/tsconfig.json`
- `git diff --check`
- independent security self-review: LGTM

Co-authored-by: Edwiv <edwiv@edwiv.com>
