### PR TITLE
fix(app): handle IPv6 bridge endpoints consistently

### DIFF
--- a/apps/mobile/lib/features/claude_session/claude_session_screen.dart
+++ b/apps/mobile/lib/features/claude_session/claude_session_screen.dart
@@ -22,6 +22,7 @@ import '../../utils/composer_tokens.dart';
 import '../../services/notification_service.dart';
 import '../../theme/app_theme.dart';
 import '../../utils/diff_parser.dart';
+import '../../utils/network_endpoint.dart';
 import '../../utils/terminal_launcher.dart';
 import '../session_list/workspace_shell_screen.dart';
 import '../settings/state/settings_cubit.dart';
@@ -1558,14 +1559,15 @@ Future<void> _openInTerminal(BuildContext context, String? projectPath) async {
               .replaceFirst('wss://', 'https://'),
         )
       : null;
-  final host = uri?.host ?? '';
+  final host = normalizeHostInput(uri?.host ?? '');
 
   // Resolve SSH user from machine config
   String? sshUser;
   try {
     final machines = context.read<MachineManagerCubit>().state.machines;
     for (final item in machines) {
-      if (item.machine.host == host) {
+      if (canonicalHostIdentity(item.machine.host) ==
+          canonicalHostIdentity(host)) {
         sshUser = item.machine.sshUsername;
         break;
       }

--- a/apps/mobile/lib/features/codex_session/codex_session_screen.dart
+++ b/apps/mobile/lib/features/codex_session/codex_session_screen.dart
@@ -24,6 +24,7 @@ import '../../services/notification_service.dart';
 import '../../widgets/session_name_title.dart';
 import '../../widgets/workspace_pane_chrome.dart';
 import '../../utils/diff_parser.dart';
+import '../../utils/network_endpoint.dart';
 import '../../utils/terminal_launcher.dart';
 import '../settings/state/settings_cubit.dart';
 import '../../widgets/new_session_sheet.dart'
@@ -1606,14 +1607,15 @@ Future<void> _openInTerminal(BuildContext context, String? projectPath) async {
               .replaceFirst('wss://', 'https://'),
         )
       : null;
-  final host = uri?.host ?? '';
+  final host = normalizeHostInput(uri?.host ?? '');
 
   // Resolve SSH user from machine config
   String? sshUser;
   try {
     final machines = context.read<MachineManagerCubit>().state.machines;
     for (final item in machines) {
-      if (item.machine.host == host) {
+      if (canonicalHostIdentity(item.machine.host) ==
+          canonicalHostIdentity(host)) {
         sshUser = item.machine.sshUsername;
         break;
       }

--- a/apps/mobile/lib/features/session_list/session_list_screen.dart
+++ b/apps/mobile/lib/features/session_list/session_list_screen.dart
@@ -8,6 +8,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../l10n/app_localizations.dart';
+import '../../utils/network_endpoint.dart';
 import '../../utils/platform_helper.dart';
 
 import '../../models/messages.dart';
@@ -1716,7 +1717,10 @@ class _SessionListScreenState extends State<SessionListScreen>
     final port = uri.hasPort ? uri.port : 8765;
     for (final item in machines) {
       final machine = item.machine;
-      if (machine.host == uri.host && machine.port == port) return machine;
+      if (endpointIdentityKey(machine.host, machine.port) ==
+          endpointIdentityKey(uri.host, port)) {
+        return machine;
+      }
     }
     return null;
   }
@@ -1725,7 +1729,7 @@ class _SessionListScreenState extends State<SessionListScreen>
     final uri = _bridgeUri(url);
     if (uri == null || uri.host.isEmpty) return null;
     final port = uri.hasPort ? uri.port : 8765;
-    return '${uri.host}:$port';
+    return formatHostPort(uri.host, port);
   }
 
   Uri? _bridgeUri(String? url) {

--- a/apps/mobile/lib/features/session_list/widgets/machine_card.dart
+++ b/apps/mobile/lib/features/session_list/widgets/machine_card.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../../../constants/app_constants.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../models/machine.dart';
+import '../../../utils/network_endpoint.dart';
 import '../../../theme/app_theme.dart';
 
 /// Card widget for displaying a saved remote machine.
@@ -218,7 +219,7 @@ class _MetadataLine extends StatelessWidget {
 
     // Host:Port (if name is set, show host:port; otherwise show last connected)
     if (machine.name != null) {
-      parts.add(TextSpan(text: '${machine.host}:${machine.port}'));
+      parts.add(TextSpan(text: formatHostPort(machine.host, machine.port)));
     } else {
       // For auto-saved machines, show last connected time
       parts.add(TextSpan(text: _formatLastConnected(machine.lastConnected, l)));

--- a/apps/mobile/lib/features/session_list/widgets/machine_edit_sheet.dart
+++ b/apps/mobile/lib/features/session_list/widgets/machine_edit_sheet.dart
@@ -4,6 +4,7 @@ import '../../../l10n/app_localizations.dart';
 import '../../../models/machine.dart';
 import '../../../services/ssh_startup_service.dart';
 import '../../../theme/app_theme.dart';
+import '../../../utils/network_endpoint.dart';
 
 /// Bottom sheet for adding or editing a remote machine configuration.
 class MachineEditSheet extends StatefulWidget {
@@ -220,13 +221,13 @@ class _MachineEditSheetState extends State<MachineEditSheet> {
 
     try {
       final result = await widget.onTestConnection(
-        host: _hostController.text,
+        host: normalizeHostInput(_hostController.text),
         sshPort: int.tryParse(_sshPortController.text) ?? 22,
         username: _sshUsernameController.text,
         authType: _sshAuthType,
         jumpHost:
             _sshJumpEnabled && _sshJumpHostController.text.trim().isNotEmpty
-            ? _sshJumpHostController.text.trim()
+            ? normalizeHostInput(_sshJumpHostController.text)
             : null,
         jumpPort: int.tryParse(_sshJumpPortController.text) ?? 22,
         jumpUsername: _sshJumpUsernameController.text.trim().isNotEmpty
@@ -284,7 +285,7 @@ class _MachineEditSheetState extends State<MachineEditSheet> {
         name: _nameController.text.trim().isNotEmpty
             ? _nameController.text.trim()
             : null,
-        host: _hostController.text.trim(),
+        host: normalizeHostInput(_hostController.text),
         port: int.tryParse(_portController.text) ?? 8765,
         useSsl: _useSsl,
         sshEnabled: _sshEnabled,
@@ -295,7 +296,7 @@ class _MachineEditSheetState extends State<MachineEditSheet> {
             _sshEnabled &&
                 _sshJumpEnabled &&
                 _sshJumpHostController.text.trim().isNotEmpty
-            ? _sshJumpHostController.text.trim()
+            ? normalizeHostInput(_sshJumpHostController.text)
             : null,
         sshJumpPort: int.tryParse(_sshJumpPortController.text) ?? 22,
         sshJumpUsername:

--- a/apps/mobile/lib/features/settings/widgets/prompt_history_section.dart
+++ b/apps/mobile/lib/features/settings/widgets/prompt_history_section.dart
@@ -4,6 +4,7 @@ import '../../../l10n/app_localizations.dart';
 import '../../../services/bridge_service.dart';
 import '../../../services/machine_manager_service.dart';
 import '../../../services/prompt_history_service.dart';
+import '../../../utils/network_endpoint.dart';
 
 class PromptHistorySection extends StatefulWidget {
   final BridgeService bridgeService;
@@ -439,8 +440,9 @@ class _StatusTile extends StatelessWidget {
 String? _endpointFromUrl(String url) {
   final uri = Uri.tryParse(url);
   if (uri == null || uri.host.isEmpty) return url.isEmpty ? null : url;
-  final port = uri.hasPort ? ':${uri.port}' : '';
-  return '${uri.host}$port';
+  return uri.hasPort
+      ? formatHostPort(uri.host, uri.port)
+      : bracketIpv6Host(uri.host);
 }
 
 bool _isBridgeIdLike(String value, String bridgeId) {

--- a/apps/mobile/lib/models/machine.dart
+++ b/apps/mobile/lib/models/machine.dart
@@ -1,5 +1,7 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
+import '../utils/network_endpoint.dart';
+
 part 'machine.freezed.dart';
 part 'machine.g.dart';
 
@@ -142,16 +144,21 @@ abstract class Machine with _$Machine {
       _$MachineFromJson(json);
 
   /// Display name (name if set, otherwise host:port)
-  String get displayName => name ?? '$host:$port';
+  String get displayName => name ?? formatHostPort(host, port);
 
   /// WebSocket URL for this machine
-  String get wsUrl => '${useSsl ? 'wss' : 'ws'}://$host:$port';
+  String get wsUrl =>
+      formatUriOrigin(scheme: useSsl ? 'wss' : 'ws', host: host, port: port);
 
   /// HTTP base URL for health checks
-  String get httpUrl => '${useSsl ? 'https' : 'http'}://$host:$port';
+  String get httpUrl => formatUriOrigin(
+    scheme: useSsl ? 'https' : 'http',
+    host: host,
+    port: port,
+  );
 
   /// Unique key for deduplication (host:port)
-  String get uniqueKey => '$host:$port';
+  String get uniqueKey => endpointIdentityKey(host, port);
 
   /// Whether this machine can be started remotely (SSH configured)
   bool get canStartRemotely => sshEnabled && sshUsername != null;

--- a/apps/mobile/lib/services/bridge_service.dart
+++ b/apps/mobile/lib/services/bridge_service.dart
@@ -11,6 +11,7 @@ import '../core/logger.dart';
 import '../models/messages.dart';
 import '../models/offline_pending_action.dart';
 import '../utils/codex_plan_update.dart';
+import '../utils/network_endpoint.dart';
 import 'bridge_service_base.dart';
 import 'session_runtime_store.dart';
 
@@ -309,8 +310,11 @@ class BridgeService implements BridgeServiceBase {
     final uri = Uri.tryParse(url);
     if (uri == null) return null;
     final scheme = uri.scheme == 'wss' ? 'https' : 'http';
-    final port = uri.hasPort ? ':${uri.port}' : '';
-    return '$scheme://${uri.host}$port';
+    return formatUriOrigin(
+      scheme: scheme,
+      host: uri.host,
+      port: uri.hasPort ? uri.port : null,
+    );
   }
 
   static const _prefKeyUrl = 'bridge_url';
@@ -643,10 +647,10 @@ class BridgeService implements BridgeServiceBase {
 
   String _bridgeTargetKey(Uri uri) {
     final scheme = uri.scheme.toLowerCase();
-    final host = uri.host.toLowerCase();
+    final host = canonicalHostIdentity(uri.host);
     final port = uri.hasPort ? uri.port : (scheme == 'wss' ? 443 : 80);
     final path = uri.path.isEmpty ? '/' : uri.path;
-    return '$scheme://$host:$port$path';
+    return '${formatUriOrigin(scheme: scheme, host: host, port: port)}$path';
   }
 
   void _clearBridgeScopedState({required bool clearOfflineQueue}) {
@@ -2146,8 +2150,8 @@ class BridgeService implements BridgeServiceBase {
       final uri = Uri.tryParse(wsUrl);
       if (uri == null) return null;
       final scheme = uri.scheme == 'wss' ? 'https' : 'http';
-      final port = uri.hasPort ? ':${uri.port}' : '';
-      final healthUrl = '$scheme://${uri.host}$port/health';
+      final healthUrl =
+          '${formatUriOrigin(scheme: scheme, host: uri.host, port: uri.hasPort ? uri.port : null)}/health';
       final response = await http
           .get(Uri.parse(healthUrl))
           .timeout(const Duration(seconds: 3));

--- a/apps/mobile/lib/services/connection_url_parser.dart
+++ b/apps/mobile/lib/services/connection_url_parser.dart
@@ -42,7 +42,7 @@ class ConnectionUrlParser {
       // ccpocket://connect?url=...&token=...
       if (uri.host == 'connect') {
         final url = uri.queryParameters['url'];
-        if (url == null || url.isEmpty) return null;
+        if (url == null || !_isValidWebSocketUrl(url)) return null;
         final token = uri.queryParameters['token'];
         return ConnectionParams(
           serverUrl: url,
@@ -55,15 +55,43 @@ class ConnectionUrlParser {
 
     // Direct ws:// or wss://
     if (trimmed.startsWith('ws://') || trimmed.startsWith('wss://')) {
-      return ConnectionParams(serverUrl: trimmed);
+      return _isValidWebSocketUrl(trimmed)
+          ? ConnectionParams(serverUrl: trimmed)
+          : null;
     }
 
     // Bare host:port
     final hostPortPattern = RegExp(r'^[\w.\-]+:\d+$');
+    final bracketedIpv6PortPattern = RegExp(r'^\[[^\]]*:[^\]]*\]:\d+$');
     if (hostPortPattern.hasMatch(trimmed)) {
       return ConnectionParams(serverUrl: 'ws://$trimmed');
     }
+    if (bracketedIpv6PortPattern.hasMatch(trimmed)) {
+      try {
+        final uri = Uri.parse('ws://$trimmed');
+        if (uri.host.contains(':') &&
+            uri.hasPort &&
+            uri.port > 0 &&
+            uri.port <= 65535) {
+          return ConnectionParams(serverUrl: 'ws://$trimmed');
+        }
+      } on FormatException {
+        return null;
+      }
+    }
 
     return null;
+  }
+
+  static bool _isValidWebSocketUrl(String value) {
+    try {
+      final uri = Uri.parse(value);
+      if ((uri.scheme != 'ws' && uri.scheme != 'wss') || uri.host.isEmpty) {
+        return false;
+      }
+      return !uri.hasPort || (uri.port > 0 && uri.port <= 65535);
+    } on FormatException {
+      return false;
+    }
   }
 }

--- a/apps/mobile/lib/services/machine_manager_service.dart
+++ b/apps/mobile/lib/services/machine_manager_service.dart
@@ -10,6 +10,7 @@ import 'package:uuid/uuid.dart';
 
 import '../constants/app_constants.dart';
 import '../models/machine.dart';
+import '../utils/network_endpoint.dart';
 
 typedef BridgeWsUrlResolver =
     Future<String> Function(
@@ -88,7 +89,7 @@ class MachineManagerService {
   /// Initialize service, migrate if needed, and load machines
   Future<void> init() async {
     await _migrateIfNeeded();
-    _machines = _loadFromPrefs();
+    _machines = await _loadFromPrefs();
     _sortMachines();
     _notifyListeners();
     // Start health check after loading
@@ -110,9 +111,9 @@ class MachineManagerService {
         final list = jsonDecode(oldMachinesRaw) as List;
         for (final e in list) {
           final old = e as Map<String, dynamic>;
-          final host = old['host'] as String;
+          final host = normalizeHostInput(old['host'] as String);
           final port = old['port'] as int? ?? 8765;
-          final key = '$host:$port';
+          final key = endpointIdentityKey(host, port);
 
           if (seenKeys.add(key)) {
             machines.add(
@@ -154,10 +155,10 @@ class MachineManagerService {
           final uri = Uri.tryParse(url);
           if (uri == null) continue;
 
-          final host = uri.host;
+          final host = normalizeHostInput(uri.host);
           final port = uri.hasPort ? uri.port : 8765;
           final useSsl = uri.scheme == 'wss' || uri.scheme == 'https';
-          final key = '$host:$port';
+          final key = endpointIdentityKey(host, port);
 
           if (seenKeys.add(key)) {
             // Migrate API key to secure storage
@@ -211,18 +212,90 @@ class MachineManagerService {
   }
 
   /// Load machines from SharedPreferences
-  List<Machine> _loadFromPrefs() {
+  Future<List<Machine>> _loadFromPrefs() async {
     final raw = _prefs.getString(_prefsKey);
     if (raw == null || raw.isEmpty) return [];
     try {
       final list = jsonDecode(raw) as List;
-      return list
-          .map((e) => Machine.fromJson(e as Map<String, dynamic>))
-          .toList();
+      final machinesByEndpoint = <String, List<Machine>>{};
+      for (final entry in list) {
+        final parsed = Machine.fromJson(entry as Map<String, dynamic>);
+        final machine = parsed.copyWith(
+          host: normalizeHostInput(parsed.host),
+          sshJumpHost: parsed.sshJumpHost == null
+              ? null
+              : normalizeHostInput(parsed.sshJumpHost!),
+        );
+        machinesByEndpoint
+            .putIfAbsent(machine.uniqueKey, () => [])
+            .add(machine);
+      }
+      final result = <Machine>[];
+      for (final machines in machinesByEndpoint.values) {
+        result.add(await _mergeStoredMachines(machines));
+      }
+      return result;
     } catch (e) {
       logger.error('[MachineManager] Failed to load machines', e);
       return [];
     }
+  }
+
+  Future<Machine> _mergeStoredMachines(List<Machine> machines) async {
+    var winner = machines.first;
+    for (final candidate in machines.skip(1)) {
+      if (_preferStoredMachine(candidate, winner)) winner = candidate;
+    }
+    if (machines.length == 1) return winner;
+
+    try {
+      String? apiKey = await getApiKey(winner.id);
+      String? sshPassword = await getSshPassword(winner.id);
+      String? sshPrivateKey = await getSshPrivateKey(winner.id);
+      String? sshJumpPassword = await getSshJumpPassword(winner.id);
+      String? sshJumpPrivateKey = await getSshJumpPrivateKey(winner.id);
+      for (final machine in machines) {
+        if (machine.id == winner.id) continue;
+        apiKey ??= await getApiKey(machine.id);
+        sshPassword ??= await getSshPassword(machine.id);
+        sshPrivateKey ??= await getSshPrivateKey(machine.id);
+        sshJumpPassword ??= await getSshJumpPassword(machine.id);
+        sshJumpPrivateKey ??= await getSshJumpPrivateKey(machine.id);
+      }
+
+      await _saveCredentials(
+        winner.id,
+        apiKey: apiKey,
+        sshPassword: sshPassword,
+        sshPrivateKey: sshPrivateKey,
+        sshJumpPassword: sshJumpPassword,
+        sshJumpPrivateKey: sshJumpPrivateKey,
+      );
+      for (final machine in machines) {
+        if (machine.id != winner.id) await _deleteCredentials(machine.id);
+      }
+      return winner.copyWith(
+        hasApiKey: apiKey != null && apiKey.isNotEmpty,
+        hasCredentials:
+            (sshPassword != null && sshPassword.isNotEmpty) ||
+            (sshPrivateKey != null && sshPrivateKey.isNotEmpty),
+        hasJumpCredentials:
+            (sshJumpPassword != null && sshJumpPassword.isNotEmpty) ||
+            (sshJumpPrivateKey != null && sshJumpPrivateKey.isNotEmpty),
+      );
+    } catch (error) {
+      logger.error(
+        '[MachineManager] Failed to merge duplicate credentials',
+        error,
+      );
+      return winner;
+    }
+  }
+
+  bool _preferStoredMachine(Machine candidate, Machine current) {
+    if (candidate.isFavorite != current.isFavorite) return candidate.isFavorite;
+    return (candidate.lastConnected?.millisecondsSinceEpoch ?? 0) >
+        (current.lastConnected?.millisecondsSinceEpoch ?? 0);
   }
 
   /// Save machines to SharedPreferences
@@ -284,8 +357,12 @@ class MachineManagerService {
 
   /// Find machine by host:port (unique key)
   Machine? findByHostPort(String host, int port) {
+    final normalizedHost = normalizeHostInput(host);
+    final identity = endpointIdentityKey(normalizedHost, port);
     try {
-      return _machines.firstWhere((m) => m.host == host && m.port == port);
+      return _machines.firstWhere(
+        (m) => endpointIdentityKey(m.host, m.port) == identity,
+      );
     } catch (_) {
       return null;
     }
@@ -311,11 +388,13 @@ class MachineManagerService {
     String? name,
     bool? useSsl,
   }) async {
-    var machine = findByHostPort(host, port);
+    final normalizedHost = normalizeHostInput(host);
+    var machine = findByHostPort(normalizedHost, port);
 
     if (machine != null) {
       // Update existing machine
       machine = machine.copyWith(
+        host: normalizedHost,
         lastConnected: DateTime.now(),
         name: name ?? machine.name,
         useSsl: useSsl ?? machine.useSsl,
@@ -328,7 +407,7 @@ class MachineManagerService {
       // Create new machine
       machine = Machine(
         id: _uuid.v4(),
-        host: host,
+        host: normalizedHost,
         port: port,
         name: name,
         useSsl: useSsl ?? false,
@@ -372,7 +451,7 @@ class MachineManagerService {
     return Machine(
       id: _uuid.v4(),
       name: name,
-      host: host,
+      host: normalizeHostInput(host),
       port: port,
       useSsl: useSsl,
     );
@@ -387,20 +466,30 @@ class MachineManagerService {
     String? sshJumpPassword,
     String? sshJumpPrivateKey,
   }) async {
+    final normalizedMachine = machine.copyWith(
+      host: normalizeHostInput(machine.host),
+      sshJumpHost: machine.sshJumpHost == null
+          ? null
+          : normalizeHostInput(machine.sshJumpHost!),
+    );
     // Check if machine with same host:port already exists
     final existingIndex = _machines.indexWhere(
-      (m) => m.host == machine.host && m.port == machine.port,
+      (m) => endpointIdentityKey(m.host, m.port) == normalizedMachine.uniqueKey,
     );
+    final existing = existingIndex == -1 ? null : _machines[existingIndex];
+    final storedMachine = existing == null
+        ? normalizedMachine
+        : normalizedMachine.copyWith(id: existing.id);
     if (existingIndex != -1) {
       // Update existing machine
-      _machines[existingIndex] = machine;
+      _machines[existingIndex] = storedMachine;
     } else {
-      _machines.add(machine);
+      _machines.add(storedMachine);
     }
 
     // Save credentials securely
     await _saveCredentials(
-      machine.id,
+      storedMachine.id,
       apiKey: apiKey,
       sshPassword: sshPassword,
       sshPrivateKey: sshPrivateKey,
@@ -409,22 +498,25 @@ class MachineManagerService {
     );
 
     // Update hasApiKey and hasCredentials flags
-    final hasApiKey = apiKey != null && apiKey.isNotEmpty;
+    final hasApiKey =
+        (apiKey != null && apiKey.isNotEmpty) || (existing?.hasApiKey ?? false);
     final hasCredentials =
         (sshPassword != null && sshPassword.isNotEmpty) ||
-        (sshPrivateKey != null && sshPrivateKey.isNotEmpty);
+        (sshPrivateKey != null && sshPrivateKey.isNotEmpty) ||
+        (existing?.hasCredentials ?? false);
     final hasJumpCredentials =
         (sshJumpPassword != null && sshJumpPassword.isNotEmpty) ||
-        (sshJumpPrivateKey != null && sshJumpPrivateKey.isNotEmpty);
+        (sshJumpPrivateKey != null && sshJumpPrivateKey.isNotEmpty) ||
+        (existing?.hasJumpCredentials ?? false);
 
     if (existingIndex != -1) {
-      _machines[existingIndex] = machine.copyWith(
+      _machines[existingIndex] = storedMachine.copyWith(
         hasApiKey: hasApiKey,
         hasCredentials: hasCredentials,
         hasJumpCredentials: hasJumpCredentials,
       );
     } else {
-      _machines[_machines.length - 1] = machine.copyWith(
+      _machines[_machines.length - 1] = storedMachine.copyWith(
         hasApiKey: hasApiKey,
         hasCredentials: hasCredentials,
         hasJumpCredentials: hasJumpCredentials,
@@ -436,7 +528,7 @@ class MachineManagerService {
     _notifyListeners();
 
     // Check health for the new/updated machine
-    await checkHealth(machine.id);
+    await checkHealth(storedMachine.id);
   }
 
   /// Update an existing machine
@@ -453,6 +545,12 @@ class MachineManagerService {
   }) async {
     final index = _machines.indexWhere((m) => m.id == machine.id);
     if (index == -1) return;
+    final normalizedMachine = machine.copyWith(
+      host: normalizeHostInput(machine.host),
+      sshJumpHost: machine.sshJumpHost == null
+          ? null
+          : normalizeHostInput(machine.sshJumpHost!),
+    );
 
     // Handle credential updates
     if (clearApiKey) {
@@ -513,7 +611,7 @@ class MachineManagerService {
     final existingJumpPassword = await getSshJumpPassword(machine.id);
     final existingJumpKey = await getSshJumpPrivateKey(machine.id);
 
-    _machines[index] = machine.copyWith(
+    _machines[index] = normalizedMachine.copyWith(
       hasApiKey: existingApiKey != null && existingApiKey.isNotEmpty,
       hasCredentials:
           (existingPassword != null && existingPassword.isNotEmpty) ||

--- a/apps/mobile/lib/services/prompt_history_service.dart
+++ b/apps/mobile/lib/services/prompt_history_service.dart
@@ -11,6 +11,7 @@ import '../core/logger.dart';
 import '../models/machine.dart';
 import '../models/messages.dart';
 import '../utils/command_parser.dart';
+import '../utils/network_endpoint.dart';
 import 'bridge_service.dart';
 import 'database_service.dart';
 import 'machine_manager_service.dart';
@@ -329,9 +330,13 @@ class PromptHistoryService {
   String? bridgeIdForUrl(String? url) {
     if (url == null || url.isEmpty) return null;
     final uri = Uri.tryParse(url);
-    if (uri == null) return null;
-    final port = uri.hasPort ? ':${uri.port}' : '';
-    return '${uri.host}$port';
+    if (uri == null || uri.host.isEmpty) return null;
+    final port = uri.hasPort
+        ? uri.port
+        : uri.scheme.toLowerCase() == 'wss'
+        ? 443
+        : 80;
+    return endpointIdentityKey(uri.host, port);
   }
 
   // ---------------------------------------------------------------------------

--- a/apps/mobile/lib/services/server_discovery_service.dart
+++ b/apps/mobile/lib/services/server_discovery_service.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import '../core/logger.dart';
+import '../utils/network_endpoint.dart';
 
 import 'server_discovery_impl_stub.dart'
     if (dart.library.io) 'server_discovery_impl_io.dart'
@@ -19,14 +20,16 @@ class DiscoveredServer {
     required this.authRequired,
   });
 
-  String get wsUrl => 'ws://$host:$port';
+  String get wsUrl => formatUriOrigin(scheme: 'ws', host: host, port: port);
 
   @override
   bool operator ==(Object other) =>
-      other is DiscoveredServer && host == other.host && port == other.port;
+      other is DiscoveredServer &&
+      endpointIdentityKey(host, port) ==
+          endpointIdentityKey(other.host, other.port);
 
   @override
-  int get hashCode => Object.hash(host, port);
+  int get hashCode => endpointIdentityKey(host, port).hashCode;
 }
 
 class ServerDiscoveryService {
@@ -48,11 +51,11 @@ class ServerDiscoveryService {
             port: port,
             authRequired: authRequired,
           );
-          _servers['$host:$port'] = server;
+          _servers[endpointIdentityKey(host, port)] = server;
           _emit();
         },
         onLost: (host, port) {
-          _servers.remove('$host:$port');
+          _servers.remove(endpointIdentityKey(host, port));
           _emit();
         },
       );

--- a/apps/mobile/lib/utils/network_endpoint.dart
+++ b/apps/mobile/lib/utils/network_endpoint.dart
@@ -1,0 +1,122 @@
+String normalizeHostInput(String host) {
+  var normalized = host.trim();
+  if (normalized.startsWith('[') && normalized.endsWith(']')) {
+    normalized = normalized.substring(1, normalized.length - 1).trim();
+  }
+  if (normalized.contains(':')) {
+    normalized = normalized.replaceFirst(
+      RegExp('%25', caseSensitive: false),
+      '%',
+    );
+  }
+  return normalized;
+}
+
+String bracketIpv6Host(String host) {
+  final normalized = normalizeHostInput(host);
+  if (normalized.isEmpty || !normalized.contains(':')) return normalized;
+  return '[$normalized]';
+}
+
+String canonicalHostIdentity(String host) {
+  final normalized = normalizeHostInput(host);
+  if (!normalized.contains(':')) return normalized.toLowerCase();
+
+  final zoneIndex = normalized.indexOf('%');
+  final address = zoneIndex == -1
+      ? normalized
+      : normalized.substring(0, zoneIndex);
+  final zone = zoneIndex == -1 ? '' : normalized.substring(zoneIndex);
+  return '${_canonicalIpv6Address(address) ?? address.toLowerCase()}$zone';
+}
+
+String? _canonicalIpv6Address(String address) {
+  if (address.indexOf('::') != address.lastIndexOf('::')) return null;
+  final halves = address.split('::');
+  final left = _parseIpv6Parts(halves.first);
+  final right = halves.length == 1 ? <int>[] : _parseIpv6Parts(halves.last);
+  if (left == null || right == null) return null;
+
+  final hasCompression = halves.length == 2;
+  final missing = 8 - left.length - right.length;
+  if ((!hasCompression && missing != 0) || (hasCompression && missing < 1)) {
+    return null;
+  }
+  final words = <int>[...left, ...List.filled(missing, 0), ...right];
+  if (words.length != 8) return null;
+
+  var bestStart = -1;
+  var bestLength = 0;
+  for (var index = 0; index < words.length;) {
+    if (words[index] != 0) {
+      index++;
+      continue;
+    }
+    final start = index;
+    while (index < words.length && words[index] == 0) {
+      index++;
+    }
+    final length = index - start;
+    if (length >= 2 && length > bestLength) {
+      bestStart = start;
+      bestLength = length;
+    }
+  }
+
+  if (bestStart == -1) {
+    return words.map((word) => word.toRadixString(16)).join(':');
+  }
+  final before = words
+      .take(bestStart)
+      .map((word) => word.toRadixString(16))
+      .join(':');
+  final after = words
+      .skip(bestStart + bestLength)
+      .map((word) => word.toRadixString(16))
+      .join(':');
+  if (before.isEmpty && after.isEmpty) return '::';
+  if (before.isEmpty) return '::$after';
+  if (after.isEmpty) return '$before::';
+  return '$before::$after';
+}
+
+List<int>? _parseIpv6Parts(String input) {
+  if (input.isEmpty) return <int>[];
+  final parts = input.split(':');
+  final words = <int>[];
+  for (var index = 0; index < parts.length; index++) {
+    final part = parts[index];
+    if (part.isEmpty) return null;
+    if (part.contains('.')) {
+      if (index != parts.length - 1) return null;
+      final octets = part.split('.').map(int.tryParse).toList();
+      if (octets.length != 4 ||
+          octets.any((octet) => octet == null || octet < 0 || octet > 255)) {
+        return null;
+      }
+      words.add((octets[0]! << 8) | octets[1]!);
+      words.add((octets[2]! << 8) | octets[3]!);
+      continue;
+    }
+    if (part.length > 4) return null;
+    final word = int.tryParse(part, radix: 16);
+    if (word == null) return null;
+    words.add(word);
+  }
+  return words;
+}
+
+String formatHostPort(String host, int port) =>
+    '${bracketIpv6Host(host)}:$port';
+
+String endpointIdentityKey(String host, int port) =>
+    formatHostPort(canonicalHostIdentity(host), port);
+
+String formatUriOrigin({
+  required String scheme,
+  required String host,
+  int? port,
+}) {
+  final origin = Uri(scheme: scheme, host: normalizeHostInput(host)).toString();
+  return port == null ? origin : '$origin:$port';
+}

--- a/apps/mobile/test/connection_url_parser_test.dart
+++ b/apps/mobile/test/connection_url_parser_test.dart
@@ -40,6 +40,14 @@ void main() {
         expect(result, isNotNull);
         expect(result!.serverUrl, 'ws://192.168.1.1:8765/ws');
       });
+
+      test('rejects invalid direct IPv6 URLs and ports', () {
+        expect(
+          ConnectionUrlParser.parse('ws://[not-ipv6:address]:8765'),
+          isNull,
+        );
+        expect(ConnectionUrlParser.parse('wss://[::1]:65536'), isNull);
+      });
     });
 
     group('bare host:port', () {
@@ -74,6 +82,21 @@ void main() {
 
         expect(result, isNotNull);
         expect(result!.serverUrl, 'ws://localhost:8765');
+      });
+
+      test('parses bracketed IPv6 host:port', () {
+        final result =
+            ConnectionUrlParser.parse('[fe80::1%25en0]:19000')
+                as ConnectionParams?;
+
+        expect(result, isNotNull);
+        expect(result!.serverUrl, 'ws://[fe80::1%25en0]:19000');
+      });
+
+      test('rejects malformed bracketed IPv6 and invalid ports', () {
+        expect(ConnectionUrlParser.parse('[not-ipv6:address]:8765'), isNull);
+        expect(ConnectionUrlParser.parse('[::1]:0'), isNull);
+        expect(ConnectionUrlParser.parse('[::1]:65536'), isNull);
       });
     });
 
@@ -125,6 +148,16 @@ void main() {
 
         expect(result, isNotNull);
         expect(result!.token, isNull);
+      });
+
+      test('rejects an invalid websocket URL in a deep link', () {
+        final encoded = Uri.encodeQueryComponent(
+          'ws://[not-ipv6:address]:8765',
+        );
+        expect(
+          ConnectionUrlParser.parse('ccpocket://connect?url=$encoded'),
+          isNull,
+        );
       });
     });
 

--- a/apps/mobile/test/machine_edit_sheet_test.dart
+++ b/apps/mobile/test/machine_edit_sheet_test.dart
@@ -401,6 +401,47 @@ void main() {
       expect(call!.jumpPassword, 'jump-pw');
     });
 
+    testWidgets('normalizes IPv6 hosts for SSH test and save', (tester) async {
+      _TestConnectionCall? call;
+      Machine? savedMachine;
+
+      await pumpSheet(
+        tester,
+        machine: const Machine(
+          id: 'm-ipv6',
+          host: '[fe80::1%25en0]',
+          sshEnabled: true,
+          sshUsername: 'target-user',
+          sshJumpHost: '[fe80::2%25en0]',
+          sshJumpUsername: 'jump-user',
+        ),
+        existingSshPassword: 'target-pw',
+        existingSshJumpPassword: 'jump-pw',
+        onTestConnectionCall: (value) => call = value,
+        onSave:
+            ({
+              required machine,
+              apiKey,
+              sshPassword,
+              sshPrivateKey,
+              sshJumpPassword,
+              sshJumpPrivateKey,
+            }) async {
+              savedMachine = machine;
+            },
+      );
+
+      await tester.tap(find.text('Test Connection'));
+      await tester.pumpAndSettle();
+      expect(call?.host, 'fe80::1%en0');
+      expect(call?.jumpHost, 'fe80::2%en0');
+
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+      expect(savedMachine?.host, 'fe80::1%en0');
+      expect(savedMachine?.sshJumpHost, 'fe80::2%en0');
+    });
+
     testWidgets('replaces saved SSH jump host password only when entered', (
       tester,
     ) async {

--- a/apps/mobile/test/machine_manager_ipv6_test.dart
+++ b/apps/mobile/test/machine_manager_ipv6_test.dart
@@ -1,0 +1,182 @@
+import 'dart:convert';
+
+import 'package:ccpocket/models/machine.dart';
+import 'package:ccpocket/services/machine_manager_service.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _FakeSecureStorage implements FlutterSecureStorage {
+  final values = <String, String>{};
+
+  @override
+  Future<void> write({
+    required String key,
+    required String? value,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    if (value == null) {
+      values.remove(key);
+    } else {
+      values[key] = value;
+    }
+  }
+
+  @override
+  Future<String?> read({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async => values[key];
+
+  @override
+  Future<void> delete({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    values.remove(key);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  Future<MachineManagerService> createManager([
+    _FakeSecureStorage? secureStorage,
+  ]) async {
+    final prefs = await SharedPreferences.getInstance();
+    final manager = MachineManagerService(
+      prefs,
+      secureStorage ?? _FakeSecureStorage(),
+    );
+    manager.configureBridgeTunnelResolvers(
+      httpBaseUrlResolver: (machine, {password, promptForPassword}) async =>
+          'http://127.0.0.1:1',
+    );
+    return manager;
+  }
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test(
+    'recordConnection deduplicates bracket and zone escape variants',
+    () async {
+      final manager = await createManager();
+
+      await manager.recordConnection(host: '[fe80::1%25en0]', port: 8765);
+      await manager.recordConnection(host: 'fe80::1%en0', port: 8765);
+
+      expect(manager.currentMachines, hasLength(1));
+      expect(manager.currentMachines.single.host, 'fe80::1%en0');
+      manager.dispose();
+    },
+  );
+
+  test(
+    'init normalizes bracketed saved hosts without changing machine id',
+    () async {
+      const saved = Machine(
+        id: 'saved-ipv6',
+        host: '[::1]',
+        sshJumpHost: '[fe80::2%25en0]',
+      );
+      SharedPreferences.setMockInitialValues({
+        'machines_v2': jsonEncode([saved.toJson()]),
+      });
+      final manager = await createManager();
+
+      await manager.init();
+
+      expect(manager.currentMachines.single.id, 'saved-ipv6');
+      expect(manager.currentMachines.single.host, '::1');
+      expect(manager.currentMachines.single.sshJumpHost, 'fe80::2%en0');
+      expect(manager.findByHostPort('[::1]', 8765)?.id, 'saved-ipv6');
+      manager.dispose();
+    },
+  );
+
+  test(
+    'init merges duplicate credentials into the preferred machine id',
+    () async {
+      const favorite = Machine(id: 'favorite', host: '[::1]', isFavorite: true);
+      const apiOwner = Machine(
+        id: 'api-owner',
+        host: '0:0:0:0:0:0:0:1',
+        hasApiKey: true,
+      );
+      const sshOwner = Machine(
+        id: 'ssh-owner',
+        host: '::1',
+        hasCredentials: true,
+        hasJumpCredentials: true,
+      );
+      SharedPreferences.setMockInitialValues({
+        'machines_v2': jsonEncode([
+          favorite.toJson(),
+          apiOwner.toJson(),
+          sshOwner.toJson(),
+        ]),
+      });
+      final storage = _FakeSecureStorage()
+        ..values['machine_api-owner_api'] = 'secret'
+        ..values['machine_ssh-owner_ssh_key'] = 'private-key'
+        ..values['machine_ssh-owner_jump_ssh_pass'] = 'jump-password';
+      final manager = await createManager(storage);
+
+      await manager.init();
+
+      expect(manager.currentMachines, hasLength(1));
+      expect(manager.currentMachines.single.id, 'favorite');
+      expect(manager.currentMachines.single.hasApiKey, isTrue);
+      expect(manager.currentMachines.single.hasCredentials, isTrue);
+      expect(manager.currentMachines.single.hasJumpCredentials, isTrue);
+      expect(await manager.getApiKey('favorite'), 'secret');
+      expect(await manager.getSshPrivateKey('favorite'), 'private-key');
+      expect(await manager.getSshJumpPassword('favorite'), 'jump-password');
+      expect(await manager.getApiKey('api-owner'), isNull);
+      expect(await manager.getSshPrivateKey('ssh-owner'), isNull);
+      expect(await manager.getSshJumpPassword('ssh-owner'), isNull);
+      manager.dispose();
+    },
+  );
+
+  test(
+    'addMachine preserves an existing normalized endpoint identity',
+    () async {
+      final manager = await createManager();
+      final existing = await manager.recordConnection(
+        host: '[::1]',
+        port: 8765,
+        apiKey: 'secret',
+      );
+
+      await manager.addMachine(
+        const Machine(id: 'replacement', host: '::1', name: 'Loopback'),
+      );
+
+      expect(manager.currentMachines, hasLength(1));
+      expect(manager.currentMachines.single.id, existing.id);
+      expect(manager.currentMachines.single.name, 'Loopback');
+      expect(manager.currentMachines.single.hasApiKey, isTrue);
+      expect(await manager.getApiKey(existing.id), 'secret');
+      manager.dispose();
+    },
+  );
+}

--- a/apps/mobile/test/machine_test.dart
+++ b/apps/mobile/test/machine_test.dart
@@ -22,6 +22,21 @@ void main() {
       expect(machine.wsUrl, 'wss://bridge.example.com:443');
       expect(machine.httpUrl, 'https://bridge.example.com:443');
     });
+
+    test('wraps IPv6 hosts in URLs and display endpoints', () {
+      const machine = Machine(id: 'm-ipv6', host: '[::1]', port: 19000);
+
+      expect(machine.wsUrl, 'ws://[::1]:19000');
+      expect(machine.httpUrl, 'http://[::1]:19000');
+      expect(machine.displayName, '[::1]:19000');
+      expect(machine.uniqueKey, '[::1]:19000');
+    });
+
+    test('encodes IPv6 zone IDs in URLs', () {
+      const machine = Machine(id: 'm-zone', host: 'fe80::1%en0');
+
+      expect(machine.wsUrl, 'ws://[fe80::1%25en0]:8765');
+    });
   });
 
   group('Machine JSON', () {

--- a/apps/mobile/test/network_endpoint_test.dart
+++ b/apps/mobile/test/network_endpoint_test.dart
@@ -1,0 +1,51 @@
+import 'package:ccpocket/utils/network_endpoint.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('network endpoint formatting', () {
+    test('keeps IPv4 and DNS hosts unchanged', () {
+      expect(formatHostPort('192.168.1.1', 9000), '192.168.1.1:9000');
+      expect(
+        formatUriOrigin(scheme: 'wss', host: 'bridge.example.com', port: 443),
+        'wss://bridge.example.com:443',
+      );
+    });
+
+    test('brackets IPv6 hosts and strips input brackets', () {
+      expect(formatHostPort('::1', 8765), '[::1]:8765');
+      expect(formatHostPort('[::1]', 8765), '[::1]:8765');
+      expect(normalizeHostInput(' [::1] '), '::1');
+    });
+
+    test('encodes an IPv6 zone separator only in URI output', () {
+      expect(normalizeHostInput('[fe80::1%25en0]'), 'fe80::1%en0');
+      expect(
+        formatUriOrigin(scheme: 'ws', host: 'fe80::1%en0', port: 8765),
+        'ws://[fe80::1%25en0]:8765',
+      );
+    });
+
+    test('canonical identity ignores host case but preserves zone case', () {
+      expect(
+        endpointIdentityKey('[FDBD:DC01::1]', 8765),
+        '[fdbd:dc01::1]:8765',
+      );
+      expect(endpointIdentityKey('FE80::1%En0', 8765), '[fe80::1%En0]:8765');
+    });
+
+    test('canonical identity normalizes expanded and embedded IPv6 forms', () {
+      expect(
+        endpointIdentityKey('0:0:0:0:0:0:0:1', 8765),
+        endpointIdentityKey('::1', 8765),
+      );
+      expect(
+        endpointIdentityKey('::ffff:192.0.2.128', 8765),
+        endpointIdentityKey('0:0:0:0:0:ffff:c000:0280', 8765),
+      );
+    });
+
+    test('omits the port when one is not supplied', () {
+      expect(formatUriOrigin(scheme: 'https', host: '::1'), 'https://[::1]');
+    });
+  });
+}

--- a/apps/mobile/test/prompt_history_service_test.dart
+++ b/apps/mobile/test/prompt_history_service_test.dart
@@ -1,8 +1,18 @@
 import 'package:ccpocket/models/messages.dart';
+import 'package:ccpocket/services/database_service.dart';
 import 'package:ccpocket/services/prompt_history_service.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('bridgeIdForUrl canonicalizes IPv6 and default ports', () {
+    final service = PromptHistoryService(DatabaseService());
+
+    expect(service.bridgeIdForUrl('ws://[0:0:0:0:0:0:0:1]'), '[::1]:80');
+    expect(service.bridgeIdForUrl('ws://[::1]:80'), '[::1]:80');
+    expect(service.bridgeIdForUrl('wss://EXAMPLE.com'), 'example.com:443');
+    expect(service.bridgeIdForUrl('wss://example.com:443'), 'example.com:443');
+  });
+
   group('PromptHistoryEntry', () {
     test('merges entries from multiple bridges for display', () {
       final first = PromptHistoryEntry(

--- a/apps/mobile/test/server_discovery_service_test.dart
+++ b/apps/mobile/test/server_discovery_service_test.dart
@@ -1,0 +1,33 @@
+import 'package:ccpocket/services/server_discovery_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('DiscoveredServer brackets IPv6 hosts in websocket URLs', () {
+    const server = DiscoveredServer(
+      name: 'bridge',
+      host: 'fdbd:dc01:ff:321:254e:39ac:2d5d:1a67',
+      port: 19000,
+      authRequired: true,
+    );
+
+    expect(server.wsUrl, 'ws://[fdbd:dc01:ff:321:254e:39ac:2d5d:1a67]:19000');
+  });
+
+  test('DiscoveredServer equality uses canonical host identity', () {
+    const raw = DiscoveredServer(
+      name: 'first',
+      host: 'FE80::1%En0',
+      port: 8765,
+      authRequired: false,
+    );
+    const escaped = DiscoveredServer(
+      name: 'second',
+      host: '[fe80::1%25En0]',
+      port: 8765,
+      authRequired: true,
+    );
+
+    expect(raw, escaped);
+    expect(raw.hashCode, escaped.hashCode);
+  });
+}


### PR DESCRIPTION
## Summary

- format IPv6 Bridge hosts consistently in WebSocket/HTTP URLs, endpoint labels, discovery, and prompt-history identities
- normalize bracketed hosts and RFC 6874 zone IDs for Machine storage, lookup, SSH, jump hosts, and terminal integration
- canonicalize equivalent IPv6 spellings and merge duplicate saved Machines without losing API/SSH credentials
- validate direct, bare, and deep-link WebSocket URLs consistently

This is the maintainer reimplementation of #130. It keeps the original endpoint-helper direction and adds coverage for zone IDs, existing saved data, credential ownership, default ports, invalid URLs, and SSH boundaries.

## Verification

- `dart analyze apps/mobile` (no issues)
- Flutter: 1,262 tests passed, 4 skipped
- focused IPv6/model/parser/MachineManager/prompt-history/SSH widget tests passed
- iOS simulator E2E against a Bridge bound only to `::1:8766`:
  - health check and connection through `ws://[::1]:8766`
  - `[::1]:8766` endpoint display
  - saved Machine reconnect after disconnect
  - no DTD runtime errors
- independent self-review: LGTM

Refs #130
