### PR TITLE
fix(codex): derive permissions display from runtime settings

### DIFF
--- a/apps/mobile/lib/models/messages.dart
+++ b/apps/mobile/lib/models/messages.dart
@@ -230,22 +230,49 @@ CodexPermissionsMode codexPermissionsModeFromSettings({
 }) {
   final explicit = codexPermissionsModeFromRaw(codexPermissionsMode);
   if (explicit != null) return explicit;
+  if (codexPermissionsMode != null && codexPermissionsMode.isNotEmpty) {
+    return CodexPermissionsMode.custom;
+  }
   final normalizedSandbox = switch (sandboxMode) {
-    'danger-full-access' || 'off' => SandboxMode.off,
-    'workspace-write' || 'read-only' || 'on' => SandboxMode.on,
+    'danger-full-access' || 'off' => 'danger-full-access',
+    'workspace-write' || 'on' => 'workspace-write',
+    'read-only' => 'read-only',
     _ => null,
   };
   if (approvalPolicy == CodexApprovalPolicy.never.value &&
-      (normalizedSandbox == null || normalizedSandbox == SandboxMode.off)) {
+      normalizedSandbox == 'danger-full-access') {
     return CodexPermissionsMode.fullAccess;
   }
   if (approvalPolicy == CodexApprovalPolicy.onRequest.value &&
-      (normalizedSandbox == null || normalizedSandbox == SandboxMode.on)) {
-    return isCodexAutoReviewApprovalsReviewer(approvalsReviewer)
-        ? CodexPermissionsMode.autoReview
-        : CodexPermissionsMode.defaultPermissions;
+      normalizedSandbox == 'workspace-write') {
+    if (isCodexAutoReviewApprovalsReviewer(approvalsReviewer)) {
+      return CodexPermissionsMode.autoReview;
+    }
+    if (approvalsReviewer == null || approvalsReviewer == 'user') {
+      return CodexPermissionsMode.defaultPermissions;
+    }
   }
   return CodexPermissionsMode.custom;
+}
+
+String? _resolveCodexPermissionsMode(Map<String, dynamic>? codexSettings) {
+  if (codexSettings == null) return null;
+  final explicit = codexPermissionsModeFromRaw(
+    codexSettings['codexPermissionsMode'] as String?,
+  );
+  if (explicit != null) return explicit.value;
+  if (codexSettings['codexPermissionsMode'] != null) {
+    return CodexPermissionsMode.custom.value;
+  }
+  if (codexSettings['approvalPolicy'] == null ||
+      codexSettings['sandboxMode'] == null) {
+    return null;
+  }
+  return codexPermissionsModeFromSettings(
+    approvalPolicy: codexSettings['approvalPolicy'] as String?,
+    approvalsReviewer: codexSettings['approvalsReviewer'] as String?,
+    sandboxMode: codexSettings['sandboxMode'] as String?,
+  ).value;
 }
 
 CodexApprovalPolicy? approvalPolicyForCodexPermissionsMode(
@@ -3187,7 +3214,7 @@ class RecentSession {
         executionMode: json['executionMode'] as String?,
       ),
       codexApprovalsReviewer: codexSettings?['approvalsReviewer'] as String?,
-      codexPermissionsMode: codexSettings?['codexPermissionsMode'] as String?,
+      codexPermissionsMode: _resolveCodexPermissionsMode(codexSettings),
       executionMode:
           json['executionMode'] as String? ??
           deriveExecutionMode(
@@ -3482,7 +3509,7 @@ class SessionInfo {
         executionMode: json['executionMode'] as String?,
       ),
       codexApprovalsReviewer: codexSettings?['approvalsReviewer'] as String?,
-      codexPermissionsMode: codexSettings?['codexPermissionsMode'] as String?,
+      codexPermissionsMode: _resolveCodexPermissionsMode(codexSettings),
       codexSandboxMode: codexSettings?['sandboxMode'] as String?,
       codexModel: sanitizeCodexModelName(codexSettings?['model'] as String?),
       codexProfile: codexSettings?['profile'] as String?,

--- a/apps/mobile/test/messages_test.dart
+++ b/apps/mobile/test/messages_test.dart
@@ -13,6 +13,119 @@ void main() {
     });
   });
 
+  group('Codex permissions mode', () {
+    test('derives only complete known presets', () {
+      expect(
+        codexPermissionsModeFromSettings(
+          approvalPolicy: 'on-request',
+          sandboxMode: 'workspace-write',
+        ),
+        CodexPermissionsMode.defaultPermissions,
+      );
+      expect(
+        codexPermissionsModeFromSettings(
+          approvalPolicy: 'on-request',
+          approvalsReviewer: 'auto_review',
+          sandboxMode: 'workspace-write',
+        ),
+        CodexPermissionsMode.autoReview,
+      );
+      expect(
+        codexPermissionsModeFromSettings(
+          approvalPolicy: 'never',
+          sandboxMode: 'danger-full-access',
+        ),
+        CodexPermissionsMode.fullAccess,
+      );
+    });
+
+    test('classifies read-only, mismatched, and unknown tuples as custom', () {
+      expect(
+        codexPermissionsModeFromSettings(
+          approvalPolicy: 'on-request',
+          sandboxMode: 'read-only',
+        ),
+        CodexPermissionsMode.custom,
+      );
+      expect(
+        codexPermissionsModeFromSettings(
+          approvalPolicy: 'never',
+          sandboxMode: 'workspace-write',
+        ),
+        CodexPermissionsMode.custom,
+      );
+      expect(
+        codexPermissionsModeFromSettings(
+          codexPermissionsMode: 'future-mode',
+          approvalPolicy: 'never',
+          sandboxMode: 'danger-full-access',
+        ),
+        CodexPermissionsMode.custom,
+      );
+    });
+
+    test(
+      'session parsers derive complete settings but not partial metadata',
+      () {
+        final complete = SessionInfo.fromJson({
+          'id': 'complete',
+          'provider': 'codex',
+          'projectPath': '/tmp/project',
+          'status': 'idle',
+          'createdAt': '',
+          'lastActivityAt': '',
+          'codexSettings': {
+            'approvalPolicy': 'on-request',
+            'sandboxMode': 'read-only',
+          },
+        });
+        final partial = SessionInfo.fromJson({
+          'id': 'partial',
+          'provider': 'codex',
+          'projectPath': '/tmp/project',
+          'status': 'idle',
+          'createdAt': '',
+          'lastActivityAt': '',
+          'codexSettings': {'approvalPolicy': 'on-request'},
+        });
+
+        expect(complete.codexPermissionsMode, 'custom');
+        expect(partial.codexPermissionsMode, isNull);
+      },
+    );
+
+    test('RecentSession follows the same complete and partial rules', () {
+      Map<String, dynamic> recentJson(
+        String id,
+        Map<String, dynamic> codexSettings,
+      ) => {
+        'sessionId': id,
+        'provider': 'codex',
+        'firstPrompt': 'resume',
+        'created': '2026-02-13T00:00:00Z',
+        'modified': '2026-02-13T00:00:00Z',
+        'gitBranch': 'main',
+        'projectPath': '/tmp/project',
+        'isSidechain': false,
+        'codexSettings': codexSettings,
+      };
+
+      final complete = RecentSession.fromJson(
+        recentJson('complete', {
+          'approvalPolicy': 'on-request',
+          'approvalsReviewer': 'auto_review',
+          'sandboxMode': 'workspace-write',
+        }),
+      );
+      final partial = RecentSession.fromJson(
+        recentJson('partial', {'approvalsReviewer': 'auto_review'}),
+      );
+
+      expect(complete.codexPermissionsMode, 'autoReview');
+      expect(partial.codexPermissionsMode, isNull);
+    });
+  });
+
   group('SystemMessage', () {
     test('parses Codex CLI join target', () {
       final msg = ServerMessage.fromJson({

--- a/packages/bridge/src/codex-permissions.test.ts
+++ b/packages/bridge/src/codex-permissions.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveCodexPermissionsMode,
+  withDerivedCodexPermissionsMode,
+} from "./codex-permissions.js";
+
+describe("deriveCodexPermissionsMode", () => {
+  it.each([
+    ["default", "on-request", "user", "workspace-write"],
+    ["default", "on-request", undefined, "workspace-write"],
+    ["autoReview", "on-request", "auto_review", "workspace-write"],
+    ["autoReview", "on-request", "guardian_subagent", "workspace-write"],
+    ["fullAccess", "never", "user", "danger-full-access"],
+  ] as const)(
+    "derives %s from a complete preset tuple",
+    (expected, approvalPolicy, approvalsReviewer, sandboxMode) => {
+      expect(deriveCodexPermissionsMode({
+        approvalPolicy,
+        approvalsReviewer,
+        sandboxMode,
+      })).toBe(expected);
+    },
+  );
+
+  it.each([
+    ["on-request", "user", "read-only"],
+    ["never", "user", "workspace-write"],
+    ["on-request", "future-reviewer", "workspace-write"],
+    ["future-policy", "user", "workspace-write"],
+    ["on-request", "user", "future-sandbox"],
+  ] as const)(
+    "classifies a complete non-preset tuple as custom",
+    (approvalPolicy, approvalsReviewer, sandboxMode) => {
+      expect(deriveCodexPermissionsMode({
+        approvalPolicy,
+        approvalsReviewer,
+        sandboxMode,
+      })).toBe("custom");
+    },
+  );
+
+  it.each([
+    { approvalPolicy: "on-request" },
+    { sandboxMode: "workspace-write" },
+    { approvalsReviewer: "auto_review" },
+    { model: "gpt" },
+  ])("does not invent a mode from partial or unrelated metadata", (settings) => {
+    expect(deriveCodexPermissionsMode(settings)).toBeUndefined();
+  });
+
+  it("prioritizes recognized explicit modes and contains unknown modes", () => {
+    expect(deriveCodexPermissionsMode({
+      codexPermissionsMode: "fullAccess",
+      approvalPolicy: "on-request",
+      sandboxMode: "read-only",
+    })).toBe("fullAccess");
+    expect(deriveCodexPermissionsMode({
+      codexPermissionsMode: "future-mode",
+      approvalPolicy: "never",
+      sandboxMode: "danger-full-access",
+    })).toBe("custom");
+  });
+
+  it("adds derived output without mutating raw settings", () => {
+    const raw = {
+      approvalPolicy: "on-request",
+      sandboxMode: "read-only",
+    };
+    expect(withDerivedCodexPermissionsMode(raw)).toEqual({
+      ...raw,
+      codexPermissionsMode: "custom",
+    });
+    expect(raw).not.toHaveProperty("codexPermissionsMode");
+  });
+});

--- a/packages/bridge/src/codex-permissions.ts
+++ b/packages/bridge/src/codex-permissions.ts
@@ -1,0 +1,91 @@
+import type { CodexPermissionsMode } from "./parser.js";
+
+export interface CodexPermissionSettings {
+  codexPermissionsMode?: string;
+  approvalPolicy?: string;
+  approvalsReviewer?: string;
+  sandboxMode?: string;
+}
+
+export function normalizeCodexPermissionsMode(
+  value?: string,
+): CodexPermissionsMode | undefined {
+  switch (value) {
+    case "default":
+    case "autoReview":
+    case "fullAccess":
+    case "custom":
+      return value;
+    default:
+      return undefined;
+  }
+}
+
+export function deriveCodexPermissionsMode(
+  settings?: CodexPermissionSettings,
+): CodexPermissionsMode | undefined {
+  if (!settings) return undefined;
+  const explicit = normalizeCodexPermissionsMode(
+    settings.codexPermissionsMode,
+  );
+  if (explicit) return explicit;
+  if (settings.codexPermissionsMode !== undefined) return "custom";
+
+  if (
+    settings.approvalPolicy === undefined ||
+    settings.sandboxMode === undefined
+  ) {
+    return undefined;
+  }
+
+  const sandboxMode = switchCodexSandboxMode(settings.sandboxMode);
+  if (
+    settings.approvalPolicy === "never" &&
+    sandboxMode === "danger-full-access"
+  ) {
+    return "fullAccess";
+  }
+  if (
+    settings.approvalPolicy === "on-request" &&
+    sandboxMode === "workspace-write"
+  ) {
+    if (
+      settings.approvalsReviewer === "auto_review" ||
+      settings.approvalsReviewer === "guardian_subagent"
+    ) {
+      return "autoReview";
+    }
+    if (
+      settings.approvalsReviewer === undefined ||
+      settings.approvalsReviewer === "user"
+    ) {
+      return "default";
+    }
+  }
+  return "custom";
+}
+
+function switchCodexSandboxMode(
+  value?: string,
+): "danger-full-access" | "workspace-write" | "read-only" | undefined {
+  switch (value) {
+    case "danger-full-access":
+    case "off":
+      return "danger-full-access";
+    case "workspace-write":
+    case "on":
+      return "workspace-write";
+    case "read-only":
+      return "read-only";
+    default:
+      return undefined;
+  }
+}
+
+export function withDerivedCodexPermissionsMode<T extends CodexPermissionSettings>(
+  settings: T | undefined,
+): T | undefined {
+  if (!settings) return undefined;
+  const mode = deriveCodexPermissionsMode(settings);
+  return mode ? { ...settings, codexPermissionsMode: mode } : settings;
+}

--- a/packages/bridge/src/session.test.ts
+++ b/packages/bridge/src/session.test.ts
@@ -147,6 +147,38 @@ describe("SessionManager codex path", () => {
 
     const session = manager.get(sessionId);
     expect(session?.provider).toBe("codex");
+    expect(manager.list()[0].codexSettings?.codexPermissionsMode).toBe(
+      "default",
+    );
+  });
+
+  it("re-derives permissions after incremental runtime settings", () => {
+    const manager = new SessionManager(() => {});
+    const sessionId = manager.create(
+      "/tmp/project-codex-permissions",
+      undefined,
+      undefined,
+      undefined,
+      "codex",
+      {
+        codexPermissionsMode: "default",
+        approvalPolicy: "on-request",
+        sandboxMode: "workspace-write",
+      },
+    );
+
+    codexInstances[0].emit("message", {
+      type: "system",
+      subtype: "init",
+      approvalPolicy: "on-request",
+      sandboxMode: "read-only",
+    });
+
+    expect(manager.get(sessionId)?.codexSettings?.codexPermissionsMode)
+      .toBeUndefined();
+    expect(manager.list()[0].codexSettings?.codexPermissionsMode).toBe(
+      "custom",
+    );
   });
 
   it("caches codex plugin completion metadata", () => {

--- a/packages/bridge/src/session.ts
+++ b/packages/bridge/src/session.ts
@@ -27,6 +27,7 @@ import type {
 } from "./parser.js";
 import type { ImageRef, ImageStore } from "./image-store.js";
 import type { GalleryStore, GalleryImageMeta } from "./gallery-store.js";
+import { withDerivedCodexPermissionsMode } from "./codex-permissions.js";
 import { createWorktree, worktreeExists } from "./worktree.js";
 import type { WorktreeStore } from "./worktree-store.js";
 import {
@@ -173,8 +174,16 @@ function mergeCodexSettings(
   msg: Extract<ServerMessage, { type: "system" }>,
 ): SessionInfo["codexSettings"] {
   const model = sanitizeCodexModel(msg.model);
+  const hasRuntimePermissionUpdate =
+    msg.approvalPolicy !== undefined ||
+    msg.approvalsReviewer !== undefined ||
+    msg.sandboxMode !== undefined;
+  const currentSettings = { ...(current ?? {}) };
+  if (hasRuntimePermissionUpdate && msg.codexPermissionsMode === undefined) {
+    delete currentSettings.codexPermissionsMode;
+  }
   const next = {
-    ...(current ?? {}),
+    ...currentSettings,
     ...(msg.approvalPolicy !== undefined
       ? { approvalPolicy: msg.approvalPolicy }
       : {}),
@@ -723,6 +732,14 @@ export class SessionManager {
 
   list(): SessionSummary[] {
     return Array.from(this.sessions.values()).map((s) => {
+      const codexSettings = s.process instanceof CodexProcess
+        ? withDerivedCodexPermissionsMode(
+            s.codexSettings ??
+              (s.process.codexPermissionsMode
+                ? { codexPermissionsMode: s.process.codexPermissionsMode }
+                : undefined),
+          )
+        : s.codexSettings;
       const processWithPending = s.process as {
         getPendingPermission?: () =>
           | {
@@ -744,7 +761,7 @@ export class SessionManager {
               ? "acceptEdits"
               : "default"
           : s.process instanceof CodexProcess
-            ? (s.codexSettings?.approvalPolicy ?? s.process.approvalPolicy) ===
+            ? (codexSettings?.approvalPolicy ?? s.process.approvalPolicy) ===
               "never"
               ? "fullAccess"
               : "default"
@@ -774,7 +791,7 @@ export class SessionManager {
             : s.process instanceof CodexProcess
               ? s.process.collaborationMode === "plan"
                 ? "plan"
-                : (s.codexSettings?.approvalPolicy ??
+                : (codexSettings?.approvalPolicy ??
                     s.process.approvalPolicy) === "never"
                   ? "bypassPermissions"
                   : "acceptEdits"
@@ -782,7 +799,7 @@ export class SessionManager {
         executionMode,
         planMode,
         model: s.process instanceof SdkProcess ? s.process.model : undefined,
-        codexSettings: s.codexSettings,
+        codexSettings,
         agentNickname:
           s.process instanceof CodexProcess
             ? (s.process.agentNickname ?? undefined)

--- a/packages/bridge/src/websocket.test.ts
+++ b/packages/bridge/src/websocket.test.ts
@@ -4096,6 +4096,31 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     bridge.close();
   });
 
+  it("derives Codex permissions mode in session_created output", () => {
+    const bridge = new BridgeWebSocketServer({ server: httpServer });
+    const complete = (bridge as any).buildSessionCreatedMessage({
+      sessionId: "codex-read-only",
+      provider: "codex",
+      projectPath: "/tmp/project",
+      session: {
+        codexSettings: {
+          approvalPolicy: "on-request",
+          sandboxMode: "read-only",
+        },
+      },
+    });
+    const partial = (bridge as any).buildSessionCreatedMessage({
+      sessionId: "codex-partial",
+      provider: "codex",
+      projectPath: "/tmp/project",
+      session: { codexSettings: { approvalPolicy: "on-request" } },
+    });
+
+    expect(complete.codexPermissionsMode).toBe("custom");
+    expect(partial.codexPermissionsMode).toBeUndefined();
+    bridge.close();
+  });
+
   it("claude busy input is acked as queued and interrupts current turn", async () => {
     const bridge = new BridgeWebSocketServer({ server: httpServer });
     const ws = {

--- a/packages/bridge/src/websocket.ts
+++ b/packages/bridge/src/websocket.ts
@@ -99,6 +99,11 @@ import {
   resolvePlatformPath,
   resolvePlatformPathFrom,
 } from "./path-utils.js";
+import {
+  deriveCodexPermissionsMode,
+  normalizeCodexPermissionsMode,
+  withDerivedCodexPermissionsMode,
+} from "./codex-permissions.js";
 
 type SystemServerMessage = Extract<ServerMessage, { type: "system" }>;
 type InputClientMessage = Extract<ClientMessage, { type: "input" }>;
@@ -335,20 +340,6 @@ interface CodexPermissionSettings {
   sandboxMode?: CodexStartOptions["sandboxMode"];
 }
 
-function normalizeCodexPermissionsMode(
-  value?: string,
-): CodexPermissionsMode | undefined {
-  switch (value) {
-    case "default":
-    case "autoReview":
-    case "fullAccess":
-    case "custom":
-      return value;
-    default:
-      return undefined;
-  }
-}
-
 function sanitizeCodexModel(model: unknown): string | undefined {
   if (typeof model !== "string") return undefined;
   const normalized = model.trim();
@@ -384,26 +375,6 @@ function codexSettingsFromPermissionsMode(
     case "custom":
       return { codexPermissionsMode: mode };
   }
-}
-
-function inferCodexPermissionsMode(params: {
-  approvalPolicy?: string;
-  approvalsReviewer?: string;
-  sandboxMode?: string;
-}): CodexPermissionsMode | undefined {
-  const approvalPolicy = params.approvalPolicy;
-  const approvalsReviewer = params.approvalsReviewer ?? "user";
-  const sandboxMode = params.sandboxMode;
-  if (approvalPolicy === "never" && sandboxMode === "danger-full-access") {
-    return "fullAccess";
-  }
-  if (approvalPolicy === "on-request" && sandboxMode === "workspace-write") {
-    return approvalsReviewer === "auto_review" ||
-      approvalsReviewer === "guardian_subagent"
-      ? "autoReview"
-      : "default";
-  }
-  return undefined;
 }
 
 function errorMessageOf(err: unknown): string {
@@ -806,6 +777,9 @@ export class BridgeWebSocketServer {
       pluginMetadata,
       sourceSessionId,
     } = params;
+    const derivedCodexSettings = provider === "codex"
+      ? withDerivedCodexPermissionsMode(session?.codexSettings)
+      : session?.codexSettings;
 
     const msg: SystemServerMessage = {
       type: "system",
@@ -823,16 +797,16 @@ export class BridgeWebSocketServer {
               | "plan",
           }
         : {}),
-      ...((approvalsReviewer ?? session?.codexSettings?.approvalsReviewer)
+      ...((approvalsReviewer ?? derivedCodexSettings?.approvalsReviewer)
         ? {
             approvalsReviewer:
-              approvalsReviewer ?? session?.codexSettings?.approvalsReviewer,
+              approvalsReviewer ?? derivedCodexSettings?.approvalsReviewer,
           }
         : {}),
-      ...((codexPermissionsMode ?? session?.codexSettings?.codexPermissionsMode)
+      ...((codexPermissionsMode ?? derivedCodexSettings?.codexPermissionsMode)
         ? {
             codexPermissionsMode: (codexPermissionsMode ??
-              session?.codexSettings?.codexPermissionsMode) as
+              derivedCodexSettings?.codexPermissionsMode) as
               | "default"
               | "autoReview"
               | "fullAccess"
@@ -914,32 +888,32 @@ export class BridgeWebSocketServer {
       ...(sourceSessionId ? { sourceSessionId } : {}),
     };
 
-    if (provider === "codex" && session?.codexSettings) {
-      if (session.codexSettings.model !== undefined) {
-        msg.model = session.codexSettings.model;
+    if (provider === "codex" && derivedCodexSettings) {
+      if (derivedCodexSettings.model !== undefined) {
+        msg.model = derivedCodexSettings.model;
       }
-      if (session.codexSettings.approvalPolicy !== undefined) {
-        msg.approvalPolicy = session.codexSettings.approvalPolicy;
+      if (derivedCodexSettings.approvalPolicy !== undefined) {
+        msg.approvalPolicy = derivedCodexSettings.approvalPolicy;
       }
-      if (session.codexSettings.codexPermissionsMode !== undefined) {
-        msg.codexPermissionsMode = session.codexSettings.codexPermissionsMode as
+      if (derivedCodexSettings.codexPermissionsMode !== undefined) {
+        msg.codexPermissionsMode = derivedCodexSettings.codexPermissionsMode as
           | "default"
           | "autoReview"
           | "fullAccess"
           | "custom";
       }
-      if (session.codexSettings.modelReasoningEffort !== undefined) {
-        msg.modelReasoningEffort = session.codexSettings.modelReasoningEffort;
+      if (derivedCodexSettings.modelReasoningEffort !== undefined) {
+        msg.modelReasoningEffort = derivedCodexSettings.modelReasoningEffort;
       }
-      if (session.codexSettings.networkAccessEnabled !== undefined) {
-        msg.networkAccessEnabled = session.codexSettings.networkAccessEnabled;
+      if (derivedCodexSettings.networkAccessEnabled !== undefined) {
+        msg.networkAccessEnabled = derivedCodexSettings.networkAccessEnabled;
       }
-      if (session.codexSettings.webSearchMode !== undefined) {
-        msg.webSearchMode = session.codexSettings.webSearchMode;
+      if (derivedCodexSettings.webSearchMode !== undefined) {
+        msg.webSearchMode = derivedCodexSettings.webSearchMode;
       }
-      if (session.codexSettings.additionalWritableRoots !== undefined) {
+      if (derivedCodexSettings.additionalWritableRoots !== undefined) {
         msg.additionalWritableRoots =
-          session.codexSettings.additionalWritableRoots;
+          derivedCodexSettings.additionalWritableRoots;
       }
     }
 
@@ -2766,7 +2740,7 @@ export class BridgeWebSocketServer {
           const newPermissionsMode =
             codexPermissionSettings?.codexPermissionsMode ??
             (collaborationOnlyChange ? currentPermissionsMode : undefined) ??
-            inferCodexPermissionsMode({
+            deriveCodexPermissionsMode({
               approvalPolicy: newApproval,
               approvalsReviewer:
                 codexPermissionSettings?.approvalsReviewer ??


### PR DESCRIPTION
## Summary

- derive Codex permission display modes from complete runtime approval and sandbox settings
- keep canonical session settings raw and add the derived mode only at serialization boundaries
- keep Bridge and Flutter classification consistent for presets, partial metadata, read-only, and unknown values

This is the maintainer reimplementation of #144. The original proposal identified the display issue; this version avoids persisting inferred values that can become stale after runtime updates.

## Verification

- `npx tsc --noEmit -p packages/bridge/tsconfig.json`
- Bridge: 31 files / 727 tests passed
- Flutter: 1,242 tests passed, 4 skipped
- `dart analyze apps/mobile` (no issues)
- iOS simulator: Codex mock conversation rendered the `Default` permission chip and approval flow; DTD reported no runtime errors
- independent self-review: LGTM

Refs #144
