### PR TITLE
fix(bridge): validate server port before startup

### DIFF
--- a/packages/bridge/src/bridge-port.test.ts
+++ b/packages/bridge/src/bridge-port.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { DEFAULT_BRIDGE_PORT, parseBridgePort } from "./bridge-port.js";
+
+const originalBridgePort = process.env.BRIDGE_PORT;
+
+describe("parseBridgePort", () => {
+  afterEach(() => {
+    if (originalBridgePort === undefined) {
+      delete process.env.BRIDGE_PORT;
+    } else {
+      process.env.BRIDGE_PORT = originalBridgePort;
+    }
+  });
+
+  it("uses the default bridge port when no value is configured", () => {
+    delete process.env.BRIDGE_PORT;
+
+    expect(parseBridgePort()).toBe(DEFAULT_BRIDGE_PORT);
+  });
+
+  it("reads BRIDGE_PORT from the environment", () => {
+    process.env.BRIDGE_PORT = "9876";
+
+    expect(parseBridgePort()).toBe(9876);
+  });
+
+  it.each([
+    ["1", 1],
+    ["8765", 8765],
+    ["65535", 65535],
+    [" 8765 ", 8765],
+  ])("accepts %s", (rawPort, expected) => {
+    expect(parseBridgePort(rawPort)).toBe(expected);
+  });
+
+  it.each(["", "0", "-1", "65536", "123abc", "8.5", "NaN"])(
+    "rejects %s",
+    (rawPort) => {
+      expect(() => parseBridgePort(rawPort)).toThrow(
+        `Invalid BRIDGE_PORT "${rawPort}"`,
+      );
+    },
+  );
+});

--- a/packages/bridge/src/bridge-port.ts
+++ b/packages/bridge/src/bridge-port.ts
@@ -1,0 +1,27 @@
+export const DEFAULT_BRIDGE_PORT = 8765;
+
+const MIN_BRIDGE_PORT = 1;
+const MAX_BRIDGE_PORT = 65535;
+
+function invalidBridgePortMessage(rawPort: string): string {
+  return `Invalid BRIDGE_PORT "${rawPort}": expected an integer between ${MIN_BRIDGE_PORT} and ${MAX_BRIDGE_PORT}.`;
+}
+
+export function parseBridgePort(
+  rawPort = process.env.BRIDGE_PORT ?? String(DEFAULT_BRIDGE_PORT),
+): number {
+  const normalized = rawPort.trim();
+  if (!/^\d+$/.test(normalized)) {
+    throw new Error(invalidBridgePortMessage(rawPort));
+  }
+
+  const port = Number(normalized);
+  if (
+    !Number.isSafeInteger(port) ||
+    port < MIN_BRIDGE_PORT ||
+    port > MAX_BRIDGE_PORT
+  ) {
+    throw new Error(invalidBridgePortMessage(rawPort));
+  }
+  return port;
+}

--- a/packages/bridge/src/cli-args.test.ts
+++ b/packages/bridge/src/cli-args.test.ts
@@ -55,6 +55,12 @@ describe("parseCliArgs", () => {
     expect(parseFlag(parsed, "host")).toBe("127.0.0.1");
   });
 
+  it("preserves a value flag with a missing value", () => {
+    const parsed = parseCliArgs(["--port"]);
+
+    expect(parseFlag(parsed, "port")).toBe("");
+  });
+
   it("detects setup command after valued flags", () => {
     const parsed = parseCliArgs(["--port", "9000", "setup", "--uninstall"]);
 

--- a/packages/bridge/src/cli-args.ts
+++ b/packages/bridge/src/cli-args.ts
@@ -50,6 +50,8 @@ export function parseCliArgs(args: string[]): ParsedCliArgs {
         } else if (i + 1 < args.length) {
           flags.set(name, args[i + 1]);
           i += 1;
+        } else {
+          flags.set(name, "");
         }
         continue;
       }

--- a/packages/bridge/src/cli.test.ts
+++ b/packages/bridge/src/cli.test.ts
@@ -1,0 +1,60 @@
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+import { describe, expect, it } from "vitest";
+
+const require = createRequire(import.meta.url);
+const tsxCli = require.resolve("tsx/cli");
+
+function runCli(args: string[], bridgePort?: string) {
+  const env = { ...process.env };
+  if (bridgePort === undefined) {
+    delete env.BRIDGE_PORT;
+  } else {
+    env.BRIDGE_PORT = bridgePort;
+  }
+  return spawnSync(process.execPath, [tsxCli, "src/cli.ts", ...args], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    env,
+  });
+}
+
+describe("ccpocket-bridge CLI", () => {
+  it("rejects an invalid --port value before server startup", () => {
+    const result = runCli(["--port", "abc"]);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      '[bridge] Failed to start: Invalid BRIDGE_PORT "abc"',
+    );
+    expect(result.stdout).not.toContain("Starting ccpocket bridge server");
+  });
+
+  it("does not ignore an empty inline --port value", () => {
+    const result = runCli(["--port="]);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      '[bridge] Failed to start: Invalid BRIDGE_PORT ""',
+    );
+  });
+
+  it("rejects --port when its value is missing", () => {
+    const result = runCli(["--port"]);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      '[bridge] Failed to start: Invalid BRIDGE_PORT ""',
+    );
+  });
+
+  it("rejects an invalid BRIDGE_PORT before server startup", () => {
+    const result = runCli([], "8.5");
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      '[bridge] Failed to start: Invalid BRIDGE_PORT "8.5"',
+    );
+    expect(result.stdout).not.toContain("Starting ccpocket bridge server");
+  });
+});

--- a/packages/bridge/src/cli.ts
+++ b/packages/bridge/src/cli.ts
@@ -5,6 +5,10 @@ import { startServer } from "./index.js";
 import { getPackageVersion } from "./version.js";
 import { hasFlag, parseCliArgs, parseFlag } from "./cli-args.js";
 
+function startupErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
 const args = process.argv.slice(2);
 const parsed = parseCliArgs(args);
 
@@ -128,7 +132,7 @@ if (parsed.helpRequested) {
   const codexAppServerPort = parseFlag(parsed, "codex-app-server-port");
   const codexAppServerUrl = parseFlag(parsed, "codex-app-server-url");
 
-  if (port) process.env.BRIDGE_PORT = port;
+  if (port !== undefined) process.env.BRIDGE_PORT = port;
   if (host) process.env.BRIDGE_HOST = host;
   if (apiKey) process.env.BRIDGE_API_KEY = apiKey;
   if (publicWsUrl) process.env.BRIDGE_PUBLIC_WS_URL = publicWsUrl;
@@ -145,5 +149,8 @@ if (parsed.helpRequested) {
   }
   if (hasFlag(parsed, "no-mdns")) process.env.BRIDGE_DISABLE_MDNS = "1";
 
-  startServer();
+  startServer().catch((err) => {
+    console.error(`[bridge] Failed to start: ${startupErrorMessage(err)}`);
+    process.exit(1);
+  });
 }

--- a/packages/bridge/src/index.ts
+++ b/packages/bridge/src/index.ts
@@ -20,9 +20,15 @@ import {
   PromptHistoryStore,
 } from "./prompt-history-store.js";
 import { parseAllowedDirectories } from "./path-utils.js";
+import { parseBridgePort } from "./bridge-port.js";
+import { listenForStartup } from "./server-listen.js";
+
+function startupErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
 
 export async function startServer() {
-  const PORT = parseInt(process.env.BRIDGE_PORT ?? "8765", 10);
+  const PORT = parseBridgePort();
   const HOST = process.env.BRIDGE_HOST ?? "0.0.0.0";
   const API_KEY = process.env.BRIDGE_API_KEY;
 
@@ -212,12 +218,6 @@ export async function startServer() {
     promptHistoryStore,
   });
 
-  httpServer.listen(PORT, HOST, () => {
-    console.log(`[bridge] Ready. Listening on http://${HOST}:${PORT} (HTTP + WebSocket)`);
-    mdns?.start(PORT, API_KEY);
-    printStartupInfo(PORT, HOST, API_KEY);
-  });
-
   function shutdown() {
     console.log("\n[bridge] Shutting down gracefully...");
     mdns?.stop();
@@ -225,6 +225,20 @@ export async function startServer() {
     httpServer.close();
     process.exit(0);
   }
+
+  try {
+    await listenForStartup(httpServer, PORT, HOST);
+  } catch (err) {
+    wsServer.close();
+    httpServer.close();
+    throw err;
+  }
+
+  console.log(
+    `[bridge] Ready. Listening on http://${HOST}:${PORT} (HTTP + WebSocket)`,
+  );
+  mdns?.start(PORT, API_KEY);
+  printStartupInfo(PORT, HOST, API_KEY);
 
   process.on("SIGINT", shutdown);
   process.on("SIGTERM", shutdown);
@@ -238,7 +252,7 @@ const isDirectExecution =
 if (isDirectExecution) {
   setupProxy();
   startServer().catch((err) => {
-    console.error("[bridge] Failed to start:", err);
+    console.error(`[bridge] Failed to start: ${startupErrorMessage(err)}`);
     process.exit(1);
   });
 }

--- a/packages/bridge/src/server-listen.test.ts
+++ b/packages/bridge/src/server-listen.test.ts
@@ -1,0 +1,44 @@
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+import { listenForStartup } from "./server-listen.js";
+
+const servers: Server[] = [];
+
+describe("listenForStartup", () => {
+  afterEach(async () => {
+    await Promise.all(
+      servers.splice(0).map(
+        (server) =>
+          new Promise<void>((resolve) => {
+            if (!server.listening) {
+              resolve();
+              return;
+            }
+            server.close(() => resolve());
+          }),
+      ),
+    );
+  });
+
+  it("resolves after the server is listening", async () => {
+    const server = createServer();
+    servers.push(server);
+
+    await listenForStartup(server, 0, "127.0.0.1");
+
+    expect(server.listening).toBe(true);
+  });
+
+  it("rejects when the port is already in use", async () => {
+    const occupied = createServer();
+    const candidate = createServer();
+    servers.push(occupied, candidate);
+    await listenForStartup(occupied, 0, "127.0.0.1");
+    const port = (occupied.address() as AddressInfo).port;
+
+    await expect(
+      listenForStartup(candidate, port, "127.0.0.1"),
+    ).rejects.toMatchObject({ code: "EADDRINUSE" });
+  });
+});

--- a/packages/bridge/src/server-listen.ts
+++ b/packages/bridge/src/server-listen.ts
@@ -1,0 +1,28 @@
+import type { Server } from "node:http";
+
+export function listenForStartup(
+  server: Server,
+  port: number,
+  host: string,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const onError = (err: Error) => {
+      server.off("listening", onListening);
+      reject(err);
+    };
+    const onListening = () => {
+      server.off("error", onError);
+      resolve();
+    };
+
+    server.once("error", onError);
+    server.once("listening", onListening);
+    try {
+      server.listen(port, host);
+    } catch (err) {
+      server.off("error", onError);
+      server.off("listening", onListening);
+      reject(err);
+    }
+  });
+}

--- a/packages/bridge/src/setup-launchd.test.ts
+++ b/packages/bridge/src/setup-launchd.test.ts
@@ -24,6 +24,7 @@ const { setupLaunchd, uninstallLaunchd } = await import("./setup-launchd.js");
 
 const PLIST_PATH = "/Users/testuser/Library/LaunchAgents/com.ccpocket.bridge.plist";
 const originalBridgeEnv = {
+  port: process.env.BRIDGE_PORT,
   allowedDirs: process.env.BRIDGE_ALLOWED_DIRS,
   publicWsUrl: process.env.BRIDGE_PUBLIC_WS_URL,
   disableMdns: process.env.BRIDGE_DISABLE_MDNS,
@@ -65,6 +66,18 @@ describe("setup-launchd", () => {
       expect(content).not.toContain("BRIDGE_CODEX_APP_SERVER_MODE");
       expect(content).not.toContain("BRIDGE_CODEX_SHARED_APP_SERVER_URL");
     });
+
+    it.each(["", "123abc"])(
+      "rejects invalid port %j before writing or registering a service",
+      (port) => {
+        expect(() => setupLaunchd({ port })).toThrow(
+          `Invalid BRIDGE_PORT "${port}"`,
+        );
+
+        expect(mockWriteFileSync).not.toHaveBeenCalled();
+        expect(mockExecSync).not.toHaveBeenCalled();
+      },
+    );
 
     it("includes BRIDGE_ALLOWED_DIRS when provided", () => {
       process.env.BRIDGE_ALLOWED_DIRS = "/Users/testuser,/tmp/work";
@@ -168,6 +181,7 @@ describe("setup-launchd", () => {
 });
 
 function clearBridgeEnv(): void {
+  delete process.env.BRIDGE_PORT;
   delete process.env.BRIDGE_ALLOWED_DIRS;
   delete process.env.BRIDGE_PUBLIC_WS_URL;
   delete process.env.BRIDGE_DISABLE_MDNS;
@@ -178,6 +192,7 @@ function clearBridgeEnv(): void {
 }
 
 function restoreBridgeEnv(): void {
+  restoreEnvVar("BRIDGE_PORT", originalBridgeEnv.port);
   restoreEnvVar("BRIDGE_ALLOWED_DIRS", originalBridgeEnv.allowedDirs);
   restoreEnvVar("BRIDGE_PUBLIC_WS_URL", originalBridgeEnv.publicWsUrl);
   restoreEnvVar("BRIDGE_DISABLE_MDNS", originalBridgeEnv.disableMdns);

--- a/packages/bridge/src/setup-launchd.ts
+++ b/packages/bridge/src/setup-launchd.ts
@@ -6,6 +6,7 @@ import {
   defaultCodexSharedAppServerUrl,
   readCodexSharedAppServerUrl,
 } from "./codex-app-server-config.js";
+import { parseBridgePort } from "./bridge-port.js";
 
 const PLIST_LABEL = "com.ccpocket.bridge";
 
@@ -43,7 +44,7 @@ interface SetupOptions {
 }
 
 export function setupLaunchd(opts: SetupOptions): void {
-  const port = opts.port ?? process.env.BRIDGE_PORT ?? "8765";
+  const port = parseBridgePort(opts.port ?? process.env.BRIDGE_PORT);
   const host = opts.host ?? process.env.BRIDGE_HOST ?? "0.0.0.0";
   const apiKey = opts.apiKey ?? process.env.BRIDGE_API_KEY ?? "";
   const allowedDirs = process.env.BRIDGE_ALLOWED_DIRS ?? "";
@@ -63,7 +64,7 @@ export function setupLaunchd(opts: SetupOptions): void {
     (codexAppServerMode === "managed"
       ? legacyCodexAppServerPort
         ? `ws://127.0.0.1:${legacyCodexAppServerPort}`
-        : defaultCodexSharedAppServerUrl(port)
+        : defaultCodexSharedAppServerUrl(String(port))
       : "");
   if (codexAppServerMode === "external" && !codexAppServerUrl) {
     throw new Error(

--- a/packages/bridge/src/setup-systemd.test.ts
+++ b/packages/bridge/src/setup-systemd.test.ts
@@ -29,6 +29,7 @@ const { setupSystemd, uninstallSystemd } = await import("./setup-systemd.js");
 const SERVICE_PATH =
   "/home/testuser/.config/systemd/user/ccpocket-bridge.service";
 const originalBridgeEnv = {
+  port: process.env.BRIDGE_PORT,
   allowedDirs: process.env.BRIDGE_ALLOWED_DIRS,
   publicWsUrl: process.env.BRIDGE_PUBLIC_WS_URL,
   disableMdns: process.env.BRIDGE_DISABLE_MDNS,
@@ -82,6 +83,14 @@ describe("setup-systemd", () => {
       expect(content).not.toContain("BRIDGE_DISABLE_MDNS");
       expect(content).not.toContain("BRIDGE_CODEX_APP_SERVER_MODE");
       expect(content).not.toContain("BRIDGE_CODEX_SHARED_APP_SERVER_URL");
+    });
+
+    it("rejects an invalid environment port before writing or registering a service", () => {
+      process.env.BRIDGE_PORT = "65536";
+
+      expect(() => setupSystemd({})).toThrow('Invalid BRIDGE_PORT "65536"');
+      expect(mockWriteFileSync).not.toHaveBeenCalled();
+      expect(mockExecSync).not.toHaveBeenCalled();
     });
 
     it("includes BRIDGE_API_KEY when apiKey is provided", () => {
@@ -338,6 +347,7 @@ describe("setup-systemd", () => {
 });
 
 function clearBridgeEnv(): void {
+  delete process.env.BRIDGE_PORT;
   delete process.env.BRIDGE_ALLOWED_DIRS;
   delete process.env.BRIDGE_PUBLIC_WS_URL;
   delete process.env.BRIDGE_DISABLE_MDNS;
@@ -348,6 +358,7 @@ function clearBridgeEnv(): void {
 }
 
 function restoreBridgeEnv(): void {
+  restoreEnvVar("BRIDGE_PORT", originalBridgeEnv.port);
   restoreEnvVar("BRIDGE_ALLOWED_DIRS", originalBridgeEnv.allowedDirs);
   restoreEnvVar("BRIDGE_PUBLIC_WS_URL", originalBridgeEnv.publicWsUrl);
   restoreEnvVar("BRIDGE_DISABLE_MDNS", originalBridgeEnv.disableMdns);

--- a/packages/bridge/src/setup-systemd.ts
+++ b/packages/bridge/src/setup-systemd.ts
@@ -6,6 +6,7 @@ import {
   defaultCodexSharedAppServerUrl,
   readCodexSharedAppServerUrl,
 } from "./codex-app-server-config.js";
+import { parseBridgePort } from "./bridge-port.js";
 
 const SERVICE_NAME = "ccpocket-bridge";
 
@@ -92,7 +93,7 @@ const START_BRIDGE_COMMAND =
   'if [ -s "$HOME/.nvm/nvm.sh" ]; then . "$HOME/.nvm/nvm.sh"; nvm use --silent default >/dev/null 2>&1 || nvm use --silent node >/dev/null 2>&1 || true; fi; export PATH="$HOME/.local/bin:$HOME/bin:$PATH"; exec npx --yes @ccpocket/bridge@latest';
 
 export function setupSystemd(opts: SetupOptions): void {
-  const port = opts.port ?? process.env.BRIDGE_PORT ?? "8765";
+  const port = parseBridgePort(opts.port ?? process.env.BRIDGE_PORT);
   const host = opts.host ?? process.env.BRIDGE_HOST ?? "0.0.0.0";
   const apiKey = opts.apiKey ?? process.env.BRIDGE_API_KEY ?? "";
   const allowedDirs = process.env.BRIDGE_ALLOWED_DIRS ?? "";
@@ -112,7 +113,7 @@ export function setupSystemd(opts: SetupOptions): void {
     (codexAppServerMode === "managed"
       ? legacyCodexAppServerPort
         ? `ws://127.0.0.1:${legacyCodexAppServerPort}`
-        : defaultCodexSharedAppServerUrl(port)
+        : defaultCodexSharedAppServerUrl(String(port))
       : "");
   if (codexAppServerMode === "external" && !codexAppServerUrl) {
     throw new Error(


### PR DESCRIPTION
## Summary
- validate Bridge ports as decimal integers from 1 through 65535 before startup side effects
- make `startServer()` resolve only after the HTTP server binds and reject bind errors with cleanup
- report invalid values and async startup failures through concise CLI errors with exit code 1
- reject invalid ports before launchd/systemd service files or commands are created
- preserve missing `--port` values so they cannot silently fall back to the default

## Context
Maintainer reimplementation of #143. It extends the original change to cover persistent service setup, bind-error cleanup, missing flag values, and cross-platform CLI tests.

Credit to @Edwiv and 鄭伊杰 for the original report and implementation. The commit preserves co-authorship.

## Validation
- `npm test -- --reporter=dot` (34 files, 765 tests)
- `npx tsc --noEmit -p packages/bridge/tsconfig.json`
- `npm run bridge:build`
- real CLI: valid startup on port 8766
- real CLI: invalid `123abc` and missing `--port` rejected before startup
- real CLI: occupied port exits 1 with a concise `EADDRINUSE` error and closes the WebSocket server
- independent self-review: PASS / LGTM

No mobile E2E was required because this changes only Bridge CLI startup and service configuration; no app UI or protocol behavior changed.