### PR TITLE
perf(bridge): limit client file list payloads

### DIFF
--- a/apps/mobile/lib/features/explore/explore_screen.dart
+++ b/apps/mobile/lib/features/explore/explore_screen.dart
@@ -215,6 +215,11 @@ class _ExploreScreenBodyState extends State<_ExploreScreenBody> {
                   _notifyResultChanged(cubit);
                 },
               ),
+              if (state.fileListTruncated)
+                _FileListTruncatedNotice(
+                  visibleCount: state.allFiles.length,
+                  totalFiles: state.totalFiles,
+                ),
               Expanded(child: _buildBody(context, state)),
             ],
           ),
@@ -260,6 +265,48 @@ class _ExploreScreenBodyState extends State<_ExploreScreenBody> {
           },
         );
     }
+  }
+}
+
+class _FileListTruncatedNotice extends StatelessWidget {
+  final int visibleCount;
+  final int? totalFiles;
+
+  const _FileListTruncatedNotice({
+    required this.visibleCount,
+    required this.totalFiles,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final text = totalFiles == null
+        ? 'Showing the first $visibleCount entries'
+        : 'Showing $visibleCount of $totalFiles entries';
+    return Container(
+      key: const ValueKey('explore_file_list_truncated_notice'),
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      color: colorScheme.surfaceContainerHighest,
+      child: Row(
+        children: [
+          Icon(
+            Icons.info_outline,
+            size: 18,
+            color: colorScheme.onSurfaceVariant,
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              text,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }
 

--- a/apps/mobile/lib/features/explore/state/explore_cubit.dart
+++ b/apps/mobile/lib/features/explore/state/explore_cubit.dart
@@ -3,11 +3,12 @@ import 'dart:async';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import '../../../services/bridge_service.dart';
+import '../../../models/messages.dart';
 import 'explore_state.dart';
 
 class ExploreCubit extends Cubit<ExploreState> {
   final BridgeService _bridge;
-  StreamSubscription<List<String>>? _fileListSub;
+  StreamSubscription<FileListMessage>? _fileListSub;
   List<String> _recentPeekedFiles;
 
   ExploreCubit({
@@ -19,19 +20,26 @@ class ExploreCubit extends Cubit<ExploreState> {
   }) : _bridge = bridge,
        _recentPeekedFiles = recentPeekedFiles.take(10).toList(),
        super(ExploreState(projectPath: projectPath, currentPath: initialPath)) {
-    _fileListSub = _bridge.fileList.listen(_onFileListUpdated);
+    _fileListSub = _bridge.fileListMessages.listen(_onFileListUpdated);
     if (initialFiles.isNotEmpty) {
-      _applyFiles(initialFiles);
-    } else {
-      _bridge.requestFileList(projectPath);
+      _applyFiles(initialFiles, truncated: false, totalFiles: null);
     }
+    _bridge.requestFileList(projectPath);
   }
 
-  void _onFileListUpdated(List<String> files) {
-    _applyFiles(files);
+  void _onFileListUpdated(FileListMessage message) {
+    _applyFiles(
+      message.files,
+      truncated: message.truncated,
+      totalFiles: message.totalFiles,
+    );
   }
 
-  void _applyFiles(List<String> files) {
+  void _applyFiles(
+    List<String> files, {
+    required bool truncated,
+    required int? totalFiles,
+  }) {
     final normalizedPath = normalizeExplorePath(files, state.currentPath);
     final entries = buildExploreEntries(files, currentPath: normalizedPath);
     emit(
@@ -39,6 +47,8 @@ class ExploreCubit extends Cubit<ExploreState> {
         currentPath: normalizedPath,
         allFiles: files,
         visibleEntries: entries,
+        fileListTruncated: truncated,
+        totalFiles: totalFiles,
         status: switch ((files.isEmpty, entries.isEmpty)) {
           (true, _) => ExploreStatus.empty,
           (_, false) => ExploreStatus.ready,

--- a/apps/mobile/lib/features/explore/state/explore_state.dart
+++ b/apps/mobile/lib/features/explore/state/explore_state.dart
@@ -34,6 +34,8 @@ abstract class ExploreState with _$ExploreState {
     @Default([]) List<String> allFiles,
     @Default([]) List<ExploreEntry> visibleEntries,
     @Default(ExploreStatus.loading) ExploreStatus status,
+    @Default(false) bool fileListTruncated,
+    int? totalFiles,
     String? error,
   }) = _ExploreState;
 }

--- a/apps/mobile/lib/features/explore/state/explore_state.freezed.dart
+++ b/apps/mobile/lib/features/explore/state/explore_state.freezed.dart
@@ -14,7 +14,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$ExploreState {
 
- String get projectPath; String get currentPath; List<String> get allFiles; List<ExploreEntry> get visibleEntries; ExploreStatus get status; String? get error;
+ String get projectPath; String get currentPath; List<String> get allFiles; List<ExploreEntry> get visibleEntries; ExploreStatus get status; bool get fileListTruncated; int? get totalFiles; String? get error;
 /// Create a copy of ExploreState
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -25,16 +25,16 @@ $ExploreStateCopyWith<ExploreState> get copyWith => _$ExploreStateCopyWithImpl<E
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is ExploreState&&(identical(other.projectPath, projectPath) || other.projectPath == projectPath)&&(identical(other.currentPath, currentPath) || other.currentPath == currentPath)&&const DeepCollectionEquality().equals(other.allFiles, allFiles)&&const DeepCollectionEquality().equals(other.visibleEntries, visibleEntries)&&(identical(other.status, status) || other.status == status)&&(identical(other.error, error) || other.error == error));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ExploreState&&(identical(other.projectPath, projectPath) || other.projectPath == projectPath)&&(identical(other.currentPath, currentPath) || other.currentPath == currentPath)&&const DeepCollectionEquality().equals(other.allFiles, allFiles)&&const DeepCollectionEquality().equals(other.visibleEntries, visibleEntries)&&(identical(other.status, status) || other.status == status)&&(identical(other.fileListTruncated, fileListTruncated) || other.fileListTruncated == fileListTruncated)&&(identical(other.totalFiles, totalFiles) || other.totalFiles == totalFiles)&&(identical(other.error, error) || other.error == error));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,projectPath,currentPath,const DeepCollectionEquality().hash(allFiles),const DeepCollectionEquality().hash(visibleEntries),status,error);
+int get hashCode => Object.hash(runtimeType,projectPath,currentPath,const DeepCollectionEquality().hash(allFiles),const DeepCollectionEquality().hash(visibleEntries),status,fileListTruncated,totalFiles,error);
 
 @override
 String toString() {
-  return 'ExploreState(projectPath: $projectPath, currentPath: $currentPath, allFiles: $allFiles, visibleEntries: $visibleEntries, status: $status, error: $error)';
+  return 'ExploreState(projectPath: $projectPath, currentPath: $currentPath, allFiles: $allFiles, visibleEntries: $visibleEntries, status: $status, fileListTruncated: $fileListTruncated, totalFiles: $totalFiles, error: $error)';
 }
 
 
@@ -45,7 +45,7 @@ abstract mixin class $ExploreStateCopyWith<$Res>  {
   factory $ExploreStateCopyWith(ExploreState value, $Res Function(ExploreState) _then) = _$ExploreStateCopyWithImpl;
 @useResult
 $Res call({
- String projectPath, String currentPath, List<String> allFiles, List<ExploreEntry> visibleEntries, ExploreStatus status, String? error
+ String projectPath, String currentPath, List<String> allFiles, List<ExploreEntry> visibleEntries, ExploreStatus status, bool fileListTruncated, int? totalFiles, String? error
 });
 
 
@@ -62,14 +62,16 @@ class _$ExploreStateCopyWithImpl<$Res>
 
 /// Create a copy of ExploreState
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? projectPath = null,Object? currentPath = null,Object? allFiles = null,Object? visibleEntries = null,Object? status = null,Object? error = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? projectPath = null,Object? currentPath = null,Object? allFiles = null,Object? visibleEntries = null,Object? status = null,Object? fileListTruncated = null,Object? totalFiles = freezed,Object? error = freezed,}) {
   return _then(_self.copyWith(
 projectPath: null == projectPath ? _self.projectPath : projectPath // ignore: cast_nullable_to_non_nullable
 as String,currentPath: null == currentPath ? _self.currentPath : currentPath // ignore: cast_nullable_to_non_nullable
 as String,allFiles: null == allFiles ? _self.allFiles : allFiles // ignore: cast_nullable_to_non_nullable
 as List<String>,visibleEntries: null == visibleEntries ? _self.visibleEntries : visibleEntries // ignore: cast_nullable_to_non_nullable
 as List<ExploreEntry>,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
-as ExploreStatus,error: freezed == error ? _self.error : error // ignore: cast_nullable_to_non_nullable
+as ExploreStatus,fileListTruncated: null == fileListTruncated ? _self.fileListTruncated : fileListTruncated // ignore: cast_nullable_to_non_nullable
+as bool,totalFiles: freezed == totalFiles ? _self.totalFiles : totalFiles // ignore: cast_nullable_to_non_nullable
+as int?,error: freezed == error ? _self.error : error // ignore: cast_nullable_to_non_nullable
 as String?,
   ));
 }
@@ -155,10 +157,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String projectPath,  String currentPath,  List<String> allFiles,  List<ExploreEntry> visibleEntries,  ExploreStatus status,  String? error)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String projectPath,  String currentPath,  List<String> allFiles,  List<ExploreEntry> visibleEntries,  ExploreStatus status,  bool fileListTruncated,  int? totalFiles,  String? error)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _ExploreState() when $default != null:
-return $default(_that.projectPath,_that.currentPath,_that.allFiles,_that.visibleEntries,_that.status,_that.error);case _:
+return $default(_that.projectPath,_that.currentPath,_that.allFiles,_that.visibleEntries,_that.status,_that.fileListTruncated,_that.totalFiles,_that.error);case _:
   return orElse();
 
 }
@@ -176,10 +178,10 @@ return $default(_that.projectPath,_that.currentPath,_that.allFiles,_that.visible
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String projectPath,  String currentPath,  List<String> allFiles,  List<ExploreEntry> visibleEntries,  ExploreStatus status,  String? error)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String projectPath,  String currentPath,  List<String> allFiles,  List<ExploreEntry> visibleEntries,  ExploreStatus status,  bool fileListTruncated,  int? totalFiles,  String? error)  $default,) {final _that = this;
 switch (_that) {
 case _ExploreState():
-return $default(_that.projectPath,_that.currentPath,_that.allFiles,_that.visibleEntries,_that.status,_that.error);case _:
+return $default(_that.projectPath,_that.currentPath,_that.allFiles,_that.visibleEntries,_that.status,_that.fileListTruncated,_that.totalFiles,_that.error);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -196,10 +198,10 @@ return $default(_that.projectPath,_that.currentPath,_that.allFiles,_that.visible
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String projectPath,  String currentPath,  List<String> allFiles,  List<ExploreEntry> visibleEntries,  ExploreStatus status,  String? error)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String projectPath,  String currentPath,  List<String> allFiles,  List<ExploreEntry> visibleEntries,  ExploreStatus status,  bool fileListTruncated,  int? totalFiles,  String? error)?  $default,) {final _that = this;
 switch (_that) {
 case _ExploreState() when $default != null:
-return $default(_that.projectPath,_that.currentPath,_that.allFiles,_that.visibleEntries,_that.status,_that.error);case _:
+return $default(_that.projectPath,_that.currentPath,_that.allFiles,_that.visibleEntries,_that.status,_that.fileListTruncated,_that.totalFiles,_that.error);case _:
   return null;
 
 }
@@ -211,7 +213,7 @@ return $default(_that.projectPath,_that.currentPath,_that.allFiles,_that.visible
 
 
 class _ExploreState implements ExploreState {
-  const _ExploreState({required this.projectPath, this.currentPath = '', final  List<String> allFiles = const [], final  List<ExploreEntry> visibleEntries = const [], this.status = ExploreStatus.loading, this.error}): _allFiles = allFiles,_visibleEntries = visibleEntries;
+  const _ExploreState({required this.projectPath, this.currentPath = '', final  List<String> allFiles = const [], final  List<ExploreEntry> visibleEntries = const [], this.status = ExploreStatus.loading, this.fileListTruncated = false, this.totalFiles, this.error}): _allFiles = allFiles,_visibleEntries = visibleEntries;
   
 
 @override final  String projectPath;
@@ -231,6 +233,8 @@ class _ExploreState implements ExploreState {
 }
 
 @override@JsonKey() final  ExploreStatus status;
+@override@JsonKey() final  bool fileListTruncated;
+@override final  int? totalFiles;
 @override final  String? error;
 
 /// Create a copy of ExploreState
@@ -243,16 +247,16 @@ _$ExploreStateCopyWith<_ExploreState> get copyWith => __$ExploreStateCopyWithImp
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ExploreState&&(identical(other.projectPath, projectPath) || other.projectPath == projectPath)&&(identical(other.currentPath, currentPath) || other.currentPath == currentPath)&&const DeepCollectionEquality().equals(other._allFiles, _allFiles)&&const DeepCollectionEquality().equals(other._visibleEntries, _visibleEntries)&&(identical(other.status, status) || other.status == status)&&(identical(other.error, error) || other.error == error));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ExploreState&&(identical(other.projectPath, projectPath) || other.projectPath == projectPath)&&(identical(other.currentPath, currentPath) || other.currentPath == currentPath)&&const DeepCollectionEquality().equals(other._allFiles, _allFiles)&&const DeepCollectionEquality().equals(other._visibleEntries, _visibleEntries)&&(identical(other.status, status) || other.status == status)&&(identical(other.fileListTruncated, fileListTruncated) || other.fileListTruncated == fileListTruncated)&&(identical(other.totalFiles, totalFiles) || other.totalFiles == totalFiles)&&(identical(other.error, error) || other.error == error));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,projectPath,currentPath,const DeepCollectionEquality().hash(_allFiles),const DeepCollectionEquality().hash(_visibleEntries),status,error);
+int get hashCode => Object.hash(runtimeType,projectPath,currentPath,const DeepCollectionEquality().hash(_allFiles),const DeepCollectionEquality().hash(_visibleEntries),status,fileListTruncated,totalFiles,error);
 
 @override
 String toString() {
-  return 'ExploreState(projectPath: $projectPath, currentPath: $currentPath, allFiles: $allFiles, visibleEntries: $visibleEntries, status: $status, error: $error)';
+  return 'ExploreState(projectPath: $projectPath, currentPath: $currentPath, allFiles: $allFiles, visibleEntries: $visibleEntries, status: $status, fileListTruncated: $fileListTruncated, totalFiles: $totalFiles, error: $error)';
 }
 
 
@@ -263,7 +267,7 @@ abstract mixin class _$ExploreStateCopyWith<$Res> implements $ExploreStateCopyWi
   factory _$ExploreStateCopyWith(_ExploreState value, $Res Function(_ExploreState) _then) = __$ExploreStateCopyWithImpl;
 @override @useResult
 $Res call({
- String projectPath, String currentPath, List<String> allFiles, List<ExploreEntry> visibleEntries, ExploreStatus status, String? error
+ String projectPath, String currentPath, List<String> allFiles, List<ExploreEntry> visibleEntries, ExploreStatus status, bool fileListTruncated, int? totalFiles, String? error
 });
 
 
@@ -280,14 +284,16 @@ class __$ExploreStateCopyWithImpl<$Res>
 
 /// Create a copy of ExploreState
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? projectPath = null,Object? currentPath = null,Object? allFiles = null,Object? visibleEntries = null,Object? status = null,Object? error = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? projectPath = null,Object? currentPath = null,Object? allFiles = null,Object? visibleEntries = null,Object? status = null,Object? fileListTruncated = null,Object? totalFiles = freezed,Object? error = freezed,}) {
   return _then(_ExploreState(
 projectPath: null == projectPath ? _self.projectPath : projectPath // ignore: cast_nullable_to_non_nullable
 as String,currentPath: null == currentPath ? _self.currentPath : currentPath // ignore: cast_nullable_to_non_nullable
 as String,allFiles: null == allFiles ? _self._allFiles : allFiles // ignore: cast_nullable_to_non_nullable
 as List<String>,visibleEntries: null == visibleEntries ? _self._visibleEntries : visibleEntries // ignore: cast_nullable_to_non_nullable
 as List<ExploreEntry>,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
-as ExploreStatus,error: freezed == error ? _self.error : error // ignore: cast_nullable_to_non_nullable
+as ExploreStatus,fileListTruncated: null == fileListTruncated ? _self.fileListTruncated : fileListTruncated // ignore: cast_nullable_to_non_nullable
+as bool,totalFiles: freezed == totalFiles ? _self.totalFiles : totalFiles // ignore: cast_nullable_to_non_nullable
+as int?,error: freezed == error ? _self.error : error // ignore: cast_nullable_to_non_nullable
 as String?,
   ));
 }

--- a/apps/mobile/lib/models/messages.dart
+++ b/apps/mobile/lib/models/messages.dart
@@ -874,6 +874,8 @@ sealed class ServerMessage {
       ),
       'file_list' => FileListMessage(
         files: (json['files'] as List).cast<String>(),
+        totalFiles: json['totalFiles'] as int?,
+        truncated: json['truncated'] as bool? ?? false,
       ),
       'project_history' => ProjectHistoryMessage(
         projects: (json['projects'] as List).cast<String>(),
@@ -2295,7 +2297,14 @@ class DebugBundleMessage implements ServerMessage {
 
 class FileListMessage implements ServerMessage {
   final List<String> files;
-  const FileListMessage({required this.files});
+  final int? totalFiles;
+  final bool truncated;
+
+  const FileListMessage({
+    required this.files,
+    this.totalFiles,
+    this.truncated = false,
+  });
 }
 
 class FileContentMessage implements ServerMessage {

--- a/apps/mobile/lib/services/bridge_service.dart
+++ b/apps/mobile/lib/services/bridge_service.dart
@@ -33,6 +33,8 @@ class BridgeService implements BridgeServiceBase {
       StreamController<List<RecentSession>>.broadcast();
   final _galleryController = StreamController<List<GalleryImage>>.broadcast();
   final _fileListController = StreamController<List<String>>.broadcast();
+  final _fileListMessageController =
+      StreamController<FileListMessage>.broadcast();
   final _projectHistoryController = StreamController<List<String>>.broadcast();
   final _diffResultController = StreamController<DiffResultMessage>.broadcast();
   final _diffImageResultController =
@@ -158,6 +160,8 @@ class BridgeService implements BridgeServiceBase {
       _projectHistoryController.stream;
   @override
   Stream<List<String>> get fileList => _fileListController.stream;
+  Stream<FileListMessage> get fileListMessages =>
+      _fileListMessageController.stream;
   Stream<FileContentMessage> get fileContent => _fileContentController.stream;
   Stream<DiffResultMessage> get diffResults => _diffResultController.stream;
   Stream<DiffImageResultMessage> get diffImageResults =>
@@ -446,6 +450,7 @@ class BridgeService implements BridgeServiceBase {
                 _fileContentController.add(msg);
               case FileListMessage(:final files):
                 _fileListController.add(files);
+                _fileListMessageController.add(msg);
               case ProjectHistoryMessage(:final projects):
                 _projectHistory = projects;
                 _projectHistoryController.add(projects);
@@ -687,6 +692,7 @@ class BridgeService implements BridgeServiceBase {
     _galleryController.add(_galleryImages);
     _projectHistoryController.add(_projectHistory);
     _fileListController.add(const []);
+    _fileListMessageController.add(const FileListMessage(files: []));
 
     if (clearOfflineQueue) {
       _clearOfflinePendingState();
@@ -2307,6 +2313,7 @@ class BridgeService implements BridgeServiceBase {
     _recentSessionsController.close();
     _galleryController.close();
     _fileListController.close();
+    _fileListMessageController.close();
     _projectHistoryController.close();
     _diffResultController.close();
     _diffImageResultController.close();

--- a/apps/mobile/test/explore_cubit_test.dart
+++ b/apps/mobile/test/explore_cubit_test.dart
@@ -15,10 +15,20 @@ import 'package:ccpocket/theme/app_theme.dart';
 class _TestBridgeService extends BridgeService {
   final _fileContentController =
       StreamController<FileContentMessage>.broadcast();
+  final _fileListMessageController =
+      StreamController<FileListMessage>.broadcast();
   final sentMessages = <ClientMessage>[];
 
   @override
   Stream<FileContentMessage> get fileContent => _fileContentController.stream;
+
+  @override
+  Stream<FileListMessage> get fileListMessages =>
+      _fileListMessageController.stream;
+
+  void emitFileList(FileListMessage message) {
+    _fileListMessageController.add(message);
+  }
 
   @override
   void send(ClientMessage message) {
@@ -28,6 +38,7 @@ class _TestBridgeService extends BridgeService {
   @override
   void dispose() {
     _fileContentController.close();
+    _fileListMessageController.close();
     super.dispose();
   }
 }
@@ -160,6 +171,39 @@ void main() {
   });
 
   group('Explore recent files', () {
+    testWidgets('shows when the bridge truncated the file list', (
+      tester,
+    ) async {
+      final bridge = _TestBridgeService();
+      addTearDown(bridge.dispose);
+
+      await tester.pumpWidget(
+        RepositoryProvider<BridgeService>.value(
+          value: bridge,
+          child: MaterialApp(
+            theme: AppTheme.darkTheme,
+            home: const ExploreScreen(
+              sessionId: 'session-1',
+              projectPath: '/tmp/project',
+            ),
+          ),
+        ),
+      );
+      bridge.emitFileList(
+        const FileListMessage(
+          files: ['lib/main.dart', 'README.md'],
+          truncated: true,
+        ),
+      );
+      await tester.pump();
+
+      expect(
+        find.byKey(const ValueKey('explore_file_list_truncated_notice')),
+        findsOneWidget,
+      );
+      expect(find.text('Showing the first 2 entries'), findsOneWidget);
+    });
+
     testWidgets('shows recent open files only and opens file peek', (
       tester,
     ) async {
@@ -195,11 +239,11 @@ void main() {
       await tester.pump(const Duration(milliseconds: 300));
 
       expect(find.byIcon(Icons.content_copy), findsOneWidget);
-      expect(bridge.sentMessages, hasLength(1));
-
-      final payload =
-          jsonDecode(bridge.sentMessages.single.toJson())
-              as Map<String, dynamic>;
+      final payload = bridge.sentMessages
+          .map(
+            (message) => jsonDecode(message.toJson()) as Map<String, dynamic>,
+          )
+          .singleWhere((message) => message['type'] == 'read_file');
       expect(payload['type'], 'read_file');
       expect(payload['projectPath'], '/tmp/project');
       expect(payload['filePath'], 'lib/main.dart');

--- a/apps/mobile/test/plan_mode_test.dart
+++ b/apps/mobile/test/plan_mode_test.dart
@@ -115,10 +115,26 @@ void main() {
       final msg = ServerMessage.fromJson({
         'type': 'file_list',
         'files': ['lib/main.dart', 'pubspec.yaml'],
+        'totalFiles': 10,
+        'truncated': true,
       });
       expect(msg, isA<FileListMessage>());
       final fl = msg as FileListMessage;
       expect(fl.files, ['lib/main.dart', 'pubspec.yaml']);
+      expect(fl.totalFiles, 10);
+      expect(fl.truncated, isTrue);
+    });
+
+    test('defaults optional file list metadata for older bridges', () {
+      final msg =
+          ServerMessage.fromJson({
+                'type': 'file_list',
+                'files': ['README.md'],
+              })
+              as FileListMessage;
+
+      expect(msg.totalFiles, isNull);
+      expect(msg.truncated, isFalse);
     });
   });
 }

--- a/packages/bridge/README.md
+++ b/packages/bridge/README.md
@@ -47,6 +47,8 @@ ccpocket-bridge --version
 | `BRIDGE_DISABLE_MDNS` | (none) | Disable mDNS auto-discovery advertisement (enabled when set) |
 | `BRIDGE_PROMPT_HISTORY_FILE` | `$HOME/.ccpocket/prompt-history-v2.json` | Custom prompt history store path |
 | `BRIDGE_RECENT_SESSIONS_PROFILE` | (none) | Log recent-session index timing when set to `1` or `true` |
+| `BRIDGE_FILE_LIST_MAX_ENTRIES` | `5000` | Maximum file and directory entries returned to a client; non-positive or invalid values use the default |
+| `BRIDGE_FILE_LIST_MAX_BYTES` | `524288` | Maximum serialized path bytes returned in a client file list; non-positive or invalid values use the default |
 | `DIFF_IMAGE_AUTO_DISPLAY_KB` | `1024` (1 MB) | Auto-display diff images up to this size, in KB |
 | `DIFF_IMAGE_MAX_SIZE_MB` | `5` (5 MB) | Maximum diff image size available for on-demand loading, in MB |
 | `ANTHROPIC_API_KEY` | (none) | Claude Agent SDK API key used for Claude sessions |

--- a/packages/bridge/src/git-operations.test.ts
+++ b/packages/bridge/src/git-operations.test.ts
@@ -19,8 +19,10 @@ import {
   gitCommit,
   getStagedDiff,
   listGitFiles,
+  listGitFilesForClient,
   listFileSystemFiles,
   listProjectFilesAndDirectories,
+  listProjectFilesAndDirectoriesForClient,
   listProjectFiles,
   listBranches,
   createBranch,
@@ -628,6 +630,48 @@ describe("listGitFiles", () => {
 
     expect(files).toContain("docs/line\nbreak.md");
   });
+
+  it("does not mark an exact entry limit as truncated", async () => {
+    writeFileSync(join(repo, "a.md"), "a\n");
+    writeFileSync(join(repo, "b.md"), "b\n");
+
+    await expect(
+      listGitFilesForClient(repo, {
+        maxEntries: 3,
+        maxBytes: 1024,
+      }),
+    ).resolves.toMatchObject({
+      truncated: false,
+      totalFiles: 3,
+    });
+  });
+
+  it("stops after observing an entry beyond the limit", async () => {
+    writeFileSync(join(repo, "a.md"), "a\n");
+    writeFileSync(join(repo, "b.md"), "b\n");
+    writeFileSync(join(repo, "c.md"), "c\n");
+
+    const result = await listGitFilesForClient(repo, {
+      maxEntries: 2,
+      maxBytes: 1024,
+    });
+
+    expect(result.files).toHaveLength(2);
+    expect(result.truncated).toBe(true);
+    expect(result.totalFiles).toBeUndefined();
+  });
+
+  it("limits serialized UTF-8 file entry bytes", async () => {
+    writeFileSync(join(repo, "あ.md"), "a\n");
+
+    const result = await listGitFilesForClient(repo, {
+      maxEntries: 10,
+      maxBytes: Buffer.byteLength(JSON.stringify("あ.md"), "utf8"),
+    });
+
+    expect(result.files).toEqual(["あ.md"]);
+    expect(result.truncated).toBe(true);
+  });
 });
 
 describe("listFileSystemFiles", () => {
@@ -748,6 +792,57 @@ describe("listProjectFilesAndDirectories", () => {
       "initial.txt",
       "README.md",
     ]);
+  });
+
+  it("limits client entries after adding directory candidates", async () => {
+    project = createTempRepo();
+    mkdirSync(join(project, "src", "features"), { recursive: true });
+    writeFileSync(join(project, "src", "features", "a.ts"), "a\n");
+    writeFileSync(join(project, "src", "features", "b.ts"), "b\n");
+
+    const result = await listProjectFilesAndDirectoriesForClient(project, {
+      maxEntries: 3,
+      maxBytes: 1024,
+    });
+
+    expect(result.files).toHaveLength(3);
+    expect(result.truncated).toBe(true);
+  });
+
+  it("does not truncate an exact filesystem fallback limit", async () => {
+    project = createTempProject();
+    writeFileSync(join(project, "a.txt"), "a\n");
+    writeFileSync(join(project, "b.txt"), "b\n");
+    writeFileSync(join(project, "c.txt"), "c\n");
+
+    await expect(
+      listProjectFilesAndDirectoriesForClient(project, {
+        maxEntries: 3,
+        maxBytes: 1024,
+      }),
+    ).resolves.toEqual({
+      files: ["a.txt", "b.txt", "c.txt"],
+      truncated: false,
+      totalFiles: 3,
+    });
+  });
+
+  it("reports a truncated filesystem fallback at the depth limit", async () => {
+    project = createTempProject();
+    mkdirSync(join(project, "a", "b", "c"), { recursive: true });
+    writeFileSync(join(project, "a", "b", "c", "deep.txt"), "deep\n");
+
+    await expect(
+      listProjectFilesAndDirectoriesForClient(project, {
+        maxDepth: 2,
+        maxEntries: 10,
+        maxBytes: 1024,
+      }),
+    ).resolves.toEqual({
+      files: [],
+      truncated: true,
+      totalFiles: undefined,
+    });
   });
 });
 

--- a/packages/bridge/src/git-operations.ts
+++ b/packages/bridge/src/git-operations.ts
@@ -1,7 +1,8 @@
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
 import { realpathSync, type Dir, type Dirent } from "node:fs";
 import { opendir } from "node:fs/promises";
 import { join, relative, resolve, sep } from "node:path";
+import { StringDecoder } from "node:string_decoder";
 
 // ---- Types ----
 
@@ -47,6 +48,17 @@ export interface FileSystemFileListOptions {
   maxDepth?: number;
   maxFiles?: number;
   excludedDirs?: ReadonlySet<string> | readonly string[];
+}
+
+export interface ClientFileListOptions extends FileSystemFileListOptions {
+  maxEntries: number;
+  maxBytes: number;
+}
+
+export interface ClientFileListResult {
+  files: string[];
+  truncated: boolean;
+  totalFiles?: number;
 }
 
 export const DEFAULT_FILESYSTEM_FILE_LIST_MAX_DEPTH = 8;
@@ -264,6 +276,105 @@ export function listGitFiles(projectPath: string): string[] {
   return output.split("\0").filter(Boolean);
 }
 
+/** Stream a bounded Git file list without buffering the complete command output. */
+export function listGitFilesForClient(
+  projectPath: string,
+  options: Pick<ClientFileListOptions, "maxEntries" | "maxBytes">,
+): Promise<ClientFileListResult> {
+  const cwd = resolveProject(projectPath);
+  const maxEntries = requirePositiveLimit(options.maxEntries, "maxEntries");
+  const maxBytes = requirePositiveLimit(options.maxBytes, "maxBytes");
+
+  return new Promise((resolvePromise, rejectPromise) => {
+    const child = spawn(
+      "git",
+      withGitPathConfig([
+        "ls-files",
+        "-z",
+        "--cached",
+        "--others",
+        "--exclude-standard",
+      ]),
+      { cwd, stdio: ["ignore", "pipe", "pipe"] },
+    );
+    const decoder = new StringDecoder("utf8");
+    const files: string[] = [];
+    const stderr: Buffer[] = [];
+    let stderrBytes = 0;
+    let pending = "";
+    let entryBytes = 0;
+    let truncated = false;
+    let settled = false;
+
+    const settle = (result: ClientFileListResult) => {
+      if (settled) return;
+      settled = true;
+      resolvePromise(result);
+    };
+    const fail = (error: unknown) => {
+      if (settled) return;
+      settled = true;
+      rejectPromise(error);
+    };
+    const stopAtLimit = () => {
+      truncated = true;
+      child.kill("SIGTERM");
+    };
+    const acceptFile = (file: string): boolean => {
+      if (!file) return true;
+      const nextBytes = serializedFileEntryBytes(file, files.length > 0);
+      if (
+        files.length >= maxEntries ||
+        entryBytes + nextBytes > maxBytes
+      ) {
+        stopAtLimit();
+        return false;
+      }
+      files.push(file);
+      entryBytes += nextBytes;
+      return true;
+    };
+    const consume = (text: string) => {
+      pending += text;
+      const parts = pending.split("\0");
+      pending = parts.pop() ?? "";
+      for (const part of parts) {
+        if (!acceptFile(part)) return;
+      }
+    };
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      if (!truncated) consume(decoder.write(chunk));
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      if (stderrBytes >= 64 * 1024) return;
+      stderr.push(chunk);
+      stderrBytes += chunk.length;
+    });
+    child.on("error", fail);
+    child.on("close", (code) => {
+      if (!truncated) {
+        consume(decoder.end());
+        if (pending) acceptFile(pending);
+      }
+      if (code === 0 || truncated) {
+        settle({
+          files,
+          truncated,
+          totalFiles: truncated ? undefined : files.length,
+        });
+        return;
+      }
+      fail(
+        new Error(
+          Buffer.concat(stderr).toString("utf8").trim() ||
+            `git ls-files failed with exit code ${code}`,
+        ),
+      );
+    });
+  });
+}
+
 /** Return project files, using Git when available and filesystem fallback otherwise. */
 export async function listProjectFiles(
   projectPath: string,
@@ -285,6 +396,85 @@ export async function listProjectFilesAndDirectories(
   options: FileSystemFileListOptions = {},
 ): Promise<string[]> {
   return withDirectoryCandidates(await listProjectFiles(projectPath, options));
+}
+
+/** Return a bounded client-facing file and directory list. */
+export async function listProjectFilesAndDirectoriesForClient(
+  projectPath: string,
+  options: ClientFileListOptions,
+): Promise<ClientFileListResult> {
+  const maxEntries = requirePositiveLimit(options.maxEntries, "maxEntries");
+  const maxBytes = requirePositiveLimit(options.maxBytes, "maxBytes");
+  let listed: ClientFileListResult;
+
+  try {
+    listed = await listGitFilesForClient(projectPath, {
+      maxEntries,
+      maxBytes,
+    });
+  } catch (err) {
+    if (!isGitFileListingUnavailable(err)) throw err;
+    const fileSystemResult = await collectFileSystemFiles(projectPath, {
+      ...options,
+      maxFiles: maxEntries + 1,
+    });
+    const candidates = fileSystemResult.files;
+    const rawTruncated = candidates.length > maxEntries;
+    listed = {
+      files: candidates.slice(0, maxEntries),
+      truncated: rawTruncated || fileSystemResult.traversalTruncated,
+      totalFiles:
+        rawTruncated || fileSystemResult.traversalTruncated
+          ? undefined
+          : candidates.length,
+    };
+  }
+
+  const filesAndDirs = withDirectoryCandidates(listed.files);
+  const limited = limitClientFileList(filesAndDirs, {
+    maxEntries,
+    maxBytes,
+  });
+  return {
+    files: limited.files,
+    truncated: listed.truncated || limited.truncated,
+    totalFiles: listed.truncated ? undefined : filesAndDirs.length,
+  };
+}
+
+function limitClientFileList(
+  files: readonly string[],
+  options: Pick<ClientFileListOptions, "maxEntries" | "maxBytes">,
+): ClientFileListResult {
+  const limited: string[] = [];
+  let bytes = 0;
+  for (const file of files) {
+    const nextBytes = serializedFileEntryBytes(file, limited.length > 0);
+    if (
+      limited.length >= options.maxEntries ||
+      bytes + nextBytes > options.maxBytes
+    ) {
+      break;
+    }
+    limited.push(file);
+    bytes += nextBytes;
+  }
+  return {
+    files: limited,
+    truncated: limited.length < files.length,
+    totalFiles: files.length,
+  };
+}
+
+function serializedFileEntryBytes(file: string, hasPrevious: boolean): number {
+  return Buffer.byteLength(JSON.stringify(file), "utf8") + (hasPrevious ? 1 : 0);
+}
+
+function requirePositiveLimit(value: number, name: string): number {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return value;
 }
 
 export function withDirectoryCandidates(files: readonly string[]): string[] {
@@ -312,6 +502,13 @@ export async function listFileSystemFiles(
   projectPath: string,
   options: FileSystemFileListOptions = {},
 ): Promise<string[]> {
+  return (await collectFileSystemFiles(projectPath, options)).files;
+}
+
+async function collectFileSystemFiles(
+  projectPath: string,
+  options: FileSystemFileListOptions,
+): Promise<{ files: string[]; traversalTruncated: boolean }> {
   const root = resolveProject(projectPath);
   const maxDepth =
     options.maxDepth ?? DEFAULT_FILESYSTEM_FILE_LIST_MAX_DEPTH;
@@ -321,19 +518,25 @@ export async function listFileSystemFiles(
     options.excludedDirs ?? DEFAULT_FILESYSTEM_FILE_LIST_EXCLUDED_DIRS,
   );
   const files: string[] = [];
+  let traversalTruncated = false;
 
   async function visit(
     absDir: string,
     relDir: string,
     depth: number,
   ): Promise<void> {
-    if (files.length >= maxFiles || depth >= maxDepth) return;
+    if (files.length >= maxFiles) return;
+    if (depth >= maxDepth) {
+      traversalTruncated = true;
+      return;
+    }
 
     let dir: Dir;
     try {
       dir = await opendir(absDir);
     } catch (err) {
       if (relDir === "") throw err;
+      traversalTruncated = true;
       return;
     }
 
@@ -368,7 +571,10 @@ export async function listFileSystemFiles(
   }
 
   await visit(root, "", 0);
-  return files.sort((a, b) => a.localeCompare(b));
+  return {
+    files: files.sort((a, b) => a.localeCompare(b)),
+    traversalTruncated,
+  };
 }
 
 function isGitFileListingUnavailable(err: unknown): boolean {

--- a/packages/bridge/src/parser.ts
+++ b/packages/bridge/src/parser.ts
@@ -531,7 +531,12 @@ export type ServerMessage =
       mimeType?: string;
       sizeBytes?: number;
     }
-  | { type: "file_list"; files: string[] }
+  | {
+      type: "file_list";
+      files: string[];
+      totalFiles?: number;
+      truncated?: boolean;
+    }
   | { type: "project_history"; projects: string[] }
   | {
       type: "diff_result";

--- a/packages/bridge/src/websocket.test.ts
+++ b/packages/bridge/src/websocket.test.ts
@@ -695,6 +695,43 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     bridge.close();
   });
 
+  it("limits file list payloads and reports truncation", async () => {
+    const repo = mkdtempSync(resolve(tmpdir(), "ccpocket-file-list-"));
+    try {
+      execFileSync("git", ["init"], { cwd: repo });
+      writeFileSync(resolve(repo, "a.ts"), "a\n");
+      writeFileSync(resolve(repo, "b.ts"), "b\n");
+      writeFileSync(resolve(repo, "c.ts"), "c\n");
+      const bridge = new BridgeWebSocketServer({
+        server: httpServer,
+        fileListMaxEntries: 2,
+        fileListMaxBytes: 1024,
+      });
+      const ws = { readyState: OPEN_STATE, send: vi.fn() } as any;
+
+      await (bridge as any).handleClientMessage(
+        { type: "list_files", projectPath: repo },
+        ws,
+      );
+      for (let i = 0; i < 50 && ws.send.mock.calls.length === 0; i++) {
+        await new Promise((resolvePromise) => setTimeout(resolvePromise, 10));
+      }
+
+      const message = ws.send.mock.calls
+        .map((call: unknown[]) => JSON.parse(call[0] as string))
+        .find((sent: { type: string }) => sent.type === "file_list");
+      expect(message).toMatchObject({
+        type: "file_list",
+        truncated: true,
+      });
+      expect(message.files).toHaveLength(2);
+      expect(message.totalFiles).toBeUndefined();
+      bridge.close();
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
   it("rejects start when selected codex profile does not exist", async () => {
     const bridge = new BridgeWebSocketServer({ server: httpServer });
     const ws = {

--- a/packages/bridge/src/websocket.ts
+++ b/packages/bridge/src/websocket.ts
@@ -72,7 +72,7 @@ import {
   unstageHunks,
   gitCommit,
   gitPush,
-  listProjectFilesAndDirectories,
+  listProjectFilesAndDirectoriesForClient,
   listBranches,
   createBranch,
   checkoutBranch,
@@ -484,6 +484,22 @@ function envFlagEnabled(name: string): boolean {
   return value === "1" || value === "true" || value === "yes" || value === "on";
 }
 
+function positiveEnvInt(name: string, fallback: number): number {
+  const raw = process.env[name]?.trim();
+  if (!raw) return fallback;
+  const value = Number(raw);
+  return Number.isSafeInteger(value) && value > 0 ? value : fallback;
+}
+
+function normalizePositiveLimit(
+  value: number | undefined,
+  fallback: number,
+): number {
+  return value !== undefined && Number.isSafeInteger(value) && value > 0
+    ? value
+    : fallback;
+}
+
 function codexThreadToRecentSession(
   thread: CodexThreadSummary,
   indexed?: CodexSessionIndexMetadata,
@@ -549,11 +565,15 @@ export interface BridgeServerOptions {
   promptHistoryBackup?: PromptHistoryBackupStore;
   promptHistoryStore?: PromptHistoryStore;
   platform?: NodeJS.Platform;
+  fileListMaxEntries?: number;
+  fileListMaxBytes?: number;
 }
 
 export class BridgeWebSocketServer {
   private static readonly MAX_DEBUG_EVENTS = 800;
   private static readonly MAX_HISTORY_SUMMARY_ITEMS = 300;
+  private static readonly DEFAULT_FILE_LIST_MAX_ENTRIES = 5000;
+  private static readonly DEFAULT_FILE_LIST_MAX_BYTES = 512 * 1024;
 
   private wss: WebSocketServer;
   private sessionManager: SessionManager;
@@ -597,6 +617,8 @@ export class BridgeWebSocketServer {
     "BRIDGE_FAIL_SET_PERMISSION_MODE",
   );
   private failSetSandboxMode = envFlagEnabled("BRIDGE_FAIL_SET_SANDBOX_MODE");
+  private readonly fileListMaxEntries: number;
+  private readonly fileListMaxBytes: number;
   private platform: NodeJS.Platform;
   private clientSupportedServerMessages = new WeakMap<WebSocket, Set<string>>();
   private pendingClaudeResumeInputs = new WeakMap<
@@ -618,6 +640,8 @@ export class BridgeWebSocketServer {
       promptHistoryBackup,
       promptHistoryStore,
       platform,
+      fileListMaxEntries,
+      fileListMaxBytes,
     } = options;
     this.apiKey = apiKey ?? null;
     this.allowedDirs = allowedDirs ?? [];
@@ -631,6 +655,20 @@ export class BridgeWebSocketServer {
     this.promptHistoryBackup = promptHistoryBackup ?? null;
     this.promptHistoryStore = promptHistoryStore ?? null;
     this.platform = platform ?? process.platform;
+    this.fileListMaxEntries = normalizePositiveLimit(
+      fileListMaxEntries,
+      positiveEnvInt(
+        "BRIDGE_FILE_LIST_MAX_ENTRIES",
+        BridgeWebSocketServer.DEFAULT_FILE_LIST_MAX_ENTRIES,
+      ),
+    );
+    this.fileListMaxBytes = normalizePositiveLimit(
+      fileListMaxBytes,
+      positiveEnvInt(
+        "BRIDGE_FILE_LIST_MAX_BYTES",
+        BridgeWebSocketServer.DEFAULT_FILE_LIST_MAX_BYTES,
+      ),
+    );
 
     this.archiveStore = new ArchiveStore();
     void this.debugTraceStore.init().catch((err) => {
@@ -4501,13 +4539,19 @@ export class BridgeWebSocketServer {
         }
         void (async () => {
           try {
-            const files = await listProjectFilesAndDirectories(
+            const result = await listProjectFilesAndDirectoriesForClient(
               msg.projectPath,
+              {
+                maxEntries: this.fileListMaxEntries,
+                maxBytes: this.fileListMaxBytes,
+              },
             );
-            this.send(ws, { type: "file_list", files } as Record<
-              string,
-              unknown
-            >);
+            this.send(ws, {
+              type: "file_list",
+              files: result.files,
+              totalFiles: result.totalFiles,
+              truncated: result.truncated,
+            } as Record<string, unknown>);
           } catch (err) {
             const message = err instanceof Error ? err.message : String(err);
             this.send(ws, {


### PR DESCRIPTION
## Summary
- stream `git ls-files` and stop only after observing an entry beyond the configured client limit
- cap client file lists at 5,000 entries and 512 KiB of serialized path data, with invalid/non-positive settings falling back to safe defaults
- propagate exact `truncated`/`totalFiles` metadata for Git and filesystem fallback paths, including depth/read truncation
- preserve the existing Mobile list stream while exposing metadata and showing a bounded-list notice in Explorer
- document `BRIDGE_FILE_LIST_MAX_ENTRIES` and `BRIDGE_FILE_LIST_MAX_BYTES`

## Validation
- `npm test -- --reporter=dot` (736 tests)
- `npx tsc --noEmit -p packages/bridge/tsconfig.json`
- `flutter test` (1,264 passed, 4 environment-dependent skipped)
- targeted Bridge tests (154 passed)
- targeted Mobile tests (21 passed)
- iOS simulator E2E with Bridge on port 8766 and max entries 2: Explorer displayed `Showing the first 2 entries` without overlap or runtime errors after connection
- independent self-review: LGTM

Reimplements and supersedes #141. Credit to @Edwiv; the original author is preserved as a co-author.