### PR TITLE
perf(bridge): batch session delta broadcasts

### DIFF
--- a/packages/bridge/README.md
+++ b/packages/bridge/README.md
@@ -49,6 +49,8 @@ ccpocket-bridge --version
 | `BRIDGE_RECENT_SESSIONS_PROFILE` | (none) | Log recent-session index timing when set to `1` or `true` |
 | `BRIDGE_FILE_LIST_MAX_ENTRIES` | `5000` | Maximum file and directory entries returned to a client; non-positive or invalid values use the default |
 | `BRIDGE_FILE_LIST_MAX_BYTES` | `524288` | Maximum serialized path bytes returned in a client file list; non-positive or invalid values use the default |
+| `BRIDGE_DELTA_BATCH_MS` | `100` | Milliseconds to batch streaming deltas per connected client; set to `0` to disable batching |
+| `BRIDGE_DELTA_BATCH_MAX_CHARS` | `4096` | Maximum Unicode characters per batched streaming payload; non-positive or invalid values use the default |
 | `DIFF_IMAGE_AUTO_DISPLAY_KB` | `1024` (1 MB) | Auto-display diff images up to this size, in KB |
 | `DIFF_IMAGE_MAX_SIZE_MB` | `5` (5 MB) | Maximum diff image size available for on-demand loading, in MB |
 | `ANTHROPIC_API_KEY` | (none) | Claude Agent SDK API key used for Claude sessions |

--- a/packages/bridge/src/websocket.test.ts
+++ b/packages/bridge/src/websocket.test.ts
@@ -426,6 +426,7 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
   afterEach(() => {
     globalThis.fetch = originalFetch;
     vi.unstubAllEnvs();
+    vi.useRealTimers();
     httpServer.close();
   });
 
@@ -4220,6 +4221,331 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     bridge.close();
   });
 
+  it("batches deltas for clients that were connected when each delta arrived", () => {
+    vi.useFakeTimers();
+    const bridge = new BridgeWebSocketServer({
+      server: httpServer,
+      deltaBatchMs: 100,
+    });
+    const first = { readyState: OPEN_STATE, send: vi.fn() } as any;
+    const late = { readyState: OPEN_STATE, send: vi.fn() } as any;
+    (bridge as any).wss.clients.add(first);
+
+    (bridge as any).broadcastSessionMessage("s-1", {
+      type: "stream_delta",
+      text: "before ",
+    });
+    (bridge as any).wss.clients.add(late);
+    (bridge as any).broadcastSessionMessage("s-1", {
+      type: "stream_delta",
+      text: "after",
+    });
+    vi.advanceTimersByTime(100);
+
+    expect(first.send).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(first.send.mock.calls[0][0] as string)).toEqual({
+      type: "stream_delta",
+      text: "before after",
+      sessionId: "s-1",
+    });
+    expect(late.send).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(late.send.mock.calls[0][0] as string)).toEqual({
+      type: "stream_delta",
+      text: "after",
+      sessionId: "s-1",
+    });
+
+    bridge.close();
+  });
+
+  it("flushes alternating deltas before a non-delta session message", () => {
+    vi.useFakeTimers();
+    const bridge = new BridgeWebSocketServer({
+      server: httpServer,
+      deltaBatchMs: 100,
+    });
+    const ws = { readyState: OPEN_STATE, send: vi.fn() } as any;
+    (bridge as any).wss.clients.add(ws);
+
+    (bridge as any).broadcastSessionMessage("s-1", {
+      type: "stream_delta",
+      text: "answer ",
+    });
+    (bridge as any).broadcastSessionMessage("s-1", {
+      type: "thinking_delta",
+      text: "thought",
+    });
+    (bridge as any).broadcastSessionMessage("s-1", {
+      type: "stream_delta",
+      text: "done",
+    });
+    (bridge as any).broadcastSessionMessage("s-1", {
+      type: "status",
+      status: "idle",
+    });
+
+    expect(
+      ws.send.mock.calls.map((call: unknown[]) => JSON.parse(call[0] as string)),
+    ).toEqual([
+      { type: "stream_delta", text: "answer ", sessionId: "s-1" },
+      { type: "thinking_delta", text: "thought", sessionId: "s-1" },
+      { type: "stream_delta", text: "done", sessionId: "s-1" },
+      { type: "status", status: "idle", sessionId: "s-1" },
+    ]);
+    vi.advanceTimersByTime(100);
+    expect(ws.send).toHaveBeenCalledTimes(4);
+
+    bridge.close();
+  });
+
+  it("keeps batches isolated by session", () => {
+    vi.useFakeTimers();
+    const bridge = new BridgeWebSocketServer({
+      server: httpServer,
+      deltaBatchMs: 100,
+    });
+    const ws = { readyState: OPEN_STATE, send: vi.fn() } as any;
+    (bridge as any).wss.clients.add(ws);
+
+    (bridge as any).broadcastSessionMessage("s-1", {
+      type: "stream_delta",
+      text: "one",
+    });
+    (bridge as any).broadcastSessionMessage("s-2", {
+      type: "stream_delta",
+      text: "two",
+    });
+    (bridge as any).broadcastSessionMessage("s-1", {
+      type: "status",
+      status: "idle",
+    });
+
+    expect(
+      ws.send.mock.calls.map((call: unknown[]) => JSON.parse(call[0] as string)),
+    ).toEqual([
+      { type: "stream_delta", text: "one", sessionId: "s-1" },
+      { type: "status", status: "idle", sessionId: "s-1" },
+    ]);
+    vi.advanceTimersByTime(100);
+    expect(JSON.parse(ws.send.mock.calls[2][0] as string)).toEqual({
+      type: "stream_delta",
+      text: "two",
+      sessionId: "s-2",
+    });
+
+    bridge.close();
+  });
+
+  it("splits oversized deltas without breaking Unicode characters", () => {
+    vi.useFakeTimers();
+    const bridge = new BridgeWebSocketServer({
+      server: httpServer,
+      deltaBatchMs: 100,
+      deltaBatchMaxChars: 2,
+    });
+    const ws = { readyState: OPEN_STATE, send: vi.fn() } as any;
+    (bridge as any).wss.clients.add(ws);
+
+    (bridge as any).broadcastSessionMessage("s-1", {
+      type: "stream_delta",
+      text: "A😀BC",
+    });
+    vi.advanceTimersByTime(100);
+
+    const messages = ws.send.mock.calls.map((call: unknown[]) =>
+      JSON.parse(call[0] as string),
+    );
+    expect(messages.map((message: { text: string }) => message.text).join(""))
+      .toBe("A😀BC");
+    expect(
+      messages.every(
+        (message: { text: string }) => Array.from(message.text).length <= 2,
+      ),
+    ).toBe(true);
+
+    bridge.close();
+  });
+
+  it("flushes pending deltas before excluding a client from a later delta", () => {
+    vi.useFakeTimers();
+    const bridge = new BridgeWebSocketServer({
+      server: httpServer,
+      deltaBatchMs: 100,
+    });
+    const included = { readyState: OPEN_STATE, send: vi.fn() } as any;
+    const excluded = { readyState: OPEN_STATE, send: vi.fn() } as any;
+    (bridge as any).wss.clients.add(included);
+    (bridge as any).wss.clients.add(excluded);
+
+    (bridge as any).broadcastSessionMessage("s-1", {
+      type: "stream_delta",
+      text: "first",
+    });
+    (bridge as any).broadcastSessionMessage(
+      "s-1",
+      { type: "stream_delta", text: "second" },
+      excluded,
+    );
+
+    expect(
+      included.send.mock.calls.map((call: unknown[]) =>
+        JSON.parse(call[0] as string),
+      ),
+    ).toEqual([
+      { type: "stream_delta", text: "first", sessionId: "s-1" },
+      { type: "stream_delta", text: "second", sessionId: "s-1" },
+    ]);
+    expect(JSON.parse(excluded.send.mock.calls[0][0] as string)).toEqual({
+      type: "stream_delta",
+      text: "first",
+      sessionId: "s-1",
+    });
+
+    bridge.close();
+  });
+
+  it("flushes pending deltas before destroying a session", () => {
+    vi.useFakeTimers();
+    const bridge = new BridgeWebSocketServer({
+      server: httpServer,
+      deltaBatchMs: 100,
+    });
+    const ws = { readyState: OPEN_STATE, send: vi.fn() } as any;
+    (bridge as any).wss.clients.add(ws);
+    const destroy = vi.spyOn((bridge as any).sessionManager, "destroy");
+
+    (bridge as any).broadcastSessionMessage("s-1", {
+      type: "stream_delta",
+      text: "final",
+    });
+    (bridge as any).destroySession("s-1");
+
+    expect(JSON.parse(ws.send.mock.calls[0][0] as string)).toEqual({
+      type: "stream_delta",
+      text: "final",
+      sessionId: "s-1",
+    });
+    expect(ws.send.mock.invocationCallOrder[0]).toBeLessThan(
+      destroy.mock.invocationCallOrder[0],
+    );
+
+    bridge.close();
+  });
+
+  it("discards pending deltas when a client disconnects", () => {
+    vi.useFakeTimers();
+    const bridge = new BridgeWebSocketServer({
+      server: httpServer,
+      deltaBatchMs: 100,
+    });
+    const ws = { readyState: OPEN_STATE, send: vi.fn() } as any;
+    (bridge as any).wss.clients.add(ws);
+
+    (bridge as any).broadcastSessionMessage("s-1", {
+      type: "stream_delta",
+      text: "discarded",
+    });
+    (bridge as any).discardClientDeltaBatches(ws);
+    vi.advanceTimersByTime(100);
+
+    expect(ws.send).not.toHaveBeenCalled();
+
+    bridge.close();
+  });
+
+  it("records original deltas immediately instead of recording batches", () => {
+    vi.useFakeTimers();
+    const recordingStore = {
+      init: vi.fn(async () => {}),
+      record: vi.fn(),
+      saveMeta: vi.fn(),
+    };
+    const bridge = new BridgeWebSocketServer({
+      server: httpServer,
+      deltaBatchMs: 100,
+      recordingStore: recordingStore as any,
+    });
+    const ws = { readyState: OPEN_STATE, send: vi.fn() } as any;
+    (bridge as any).wss.clients.add(ws);
+
+    (bridge as any).broadcastSessionMessage("s-1", {
+      type: "stream_delta",
+      text: "a",
+    });
+    (bridge as any).broadcastSessionMessage("s-1", {
+      type: "stream_delta",
+      text: "b",
+    });
+
+    expect(recordingStore.record.mock.calls).toEqual([
+      ["s-1", "outgoing", { type: "stream_delta", text: "a" }],
+      ["s-1", "outgoing", { type: "stream_delta", text: "b" }],
+    ]);
+    expect(ws.send).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(100);
+    expect(JSON.parse(ws.send.mock.calls[0][0] as string).text).toBe("ab");
+
+    bridge.close();
+  });
+
+  it("supports disabled batching and strict environment defaults", () => {
+    vi.stubEnv("BRIDGE_DELTA_BATCH_MS", "100ms");
+    vi.stubEnv("BRIDGE_DELTA_BATCH_MAX_CHARS", "-1");
+    const fallbackBridge = new BridgeWebSocketServer({ server: httpServer });
+    expect((fallbackBridge as any).deltaBatchMs).toBe(100);
+    expect((fallbackBridge as any).deltaBatchMaxChars).toBe(4096);
+    fallbackBridge.close();
+
+    vi.stubEnv("BRIDGE_DELTA_BATCH_MS", "3000000000");
+    const overflowBridge = new BridgeWebSocketServer({ server: httpServer });
+    expect((overflowBridge as any).deltaBatchMs).toBe(100);
+    overflowBridge.close();
+
+    const overflowOptionBridge = new BridgeWebSocketServer({
+      server: httpServer,
+      deltaBatchMs: 3_000_000_000,
+    });
+    expect((overflowOptionBridge as any).deltaBatchMs).toBe(100);
+    overflowOptionBridge.close();
+
+    const disabledBridge = new BridgeWebSocketServer({
+      server: httpServer,
+      deltaBatchMs: 0,
+    });
+    const ws = { readyState: OPEN_STATE, send: vi.fn() } as any;
+    (disabledBridge as any).wss.clients.add(ws);
+    (disabledBridge as any).broadcastSessionMessage("s-1", {
+      type: "stream_delta",
+      text: "now",
+    });
+    expect(JSON.parse(ws.send.mock.calls[0][0] as string).text).toBe("now");
+    disabledBridge.close();
+  });
+
+  it("flushes every client batch during shutdown", () => {
+    vi.useFakeTimers();
+    const bridge = new BridgeWebSocketServer({
+      server: httpServer,
+      deltaBatchMs: 100,
+    });
+    const first = { readyState: OPEN_STATE, send: vi.fn() } as any;
+    const second = { readyState: OPEN_STATE, send: vi.fn() } as any;
+    (bridge as any).wss.clients.add(first);
+    (bridge as any).wss.clients.add(second);
+
+    (bridge as any).broadcastSessionMessage("s-1", {
+      type: "thinking_delta",
+      text: "closing",
+    });
+    bridge.close();
+
+    expect(first.send).toHaveBeenCalledTimes(1);
+    expect(second.send).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(100);
+    expect(first.send).toHaveBeenCalledTimes(1);
+    expect(second.send).toHaveBeenCalledTimes(1);
+  });
+
   it("sends push notification once per permission toolUseId", async () => {
     const fetchMock = vi.fn(async () => new Response("", { status: 200 }));
     globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
@@ -5376,8 +5702,13 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
   });
 
   it("includes sourceSessionId in rewind conversation session_created", async () => {
-    const bridge = new BridgeWebSocketServer({ server: httpServer });
+    vi.useFakeTimers();
+    const bridge = new BridgeWebSocketServer({
+      server: httpServer,
+      deltaBatchMs: 100,
+    });
     const ws = { readyState: OPEN_STATE, send: vi.fn() } as any;
+    (bridge as any).wss.clients.add(ws);
 
     // Create a session first
     (bridge as any).handleClientMessage(
@@ -5392,6 +5723,11 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
 
     ws.send.mockClear();
 
+    (bridge as any).broadcastSessionMessage(sessionId, {
+      type: "stream_delta",
+      text: "before rewind",
+    });
+
     // Send rewind (conversation mode)
     (bridge as any).handleClientMessage(
       { type: "rewind", sessionId, targetUuid: "user-msg-1", mode: "conversation" },
@@ -5401,6 +5737,11 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     await Promise.resolve();
 
     const rewindSends = ws.send.mock.calls.map((c: unknown[]) => JSON.parse(c[0] as string));
+    expect(rewindSends[0]).toEqual({
+      type: "stream_delta",
+      text: "before rewind",
+      sessionId,
+    });
     const rewindCreated = rewindSends.find(
       (m: any) => m.type === "system" && m.subtype === "session_created",
     );

--- a/packages/bridge/src/websocket.ts
+++ b/packages/bridge/src/websocket.ts
@@ -484,6 +484,8 @@ function envFlagEnabled(name: string): boolean {
   return value === "1" || value === "true" || value === "yes" || value === "on";
 }
 
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
 function positiveEnvInt(name: string, fallback: number): number {
   const raw = process.env[name]?.trim();
   if (!raw) return fallback;
@@ -491,11 +493,34 @@ function positiveEnvInt(name: string, fallback: number): number {
   return Number.isSafeInteger(value) && value > 0 ? value : fallback;
 }
 
+function nonNegativeEnvInt(name: string, fallback: number): number {
+  const raw = process.env[name]?.trim();
+  if (!raw) return fallback;
+  const value = Number(raw);
+  return Number.isSafeInteger(value) &&
+    value >= 0 &&
+    value <= MAX_TIMER_DELAY_MS
+    ? value
+    : fallback;
+}
+
 function normalizePositiveLimit(
   value: number | undefined,
   fallback: number,
 ): number {
   return value !== undefined && Number.isSafeInteger(value) && value > 0
+    ? value
+    : fallback;
+}
+
+function normalizeNonNegativeLimit(
+  value: number | undefined,
+  fallback: number,
+): number {
+  return value !== undefined &&
+    Number.isSafeInteger(value) &&
+    value >= 0 &&
+    value <= MAX_TIMER_DELAY_MS
     ? value
     : fallback;
 }
@@ -567,6 +592,24 @@ export interface BridgeServerOptions {
   platform?: NodeJS.Platform;
   fileListMaxEntries?: number;
   fileListMaxBytes?: number;
+  deltaBatchMs?: number;
+  deltaBatchMaxChars?: number;
+}
+
+type DeltaServerMessage = Extract<
+  ServerMessage,
+  { type: "stream_delta" | "thinking_delta" }
+>;
+
+interface DeltaBatch {
+  messages: DeltaServerMessage[];
+  timer: NodeJS.Timeout;
+  charCount: number;
+}
+
+interface DeltaTextChunk {
+  text: string;
+  charCount: number;
 }
 
 export class BridgeWebSocketServer {
@@ -575,6 +618,8 @@ export class BridgeWebSocketServer {
   private static readonly CONNECT_METADATA_REFRESH_COOLDOWN_MS = 5 * 60 * 1000;
   private static readonly DEFAULT_FILE_LIST_MAX_ENTRIES = 5000;
   private static readonly DEFAULT_FILE_LIST_MAX_BYTES = 512 * 1024;
+  private static readonly DEFAULT_DELTA_BATCH_MS = 100;
+  private static readonly DEFAULT_DELTA_BATCH_MAX_CHARS = 4096;
 
   private wss: WebSocketServer;
   private sessionManager: SessionManager;
@@ -620,6 +665,9 @@ export class BridgeWebSocketServer {
   private failSetSandboxMode = envFlagEnabled("BRIDGE_FAIL_SET_SANDBOX_MODE");
   private readonly fileListMaxEntries: number;
   private readonly fileListMaxBytes: number;
+  private readonly deltaBatchMs: number;
+  private readonly deltaBatchMaxChars: number;
+  private deltaBatches = new Map<WebSocket, Map<string, DeltaBatch>>();
   private platform: NodeJS.Platform;
   private clientSupportedServerMessages = new WeakMap<WebSocket, Set<string>>();
   private pendingClaudeResumeInputs = new WeakMap<
@@ -643,6 +691,8 @@ export class BridgeWebSocketServer {
       platform,
       fileListMaxEntries,
       fileListMaxBytes,
+      deltaBatchMs,
+      deltaBatchMaxChars,
     } = options;
     this.apiKey = apiKey ?? null;
     this.allowedDirs = allowedDirs ?? [];
@@ -668,6 +718,20 @@ export class BridgeWebSocketServer {
       positiveEnvInt(
         "BRIDGE_FILE_LIST_MAX_BYTES",
         BridgeWebSocketServer.DEFAULT_FILE_LIST_MAX_BYTES,
+      ),
+    );
+    this.deltaBatchMs = normalizeNonNegativeLimit(
+      deltaBatchMs,
+      nonNegativeEnvInt(
+        "BRIDGE_DELTA_BATCH_MS",
+        BridgeWebSocketServer.DEFAULT_DELTA_BATCH_MS,
+      ),
+    );
+    this.deltaBatchMaxChars = normalizePositiveLimit(
+      deltaBatchMaxChars,
+      positiveEnvInt(
+        "BRIDGE_DELTA_BATCH_MAX_CHARS",
+        BridgeWebSocketServer.DEFAULT_DELTA_BATCH_MAX_CHARS,
       ),
     );
 
@@ -1067,7 +1131,7 @@ export class BridgeWebSocketServer {
       expectedUserTurns: targetOrdinal - 1,
       fallback: buildCodexHistoryPrefix(session, targetOrdinal - 1),
     });
-    this.sessionManager.destroy(sessionId);
+    this.destroySession(sessionId);
     const newSessionId = this.sessionManager.create(
       projectPath,
       undefined,
@@ -1864,7 +1928,9 @@ export class BridgeWebSocketServer {
 
   close(): void {
     console.log("[ws] Shutting down...");
+    this.flushAllDeltaBatches();
     this.sessionManager.destroyAll();
+    this.flushAllDeltaBatches();
     stopManagedCodexAppServers();
     this.debugEvents.clear();
     this.wss.close();
@@ -1919,6 +1985,7 @@ export class BridgeWebSocketServer {
 
     ws.on("close", () => {
       console.log("[ws] Client disconnected");
+      this.discardClientDeltaBatches(ws);
       this.clearPendingClaudeResumeInputs(ws);
     });
 
@@ -2878,7 +2945,7 @@ export class BridgeWebSocketServer {
           const worktreeBranch = session.worktreeBranch;
           const sessionName = session.name;
 
-          this.sessionManager.destroy(oldSessionId);
+          this.destroySession(oldSessionId);
           console.log(
             `[ws] Permission mode change: destroyed session ${oldSessionId}`,
           );
@@ -3211,7 +3278,7 @@ export class BridgeWebSocketServer {
           const permissionMode = (session.process as SdkProcess).permissionMode;
           const model = (session.process as SdkProcess).model;
 
-          this.sessionManager.destroy(oldSessionId);
+          this.destroySession(oldSessionId);
           console.log(
             `[ws] Claude sandbox change: destroyed session ${oldSessionId}`,
           );
@@ -3296,7 +3363,7 @@ export class BridgeWebSocketServer {
           planMode,
         );
 
-        this.sessionManager.destroy(oldSessionId);
+        this.destroySession(oldSessionId);
         console.log(
           `[ws] Sandbox mode change: destroyed session ${oldSessionId}`,
         );
@@ -3512,7 +3579,7 @@ export class BridgeWebSocketServer {
           const worktreePath = session.worktreePath;
           const worktreeBranch = session.worktreeBranch;
 
-          this.sessionManager.destroy(sessionId);
+          this.destroySession(sessionId);
           console.log(`[ws] Clear context: destroyed session ${sessionId}`);
 
           const newId = this.sessionManager.create(
@@ -3610,7 +3677,7 @@ export class BridgeWebSocketServer {
             subtype: "stopped",
             sessionId: session.claudeSessionId,
           });
-          this.sessionManager.destroy(msg.sessionId);
+          this.destroySession(msg.sessionId);
           this.recordDebugEvent(msg.sessionId, {
             direction: "internal",
             channel: "bridge",
@@ -5264,6 +5331,7 @@ export class BridgeWebSocketServer {
         } else if (msg.mode === "conversation") {
           // Conversation-only rewind: restart session at the target UUID
           try {
+            this.flushSessionDeltaBatches(msg.sessionId);
             this.sessionManager.rewindConversation(
               msg.sessionId,
               msg.targetUuid,
@@ -5311,6 +5379,7 @@ export class BridgeWebSocketServer {
                 return;
               }
               try {
+                this.flushSessionDeltaBatches(msg.sessionId);
                 this.sessionManager.rewindConversation(
                   msg.sessionId,
                   msg.targetUuid,
@@ -5871,6 +5940,137 @@ export class BridgeWebSocketServer {
     msg: ServerMessage,
     exclude?: WebSocket,
   ): void {
+    if (this.shouldBatchDelta(msg, exclude)) {
+      this.trackSessionMessage(sessionId, msg);
+      const chunks = this.splitDeltaText(msg.text);
+      for (const client of this.wss.clients) {
+        if (client.readyState !== WebSocket.OPEN) continue;
+        if (!this.shouldSendToClient(client, msg)) continue;
+        this.queueDeltaForClient(client, sessionId, msg.type, chunks);
+      }
+      return;
+    }
+
+    this.flushSessionDeltaBatches(sessionId);
+    this.trackSessionMessage(sessionId, msg);
+    this.broadcastSessionMessageNow(sessionId, msg, exclude);
+  }
+
+  private shouldBatchDelta(
+    msg: ServerMessage,
+    exclude?: WebSocket,
+  ): msg is DeltaServerMessage {
+    if (this.deltaBatchMs === 0 || exclude) return false;
+    return msg.type === "stream_delta" || msg.type === "thinking_delta";
+  }
+
+  private queueDeltaForClient(
+    client: WebSocket,
+    sessionId: string,
+    type: DeltaServerMessage["type"],
+    chunks: DeltaTextChunk[],
+  ): void {
+    for (const chunk of chunks) {
+      let batch = this.deltaBatches.get(client)?.get(sessionId);
+      if (
+        batch &&
+        batch.charCount > 0 &&
+        batch.charCount + chunk.charCount > this.deltaBatchMaxChars
+      ) {
+        this.flushClientDeltaBatch(client, sessionId);
+        batch = undefined;
+      }
+
+      if (!batch) {
+        const clientBatches = this.deltaBatches.get(client) ?? new Map();
+        batch = {
+          messages: [],
+          charCount: 0,
+          timer: setTimeout(() => {
+            this.flushClientDeltaBatch(client, sessionId);
+          }, this.deltaBatchMs),
+        };
+        clientBatches.set(sessionId, batch);
+        this.deltaBatches.set(client, clientBatches);
+      }
+
+      const last = batch.messages.at(-1);
+      if (last?.type === type) {
+        last.text += chunk.text;
+      } else {
+        batch.messages.push({ type, text: chunk.text });
+      }
+      batch.charCount += chunk.charCount;
+
+      if (batch.charCount >= this.deltaBatchMaxChars) {
+        this.flushClientDeltaBatch(client, sessionId);
+      }
+    }
+  }
+
+  private splitDeltaText(text: string): DeltaTextChunk[] {
+    if (text.length === 0) return [{ text, charCount: 0 }];
+
+    const chunks: DeltaTextChunk[] = [];
+    let chars: string[] = [];
+    let charCount = 0;
+    for (const char of text) {
+      chars.push(char);
+      charCount += 1;
+      if (charCount >= this.deltaBatchMaxChars) {
+        chunks.push({ text: chars.join(""), charCount });
+        chars = [];
+        charCount = 0;
+      }
+    }
+    if (chars.length > 0) {
+      chunks.push({ text: chars.join(""), charCount });
+    }
+    return chunks;
+  }
+
+  private flushSessionDeltaBatches(sessionId: string): void {
+    for (const client of Array.from(this.deltaBatches.keys())) {
+      this.flushClientDeltaBatch(client, sessionId);
+    }
+  }
+
+  private flushAllDeltaBatches(): void {
+    for (const [client, batches] of Array.from(this.deltaBatches.entries())) {
+      for (const sessionId of Array.from(batches.keys())) {
+        this.flushClientDeltaBatch(client, sessionId);
+      }
+    }
+  }
+
+  private flushClientDeltaBatch(client: WebSocket, sessionId: string): void {
+    const clientBatches = this.deltaBatches.get(client);
+    const batch = clientBatches?.get(sessionId);
+    if (!batch) return;
+
+    clearTimeout(batch.timer);
+    clientBatches?.delete(sessionId);
+    if (clientBatches?.size === 0) this.deltaBatches.delete(client);
+    if (client.readyState !== WebSocket.OPEN) return;
+
+    for (const msg of batch.messages) {
+      client.send(JSON.stringify({ ...msg, sessionId }));
+    }
+  }
+
+  private discardClientDeltaBatches(client: WebSocket): void {
+    const batches = this.deltaBatches.get(client);
+    if (!batches) return;
+    for (const batch of batches.values()) clearTimeout(batch.timer);
+    this.deltaBatches.delete(client);
+  }
+
+  private destroySession(sessionId: string): void {
+    this.flushSessionDeltaBatches(sessionId);
+    this.sessionManager.destroy(sessionId);
+  }
+
+  private trackSessionMessage(sessionId: string, msg: ServerMessage): void {
     this.maybeSendPushNotification(sessionId, msg);
     this.recordDebugEvent(sessionId, {
       direction: "outgoing",
@@ -5896,7 +6096,13 @@ export class BridgeWebSocketServer {
         });
       }
     }
-    // Wrap the message with sessionId
+  }
+
+  private broadcastSessionMessageNow(
+    sessionId: string,
+    msg: ServerMessage,
+    exclude?: WebSocket,
+  ): void {
     const data = JSON.stringify({ ...msg, sessionId });
     for (const client of this.wss.clients) {
       if (client === exclude) continue;


### PR DESCRIPTION
## Summary
- batch high-frequency stream/thinking deltas per client and session while preserving recipient snapshots and message order
- keep logical debug/recording events unbatched and immediate
- flush pending deltas before terminal/session lifecycle messages and every session replacement path
- discard disconnected-client timers and flush active clients during shutdown
- enforce configurable time and Unicode-character bounds, including Node timer overflow handling

## Context
Maintainer reimplementation of #137. The original session-level batch could send pre-connection deltas to late clients and leak old-session deltas after recreation. This implementation batches per recipient and covers rewind, permission/sandbox changes, clear-context, stop, disconnect, and shutdown.

Credit to @Edwiv and 鄭伊杰 for the original report and implementation. The commit preserves co-authorship.

## Validation
- `npm test -- --reporter=dot` (34 files, 775 tests)
- `npx tsc --noEmit -p packages/bridge/tsconfig.json`
- independent self-review: PASS / LGTM
- iPhone 17 Pro simulator + Marionette against a test Bridge on port 8766
- stress settings: 250ms batching, 64 Unicode character maximum
- two deterministic streamed responses matched all sentinels exactly and remained unchanged after completion
- raw WebSocket observer: 16 frames, max 35 Unicode characters, concatenated text matched exactly
- interrupted long stream flushed through `ITEM-0150` plus the partial next token; text remained unchanged for 1.5s after Stop
- no Flutter runtime exception; test app, Bridge, and Codex session were stopped

No protocol or Flutter code changes are required; Mobile already appends delta text losslessly.