### PR TITLE
perf(bridge): cool down connection metadata refreshes

### DIFF
--- a/packages/bridge/src/websocket.test.ts
+++ b/packages/bridge/src/websocket.test.ts
@@ -137,6 +137,8 @@ vi.mock("./session.js", () => ({
         }),
         listThreads: vi.fn(async () => ({ data: [], nextCursor: null })),
         listAvailableModels: vi.fn(async () => []),
+        listAvailableModelMetadata: vi.fn(async () => []),
+        readProfileConfig: vi.fn(async () => ({ profiles: [] })),
         readThread: vi.fn(async () => ({ id: "thread-read", turns: [] })),
         rollbackThread: vi.fn(async () => ({ id: "thread-rollback", turns: [] })),
         rollbackThreadById: vi.fn(async () => ({
@@ -394,6 +396,7 @@ vi.mock("./session.js", () => ({
 }));
 
 import { BridgeWebSocketServer } from "./websocket.js";
+import { CodexProcess } from "./codex-process.js";
 
 describe("BridgeWebSocketServer resume/get_history flow", () => {
   const OPEN_STATE = 1;
@@ -575,27 +578,32 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
       send: vi.fn(),
     } as any;
 
-    (bridge as any).loadCodexModels = vi.fn(async () => [
-      {
-        model: "gpt-dynamic-default",
-        supportedReasoningEfforts: ["low", "medium", "high"],
-      },
-      {
-        model: "gpt-dynamic-fast",
-        supportedReasoningEfforts: ["low"],
-      },
-    ]);
+    const codexProcess = {
+      readProfileConfig: vi.fn(async () => ({ profiles: [] })),
+      listAvailableModelMetadata: vi.fn(async () => [
+        {
+          model: "gpt-dynamic-default",
+          supportedReasoningEfforts: ["low", "medium", "high"],
+        },
+        {
+          model: "gpt-dynamic-fast",
+          supportedReasoningEfforts: ["low"],
+        },
+      ]),
+      stop: vi.fn(),
+    };
+    vi.spyOn(bridge as any, "createStandaloneCodexProcess").mockResolvedValue(
+      codexProcess,
+    );
 
-    await (bridge as any).refreshCodexModels("/tmp/project-models");
+    await (bridge as any).refreshCodexMetadata("/tmp/project-models");
     (bridge as any).sendSessionList(ws);
 
     const sessionList = ws.send.mock.calls
       .map((c: unknown[]) => JSON.parse(c[0] as string))
       .find((msg: any) => msg.type === "session_list");
 
-    expect((bridge as any).loadCodexModels).toHaveBeenCalledWith(
-      "/tmp/project-models",
-    );
+    expect(codexProcess.listAvailableModelMetadata).toHaveBeenCalledTimes(1);
     expect(sessionList.codexModels).toEqual([
       "gpt-dynamic-default",
       "gpt-dynamic-fast",
@@ -615,11 +623,18 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
       send: vi.fn(),
     } as any;
 
-    (bridge as any).loadCodexModels = vi.fn(async () => {
-      throw new Error("unsupported method");
-    });
+    const codexProcess = {
+      readProfileConfig: vi.fn(async () => ({ profiles: [] })),
+      listAvailableModelMetadata: vi.fn(async () => {
+        throw new Error("unsupported method");
+      }),
+      stop: vi.fn(),
+    };
+    vi.spyOn(bridge as any, "createStandaloneCodexProcess").mockResolvedValue(
+      codexProcess,
+    );
 
-    await (bridge as any).refreshCodexModels("/tmp/project-models");
+    await (bridge as any).refreshCodexMetadata("/tmp/project-models");
     (bridge as any).sendSessionList(ws);
 
     const sessionList = ws.send.mock.calls
@@ -732,6 +747,130 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     }
   });
 
+  it("refreshes connection metadata initially and after the cooldown", () => {
+    const bridge = new BridgeWebSocketServer({ server: httpServer });
+    const refreshCodexMetadata = vi
+      .spyOn(bridge as any, "refreshCodexMetadata")
+      .mockResolvedValue(undefined);
+    const refreshClaudeModels = vi
+      .spyOn(bridge as any, "refreshClaudeModels")
+      .mockResolvedValue(undefined);
+
+    (bridge as any).refreshConnectionMetadata(1_000);
+    (bridge as any).refreshConnectionMetadata(2_000);
+    (bridge as any).refreshConnectionMetadata(301_000);
+
+    expect(refreshCodexMetadata).toHaveBeenCalledTimes(2);
+    expect(refreshClaudeModels).toHaveBeenCalledTimes(2);
+    bridge.close();
+  });
+
+  it("loads codex profiles and models with one standalone process", async () => {
+    const bridge = new BridgeWebSocketServer({ server: httpServer });
+    const codexProcess = {
+      readProfileConfig: vi.fn().mockResolvedValue({
+        profiles: ["ccpocket"],
+        defaultProfile: "ccpocket",
+      }),
+      listAvailableModelMetadata: vi.fn().mockResolvedValue([
+        {
+          model: "gpt-test",
+          supportedReasoningEfforts: ["high"],
+        },
+      ]),
+      stop: vi.fn(),
+    };
+    const createStandalone = vi
+      .spyOn(bridge as any, "createStandaloneCodexProcess")
+      .mockResolvedValue(codexProcess);
+    vi.spyOn(bridge as any, "broadcastSessionList").mockImplementation(() => {});
+
+    await (bridge as any).refreshCodexMetadata("/tmp/project-a");
+
+    expect(createStandalone).toHaveBeenCalledTimes(1);
+    expect(codexProcess.readProfileConfig).toHaveBeenCalledWith(
+      "/tmp/project-a",
+    );
+    expect(codexProcess.listAvailableModelMetadata).toHaveBeenCalledTimes(1);
+    expect(codexProcess.stop).toHaveBeenCalledTimes(1);
+    expect((bridge as any).codexProfiles).toEqual(["ccpocket"]);
+    expect((bridge as any).codexModels).toEqual(["gpt-test"]);
+    bridge.close();
+  });
+
+  it("keeps codex models when profile metadata fails", async () => {
+    const bridge = new BridgeWebSocketServer({ server: httpServer });
+    const codexProcess = {
+      readProfileConfig: vi.fn().mockRejectedValue(new Error("profile failed")),
+      listAvailableModelMetadata: vi.fn().mockResolvedValue([
+        {
+          model: "gpt-test",
+          supportedReasoningEfforts: ["medium"],
+        },
+      ]),
+      stop: vi.fn(),
+    };
+    vi.spyOn(bridge as any, "createStandaloneCodexProcess").mockResolvedValue(
+      codexProcess,
+    );
+    vi.spyOn(bridge as any, "broadcastSessionList").mockImplementation(() => {});
+
+    await (bridge as any).refreshCodexMetadata();
+
+    expect((bridge as any).codexProfiles).toEqual([]);
+    expect((bridge as any).codexModels).toEqual(["gpt-test"]);
+    expect(codexProcess.stop).toHaveBeenCalledTimes(1);
+    bridge.close();
+  });
+
+  it("runs a project metadata refresh after an in-flight connect refresh", async () => {
+    const bridge = new BridgeWebSocketServer({ server: httpServer });
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>((resolvePromise) => {
+      releaseFirst = resolvePromise;
+    });
+    const paths: Array<string | undefined> = [];
+    vi.spyOn(bridge as any, "loadAndApplyCodexMetadata").mockImplementation(
+      async (projectPath?: string) => {
+        paths.push(projectPath);
+        if (paths.length === 1) await firstGate;
+      },
+    );
+
+    const connectRefresh = (bridge as any).refreshCodexMetadata();
+    const projectRefresh = (bridge as any).refreshCodexMetadata(
+      "/tmp/project-a",
+    );
+    await Promise.resolve();
+    expect(paths).toEqual([undefined]);
+
+    releaseFirst();
+    await Promise.all([connectRefresh, projectRefresh]);
+    expect(paths).toEqual([undefined, "/tmp/project-a"]);
+    bridge.close();
+  });
+
+  it("stops a standalone codex process when initialization fails", async () => {
+    const bridge = new BridgeWebSocketServer({ server: httpServer });
+    const initializeOnly = vi
+      .spyOn(CodexProcess.prototype, "initializeOnly")
+      .mockRejectedValueOnce(new Error("initialize failed"));
+    const stop = vi
+      .spyOn(CodexProcess.prototype, "stop")
+      .mockImplementation(() => {});
+    try {
+      await expect(
+        (bridge as any).createStandaloneCodexProcess("/tmp/project-a"),
+      ).rejects.toThrow("initialize failed");
+      expect(initializeOnly).toHaveBeenCalledWith("/tmp/project-a");
+      expect(stop).toHaveBeenCalledTimes(1);
+    } finally {
+      initializeOnly.mockRestore();
+      stop.mockRestore();
+      bridge.close();
+    }
+  });
+
   it("rejects start when selected codex profile does not exist", async () => {
     const bridge = new BridgeWebSocketServer({ server: httpServer });
     const ws = {
@@ -790,6 +929,28 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
       profile: "ccpocket",
     });
 
+    bridge.close();
+  });
+
+  it("refreshes codex metadata after a codex session starts", async () => {
+    const bridge = new BridgeWebSocketServer({ server: httpServer });
+    const ws = { readyState: OPEN_STATE, send: vi.fn() } as any;
+    const refreshCodexMetadata = vi
+      .spyOn(bridge as any, "refreshCodexMetadata")
+      .mockResolvedValue(undefined);
+
+    await (bridge as any).handleClientMessage(
+      {
+        type: "start",
+        projectPath: "/tmp/project-a",
+        provider: "codex",
+      },
+      ws,
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(refreshCodexMetadata).toHaveBeenCalledWith("/tmp/project-a");
     bridge.close();
   });
 

--- a/packages/bridge/src/websocket.ts
+++ b/packages/bridge/src/websocket.ts
@@ -572,6 +572,7 @@ export interface BridgeServerOptions {
 export class BridgeWebSocketServer {
   private static readonly MAX_DEBUG_EVENTS = 800;
   private static readonly MAX_HISTORY_SUMMARY_ITEMS = 300;
+  private static readonly CONNECT_METADATA_REFRESH_COOLDOWN_MS = 5 * 60 * 1000;
   private static readonly DEFAULT_FILE_LIST_MAX_ENTRIES = 5000;
   private static readonly DEFAULT_FILE_LIST_MAX_BYTES = 512 * 1024;
 
@@ -595,7 +596,8 @@ export class BridgeWebSocketServer {
   private archiveStore: ArchiveStore;
   private codexProfiles: string[] = [];
   private defaultCodexProfile: string | undefined;
-  private codexProfilesRequest: Promise<void> | null = null;
+  private codexMetadataRequest: Promise<void> | null = null;
+  private lastConnectMetadataRefreshAt: number | null = null;
   private claudeModels: string[] = FALLBACK_CLAUDE_MODELS;
   private claudeModelEfforts: Record<string, ClaudeEffortLevel[]> = {
     ...FALLBACK_CLAUDE_MODEL_EFFORTS,
@@ -609,7 +611,6 @@ export class BridgeWebSocketServer {
         FALLBACK_CODEX_REASONING_EFFORTS,
       ]),
     );
-  private codexModelsRequest: Promise<void> | null = null;
   /** FCM token → push notification locale */
   private tokenLocales = new Map<string, PushLocale>();
   private tokenPrivacyMode = new Map<string, boolean>();
@@ -1881,9 +1882,7 @@ export class BridgeWebSocketServer {
 
   private handleConnection(ws: WebSocket): void {
     // Send session list and project history on connect
-    void this.refreshCodexProfiles();
-    void this.refreshCodexModels();
-    void this.refreshClaudeModels();
+    this.refreshConnectionMetadata();
     this.sendSessionList(ws);
     const projects = this.projectHistory?.getProjects() ?? [];
     this.send(ws, { type: "project_history", projects });
@@ -1926,6 +1925,21 @@ export class BridgeWebSocketServer {
     ws.on("error", (err) => {
       console.error("[ws] Client error:", err.message);
     });
+  }
+
+  private refreshConnectionMetadata(now = Date.now()): void {
+    const lastRefreshAt = this.lastConnectMetadataRefreshAt;
+    if (
+      lastRefreshAt !== null &&
+      now >= lastRefreshAt &&
+      now - lastRefreshAt <
+        BridgeWebSocketServer.CONNECT_METADATA_REFRESH_COOLDOWN_MS
+    ) {
+      return;
+    }
+    this.lastConnectMetadataRefreshAt = now;
+    void this.refreshCodexMetadata();
+    void this.refreshClaudeModels();
   }
 
   private async handleClientMessage(
@@ -2180,7 +2194,7 @@ export class BridgeWebSocketServer {
             );
             this.broadcastSessionList();
             if (provider === "codex") {
-              void this.refreshCodexModels(projectPath);
+              void this.refreshCodexMetadata(projectPath);
             } else {
               void this.refreshClaudeModels(projectPath);
             }
@@ -5974,26 +5988,64 @@ export class BridgeWebSocketServer {
     }
   }
 
-  private async refreshCodexModels(projectPath?: string): Promise<void> {
-    if (this.codexModelsRequest) return this.codexModelsRequest;
-    this.codexModelsRequest = this.loadCodexModels(projectPath)
-      .then((models) => {
-        if (models.length > 0) {
-          this.applyCodexModels(models);
-        } else {
-          this.applyFallbackCodexModels();
-        }
-        this.broadcastSessionList();
-      })
+  private async refreshCodexMetadata(projectPath?: string): Promise<void> {
+    if (this.codexMetadataRequest) {
+      if (projectPath) {
+        return this.codexMetadataRequest.then(() =>
+          this.refreshCodexMetadata(projectPath),
+        );
+      }
+      return this.codexMetadataRequest;
+    }
+    this.codexMetadataRequest = this.loadAndApplyCodexMetadata(projectPath)
       .catch((err) => {
-        console.warn(`[ws] Failed to load Codex models: ${err}`);
+        console.warn(`[ws] Failed to load Codex metadata: ${err}`);
+        this.codexProfiles = [];
+        this.defaultCodexProfile = undefined;
         this.applyFallbackCodexModels();
         this.broadcastSessionList();
       })
       .finally(() => {
-        this.codexModelsRequest = null;
+        this.codexMetadataRequest = null;
       });
-    return this.codexModelsRequest;
+    return this.codexMetadataRequest;
+  }
+
+  private async loadAndApplyCodexMetadata(
+    projectPath?: string,
+  ): Promise<void> {
+    const activeProcess = this.getActiveCodexProcess();
+    const codexProcess =
+      activeProcess ?? (await this.createStandaloneCodexProcess(projectPath));
+    try {
+      const [profileResult, modelResult] = await Promise.allSettled([
+        codexProcess.readProfileConfig(projectPath),
+        this.readCodexModels(codexProcess),
+      ]);
+
+      if (profileResult.status === "fulfilled") {
+        this.codexProfiles = profileResult.value.profiles;
+        this.defaultCodexProfile = profileResult.value.defaultProfile;
+      } else {
+        console.warn(
+          `[ws] Failed to load Codex profiles: ${profileResult.reason}`,
+        );
+        this.codexProfiles = [];
+        this.defaultCodexProfile = undefined;
+      }
+
+      if (modelResult.status === "fulfilled" && modelResult.value.length > 0) {
+        this.applyCodexModels(modelResult.value);
+      } else {
+        if (modelResult.status === "rejected") {
+          console.warn(`[ws] Failed to load Codex models: ${modelResult.reason}`);
+        }
+        this.applyFallbackCodexModels();
+      }
+      this.broadcastSessionList();
+    } finally {
+      if (!activeProcess) codexProcess.stop();
+    }
   }
 
   private async refreshClaudeModels(projectPath?: string): Promise<void> {
@@ -6042,33 +6094,23 @@ export class BridgeWebSocketServer {
     this.claudeModelEfforts = { ...FALLBACK_CLAUDE_MODEL_EFFORTS };
   }
 
-  private async loadCodexModels(
-    projectPath?: string,
+  private async readCodexModels(
+    codexProcess: CodexProcess,
   ): Promise<CodexModelMetadata[]> {
-    const process =
-      this.getActiveCodexProcess() ??
-      (await this.createStandaloneCodexProcess(projectPath));
-    const isStandalone = process !== this.getActiveCodexProcess();
-    try {
-      const modelSource = process as CodexProcess & {
-        listAvailableModelMetadata?: () => Promise<CodexModelMetadata[]>;
-        listAvailableModels?: () => Promise<string[]>;
-      };
-      if (typeof modelSource.listAvailableModelMetadata === "function") {
-        return await modelSource.listAvailableModelMetadata();
-      }
-      const models = typeof modelSource.listAvailableModels === "function"
-        ? await modelSource.listAvailableModels()
-        : [];
-      return models.map((model) => ({
-        model,
-        supportedReasoningEfforts: FALLBACK_CODEX_REASONING_EFFORTS,
-      }));
-    } finally {
-      if (isStandalone) {
-        process.stop();
-      }
+    const modelSource = codexProcess as CodexProcess & {
+      listAvailableModelMetadata?: () => Promise<CodexModelMetadata[]>;
+      listAvailableModels?: () => Promise<string[]>;
+    };
+    if (typeof modelSource.listAvailableModelMetadata === "function") {
+      return modelSource.listAvailableModelMetadata();
     }
+    const models = typeof modelSource.listAvailableModels === "function"
+      ? await modelSource.listAvailableModels()
+      : [];
+    return models.map((model) => ({
+      model,
+      supportedReasoningEfforts: FALLBACK_CODEX_REASONING_EFFORTS,
+    }));
   }
 
   private applyCodexModels(models: CodexModelMetadata[]): void {
@@ -6091,25 +6133,6 @@ export class BridgeWebSocketServer {
         FALLBACK_CODEX_REASONING_EFFORTS,
       ]),
     );
-  }
-
-  private async refreshCodexProfiles(projectPath?: string): Promise<void> {
-    if (this.codexProfilesRequest) return this.codexProfilesRequest;
-    this.codexProfilesRequest = this.loadCodexProfiles(projectPath)
-      .then(({ profiles, defaultProfile }) => {
-        this.codexProfiles = profiles;
-        this.defaultCodexProfile = defaultProfile;
-        this.broadcastSessionList();
-      })
-      .catch((err) => {
-        console.warn(`[ws] Failed to load Codex profiles: ${err}`);
-        this.codexProfiles = [];
-        this.defaultCodexProfile = undefined;
-      })
-      .finally(() => {
-        this.codexProfilesRequest = null;
-      });
-    return this.codexProfilesRequest;
   }
 
   private async loadCodexProfiles(
@@ -6248,8 +6271,13 @@ export class BridgeWebSocketServer {
     projectPath?: string,
   ): Promise<CodexProcess> {
     const proc = new CodexProcess();
-    await proc.initializeOnly(projectPath ?? process.cwd());
-    return proc;
+    try {
+      await proc.initializeOnly(projectPath ?? process.cwd());
+      return proc;
+    } catch (err) {
+      proc.stop();
+      throw err;
+    }
   }
 
   /** Extract a short project label from the full projectPath (last directory name). */


### PR DESCRIPTION
## Summary
- refresh Codex profiles/models and Claude models on the first client connection, then suppress reconnect refreshes for five minutes
- fetch Codex profiles and models through one process while preserving independent fallbacks
- refresh Codex metadata with the project-scoped active process after session start
- stop standalone Codex processes even when initialization fails

## Context
Maintainer reimplementation of #138. The original reconnect optimization skipped initial Codex profile discovery; this keeps the optimization without regressing profile availability.

Credit to @Edwiv and 鄭伊杰 for the original report and implementation. The commit preserves co-authorship.

## Validation
- `npm test -- --reporter=dot` (31 files, 742 tests)
- `npx tsc --noEmit -p packages/bridge/tsconfig.json`
- real Bridge on port 8766: first WebSocket connection spawned one Codex app-server; the second connection within the cooldown spawned none
- independent self-review: PASS / LGTM