### PR TITLE
fix(bridge): retain idle permission mode changes

### DIFF
--- a/packages/bridge/src/sdk-process.test.ts
+++ b/packages/bridge/src/sdk-process.test.ts
@@ -4,6 +4,7 @@ import {
   matchesSessionRule,
   buildSessionRule,
   buildAskUserAnswers,
+  resolvePermissionMode,
   ACCEPT_EDITS_AUTO_APPROVE,
   extractTokenUsage,
   buildThinkingOptions,
@@ -972,5 +973,149 @@ describe("SdkProcess.answer", () => {
       "Which database?": "SQLite",
       "Which ORM?": "Drizzle",
     });
+  });
+});
+
+describe("SdkProcess.setPermissionMode", () => {
+  it("keeps an idle mode unless the next start explicitly overrides it", () => {
+    expect(resolvePermissionMode("acceptEdits", undefined)).toBe(
+      "acceptEdits",
+    );
+    expect(resolvePermissionMode("acceptEdits", "bypassPermissions")).toBe(
+      "bypassPermissions",
+    );
+    expect(resolvePermissionMode(undefined, undefined)).toBeUndefined();
+  });
+
+  it("retains an idle mode when start omits permissionMode", async () => {
+    const proc = new SdkProcess();
+    await proc.setPermissionMode("acceptEdits");
+
+    proc.start("/tmp");
+    expect(proc.permissionMode).toBe("acceptEdits");
+    proc.stop();
+  });
+
+  it("lets an explicit start mode override the retained idle mode", async () => {
+    const proc = new SdkProcess();
+    await proc.setPermissionMode("acceptEdits");
+
+    proc.start("/tmp", { permissionMode: "bypassPermissions" });
+    expect(proc.permissionMode).toBe("bypassPermissions");
+    proc.stop();
+  });
+
+  it("records and emits a permission mode change while idle", async () => {
+    const proc = new SdkProcess();
+    const messages: ServerMessage[] = [];
+    (proc as any)._sessionId = "claude-session";
+    proc.on("message", (message) => messages.push(message));
+
+    await proc.setPermissionMode("bypassPermissions");
+
+    expect(proc.permissionMode).toBe("bypassPermissions");
+    expect(messages).toContainEqual(expect.objectContaining({
+      type: "system",
+      subtype: "set_permission_mode",
+      permissionMode: "bypassPermissions",
+      sessionId: "claude-session",
+    }));
+  });
+
+  it("applies a permission mode change to a live query before updating state", async () => {
+    const proc = new SdkProcess();
+    const setPermissionMode = vi.fn(async () => {});
+    (proc as any).queryInstance = { setPermissionMode };
+
+    await proc.setPermissionMode("acceptEdits");
+
+    expect(setPermissionMode).toHaveBeenCalledWith("acceptEdits");
+    expect(proc.permissionMode).toBe("acceptEdits");
+  });
+
+  it("does not update state when a live query rejects the change", async () => {
+    const proc = new SdkProcess();
+    (proc as any)._permissionMode = "default";
+    (proc as any).queryInstance = {
+      setPermissionMode: vi.fn(async () => {
+        throw new Error("unsupported");
+      }),
+    };
+
+    await expect(proc.setPermissionMode("auto")).rejects.toThrow("unsupported");
+    expect(proc.permissionMode).toBe("default");
+  });
+
+  it("ignores an old live update that finishes after a new start", async () => {
+    const proc = new SdkProcess();
+    let finishUpdate!: () => void;
+    const setPermissionMode = vi.fn(
+      () => new Promise<void>((resolve) => {
+        finishUpdate = resolve;
+      }),
+    );
+    (proc as any).queryInstance = {
+      setPermissionMode,
+      close: vi.fn(),
+    };
+    const messages: ServerMessage[] = [];
+    proc.on("message", (message) => messages.push(message));
+
+    const oldUpdate = proc.setPermissionMode("bypassPermissions");
+    await Promise.resolve();
+    proc.start("/tmp", { permissionMode: "default" });
+    finishUpdate();
+    await oldUpdate;
+
+    expect(proc.permissionMode).toBe("default");
+    expect(messages).not.toContainEqual(expect.objectContaining({
+      type: "system",
+      subtype: "set_permission_mode",
+      permissionMode: "bypassPermissions",
+    }));
+    proc.stop();
+  });
+
+  it("commits an earlier success when the next queued change fails", async () => {
+    const proc = new SdkProcess();
+    let finishFirst!: () => void;
+    const firstUpdate = new Promise<void>((resolve) => {
+      finishFirst = resolve;
+    });
+    const setPermissionMode = vi.fn()
+      .mockImplementationOnce(() => firstUpdate)
+      .mockRejectedValueOnce(new Error("unsupported"));
+    (proc as any)._permissionMode = "default";
+    (proc as any).queryInstance = { setPermissionMode };
+
+    const earlier = proc.setPermissionMode("bypassPermissions");
+    const later = proc.setPermissionMode("default");
+    await Promise.resolve();
+    finishFirst();
+
+    await earlier;
+    await expect(later).rejects.toThrow("unsupported");
+    expect(setPermissionMode.mock.calls).toEqual([
+      ["bypassPermissions"],
+      ["default"],
+    ]);
+    expect(proc.permissionMode).toBe("bypassPermissions");
+  });
+
+  it("does not let an unresolved old update block the new generation", async () => {
+    const proc = new SdkProcess();
+    const neverFinishes = new Promise<void>(() => {});
+    (proc as any).queryInstance = {
+      setPermissionMode: vi.fn(() => neverFinishes),
+      close: vi.fn(),
+    };
+
+    void proc.setPermissionMode("bypassPermissions");
+    await Promise.resolve();
+    proc.start("/tmp", { permissionMode: "acceptEdits" });
+    proc.stop();
+
+    await expect(proc.setPermissionMode("default")).resolves.toBeUndefined();
+    expect(proc.permissionMode).toBe("default");
   });
 });

--- a/packages/bridge/src/sdk-process.ts
+++ b/packages/bridge/src/sdk-process.ts
@@ -310,6 +310,13 @@ export function buildAskUserAnswers(
   return Object.fromEntries(mapped);
 }
 
+export function resolvePermissionMode(
+  current: PermissionMode | undefined,
+  requested: PermissionMode | undefined,
+): PermissionMode | undefined {
+  return requested ?? current;
+}
+
 // ---- Auth error helpers (exported for testing) ----
 
 export type AuthErrorCode = "auth_login_required" | "auth_token_expired" | "auth_api_error";
@@ -601,6 +608,8 @@ export class SdkProcess extends EventEmitter<SdkProcessEvents> {
   private _sessionId: string | null = null;
   private pendingPermissions = new Map<string, PendingPermission>();
   private _permissionMode: PermissionMode | undefined;
+  private permissionModeGeneration = 0;
+  private permissionModeUpdates: Promise<void> = Promise.resolve();
   get permissionMode(): PermissionMode | undefined { return this._permissionMode; }
   private _model: string | undefined;
   get model(): string | undefined { return this._model; }
@@ -653,7 +662,12 @@ export class SdkProcess extends EventEmitter<SdkProcessEvents> {
     this._sessionId = null;
     this.sessionEndEmitted = false;
     this.pendingPermissions.clear();
-    this._permissionMode = options?.permissionMode;
+    this.permissionModeGeneration += 1;
+    this.permissionModeUpdates = Promise.resolve();
+    this._permissionMode = resolvePermissionMode(
+      this._permissionMode,
+      options?.permissionMode,
+    );
     this.sessionAllowRules.clear();
     this.toolCallsSinceLastResult = 0;
     this.fileEditsSinceLastResult = 0;
@@ -699,7 +713,7 @@ export class SdkProcess extends EventEmitter<SdkProcessEvents> {
   }
 
   private startSdkQuery(projectPath: string, options?: StartOptions): void {
-    console.log(`[sdk-process] Starting SDK query (cwd: ${projectPath}, mode: ${options?.permissionMode ?? "default"}${options?.sessionId ? `, resume: ${options.sessionId}` : ""}${options?.continueMode ? ", continue: true" : ""})`);
+    console.log(`[sdk-process] Starting SDK query (cwd: ${projectPath}, mode: ${this._permissionMode ?? "default"}${options?.sessionId ? `, resume: ${options.sessionId}` : ""}${options?.continueMode ? ", continue: true" : ""})`);
 
     // In -p mode with --input-format stream-json, Claude CLI won't emit
     // system/init until the first user input. Set a fallback timeout to
@@ -720,7 +734,7 @@ export class SdkProcess extends EventEmitter<SdkProcessEvents> {
         cwd: projectPath,
         resume: options?.sessionId,
         continue: options?.continueMode,
-        permissionMode: options?.permissionMode ?? "default",
+        permissionMode: this._permissionMode ?? "default",
         ...(options?.model ? { model: options.model } : {}),
         ...buildThinkingOptions(options?.model),
         ...(options?.effort ? { effort: options.effort } : {}),
@@ -1031,20 +1045,33 @@ export class SdkProcess extends EventEmitter<SdkProcessEvents> {
 
   /**
    * Update permission mode for the current session.
-   * Only available while the query instance is active.
+   * Idle changes are retained and applied when the next query starts.
    */
   async setPermissionMode(mode: PermissionMode): Promise<void> {
-    if (!this.queryInstance) {
-      throw new Error("No active query instance");
-    }
-    await this.queryInstance.setPermissionMode(mode);
-    this._permissionMode = mode;
-    this.emitMessage({
-      type: "system",
-      subtype: "set_permission_mode",
-      permissionMode: mode,
-      sessionId: this._sessionId ?? undefined,
+    const generation = this.permissionModeGeneration;
+    const update = this.permissionModeUpdates.then(async () => {
+      if (generation !== this.permissionModeGeneration) return;
+
+      const queryInstance = this.queryInstance;
+      if (queryInstance) {
+        await queryInstance.setPermissionMode(mode);
+        if (
+          generation !== this.permissionModeGeneration ||
+          queryInstance !== this.queryInstance
+        ) {
+          return;
+        }
+      }
+      this._permissionMode = mode;
+      this.emitMessage({
+        type: "system",
+        subtype: "set_permission_mode",
+        permissionMode: mode,
+        sessionId: this._sessionId ?? undefined,
+      });
     });
+    this.permissionModeUpdates = update.catch(() => {});
+    return update;
   }
 
   /**


### PR DESCRIPTION
## Summary

- retain Claude permission mode changes made before a query starts or while the process is idle
- apply explicit start options before retained state, while allowing auth-wait changes to reach the SDK query
- serialize live mode changes so successful state is committed in order and later failures cannot hide broader SDK permissions
- isolate new process generations from stale or permanently unresolved updates

Reimplements #136 with lifecycle and concurrency handling beyond the original idle-state change.

## Verification

- `npm test -- --run --reporter=dot` (709 tests passed)
- `npx vitest run src/sdk-process.test.ts --reporter=dot` (94 tests passed after final concurrency changes)
- `npx tsc --noEmit -p packages/bridge/tsconfig.json`
- `git diff --check`
- independent self-review: LGTM

Co-authored-by: Edwiv <edwiv@edwiv.com>
