### PR TITLE
fix(bridge): map AskUserQuestion answers by question

### DIFF
--- a/packages/bridge/src/sdk-process.test.ts
+++ b/packages/bridge/src/sdk-process.test.ts
@@ -3,6 +3,7 @@ import {
   parseRule,
   matchesSessionRule,
   buildSessionRule,
+  buildAskUserAnswers,
   ACCEPT_EDITS_AUTO_APPROVE,
   extractTokenUsage,
   buildThinkingOptions,
@@ -801,5 +802,175 @@ describe("SdkProcess input dispatch", () => {
       ]),
     ).toEqual({ queued: true, shouldInterrupt: true });
     expect(resolve).not.toHaveBeenCalled();
+  });
+});
+
+describe("buildAskUserAnswers", () => {
+  const multiInput = {
+    questions: [
+      { question: "Which database?" },
+      { question: "Which ORM?" },
+    ],
+  };
+  const singleInput = { questions: [{ question: "Which database?" }] };
+
+  it("maps a bare answer for a single question", () => {
+    expect(buildAskUserAnswers(singleInput, "SQLite")).toEqual({
+      "Which database?": "SQLite",
+    });
+  });
+
+  it("maps multi-question JSON answers by question text", () => {
+    const result = JSON.stringify({
+      questions: multiInput.questions,
+      answers: {
+        "Which database?": "SQLite",
+        "Which ORM?": "Drizzle, Prisma",
+      },
+    });
+    expect(buildAskUserAnswers(multiInput, result)).toEqual({
+      "Which database?": "SQLite",
+      "Which ORM?": "Drizzle, Prisma",
+    });
+  });
+
+  it("joins string arrays for multi-select and ignores invalid values", () => {
+    const result = JSON.stringify({
+      questions: multiInput.questions,
+      answers: {
+        "Which database?": ["SQLite", "Postgres"],
+        injected: "value",
+        "Which ORM?": { nested: true },
+      },
+    });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(buildAskUserAnswers(multiInput, result)).toEqual({
+      "Which database?": "SQLite, Postgres",
+    });
+    warn.mockRestore();
+  });
+
+  it("preserves existing answers and overwrites matching new answers", () => {
+    const result = JSON.stringify({
+      questions: multiInput.questions,
+      answers: { "Which ORM?": "Drizzle" },
+    });
+    expect(buildAskUserAnswers({
+      ...multiInput,
+      answers: { "Which database?": "SQLite", injected: "value" },
+    }, result)).toEqual({
+      "Which database?": "SQLite",
+      "Which ORM?": "Drizzle",
+    });
+  });
+
+  it("does not map non-envelope input onto the first of multiple questions", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(buildAskUserAnswers(multiInput, "SQLite")).toEqual({});
+    expect(buildAskUserAnswers(multiInput, "{bad json")).toEqual({});
+    warn.mockRestore();
+  });
+
+  it("preserves JSON-shaped custom text for a single question", () => {
+    const result = JSON.stringify({ custom: true });
+    expect(buildAskUserAnswers(singleInput, result)).toEqual({
+      "Which database?": result,
+    });
+  });
+
+  it("does not mistake a mismatched envelope-shaped custom answer for app data", () => {
+    const result = JSON.stringify({
+      questions: [],
+      answers: { other: "value" },
+    });
+    expect(buildAskUserAnswers(singleInput, result)).toEqual({
+      "Which database?": result,
+    });
+  });
+
+  it("creates safe own properties for special question text", () => {
+    const answers = buildAskUserAnswers(
+      { questions: [{ question: "__proto__" }] },
+      "safe",
+    );
+    expect(Object.hasOwn(answers, "__proto__")).toBe(true);
+    expect(answers.__proto__).toBe("safe");
+  });
+
+  it("collapses duplicate question text deterministically", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const duplicateInput = {
+      questions: [{ question: "Same" }, { question: "Same" }],
+    };
+    const result = JSON.stringify({
+      questions: duplicateInput.questions,
+      answers: { Same: "answer" },
+    });
+    expect(buildAskUserAnswers(duplicateInput, result)).toEqual({
+      Same: "answer",
+    });
+    expect(buildAskUserAnswers(duplicateInput, "answer")).toEqual({});
+    warn.mockRestore();
+  });
+
+  it("returns an empty map when the pending input has no question text", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(buildAskUserAnswers({ questions: [] }, "SQLite")).toEqual({});
+    warn.mockRestore();
+  });
+});
+
+describe("SdkProcess.answer", () => {
+  it("resolves AskUserQuestion with question-keyed SDK answers", () => {
+    const proc = new SdkProcess();
+    const resolve = vi.fn();
+    const internal = proc as any;
+    internal._status = "waiting_approval";
+    internal.pendingPermissions.set("ask-1", {
+      resolve,
+      toolName: "AskUserQuestion",
+      input: { questions: [{ question: "Which database?" }] },
+    });
+
+    proc.answer("ask-1", "SQLite");
+
+    expect(resolve).toHaveBeenCalledWith({
+      behavior: "allow",
+      updatedInput: {
+        questions: [{ question: "Which database?" }],
+        answers: { "Which database?": "SQLite" },
+      },
+    });
+    expect(resolve.mock.calls[0][0].updatedInput.answers).not.toHaveProperty(
+      "result",
+    );
+    expect(proc.status).toBe("running");
+  });
+
+  it("resolves multi-question envelopes with every mapped answer", () => {
+    const proc = new SdkProcess();
+    const resolve = vi.fn();
+    const questions = [
+      { question: "Which database?" },
+      { question: "Which ORM?" },
+    ];
+    (proc as any).pendingPermissions.set("ask-multi", {
+      resolve,
+      toolName: "AskUserQuestion",
+      input: { questions },
+    });
+
+    proc.answer("ask-multi", JSON.stringify({
+      questions,
+      answers: {
+        "Which database?": "SQLite",
+        "Which ORM?": "Drizzle",
+      },
+    }));
+
+    expect(resolve.mock.calls[0][0].updatedInput.answers).toEqual({
+      "Which database?": "SQLite",
+      "Which ORM?": "Drizzle",
+    });
   });
 });

--- a/packages/bridge/src/sdk-process.ts
+++ b/packages/bridge/src/sdk-process.ts
@@ -215,6 +215,101 @@ export function buildSessionRule(toolName: string, input: Record<string, unknown
   return toolName;
 }
 
+export function buildAskUserAnswers(
+  input: Record<string, unknown>,
+  result: string,
+): Record<string, string> {
+  const extractQuestionTexts = (questions: unknown): string[] =>
+    Array.isArray(questions)
+      ? questions.flatMap((question) => {
+        if (
+          !question ||
+          typeof question !== "object" ||
+          Array.isArray(question)
+        ) {
+          return [];
+        }
+        const text = (question as Record<string, unknown>).question;
+        return typeof text === "string" && text.trim().length > 0 ? [text] : [];
+      })
+      : [];
+  const rawQuestionTexts = extractQuestionTexts(input.questions);
+  const questionTexts = [...new Set(rawQuestionTexts)];
+
+  if (questionTexts.length === 0) {
+    console.warn(
+      "[sdk-process] answer() could not resolve AskUserQuestion text",
+    );
+    return {};
+  }
+  if (questionTexts.length !== rawQuestionTexts.length) {
+    console.warn("[sdk-process] AskUserQuestion contains duplicate question text");
+  }
+
+  const mapped = new Map<string, string>();
+  const existingAnswers = input.answers;
+  if (
+    existingAnswers &&
+    typeof existingAnswers === "object" &&
+    !Array.isArray(existingAnswers)
+  ) {
+    const existingRecord = existingAnswers as Record<string, unknown>;
+    for (const questionText of questionTexts) {
+      const answer = existingRecord[questionText];
+      if (typeof answer === "string") mapped.set(questionText, answer);
+    }
+  }
+
+  try {
+    const parsed = JSON.parse(result) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      const payload = parsed as Record<string, unknown>;
+      const answers = payload.answers;
+      const payloadQuestionTexts = extractQuestionTexts(payload.questions);
+      const questionsMatch =
+        payloadQuestionTexts.length === rawQuestionTexts.length &&
+        payloadQuestionTexts.every(
+          (questionText, index) => questionText === rawQuestionTexts[index],
+        );
+      if (
+        questionsMatch &&
+        answers &&
+        typeof answers === "object" &&
+        !Array.isArray(answers)
+      ) {
+        const answerRecord = answers as Record<string, unknown>;
+        for (const questionText of questionTexts) {
+          const answer = answerRecord[questionText];
+          if (typeof answer === "string") {
+            mapped.set(questionText, answer);
+          } else if (
+            Array.isArray(answer) &&
+            answer.every((value) => typeof value === "string")
+          ) {
+            mapped.set(questionText, answer.join(", "));
+          } else if (answer !== undefined) {
+            console.warn(
+              `[sdk-process] Ignoring invalid answer for question: ${questionText}`,
+            );
+          }
+        }
+        return Object.fromEntries(mapped);
+      }
+    }
+  } catch {
+    // A normal single-question answer is not JSON.
+  }
+
+  if (rawQuestionTexts.length === 1) {
+    mapped.set(questionTexts[0], result);
+  } else {
+    console.warn(
+      "[sdk-process] Ignoring non-envelope answer for multiple questions",
+    );
+  }
+  return Object.fromEntries(mapped);
+}
+
 // ---- Auth error helpers (exported for testing) ----
 
 export type AuthErrorCode = "auth_login_required" | "auth_token_expired" | "auth_api_error";
@@ -920,11 +1015,12 @@ export class SdkProcess extends EventEmitter<SdkProcessEvents> {
     }
 
     this.pendingPermissions.delete(toolUseId);
+    const answers = buildAskUserAnswers(pending.input, result);
     pending.resolve({
       behavior: "allow",
       updatedInput: {
         ...pending.input,
-        answers: { ...(pending.input.answers as Record<string, string> ?? {}), result },
+        answers,
       },
     });
 


### PR DESCRIPTION
## Summary

- map Claude `AskUserQuestion` answers by the pending question text expected by the Agent SDK
- support single answers, multi-question envelopes, and multi-select string arrays
- preserve valid existing answers while restricting new keys to pending questions
- reject ambiguous bare answers for multiple questions and safely handle duplicate or special question keys

Reimplements #132 with pending-question validation and envelope matching so arbitrary or mismatched JSON cannot replace the SDK answer map.

## Verification

- `npm test -- --run --reporter=dot` (698 tests passed)
- `npx vitest run src/sdk-process.test.ts --reporter=dot` (85 tests passed after final changes)
- `npx tsc --noEmit -p packages/bridge/tsconfig.json`
- `git diff --check`
- independent self-review: LGTM

Co-authored-by: Edwiv <edwiv@edwiv.com>
