### PR TITLE
fix(app): show scoped release render fallback

### DIFF
--- a/apps/mobile/lib/l10n/app_en.arb
+++ b/apps/mobile/lib/l10n/app_en.arb
@@ -969,5 +969,6 @@
   "googleSearchSelectionAction": "Search with Google",
   "approvalQuestionNotificationTitle": "Question - ccpocket",
   "approvalRequiredNotificationTitle": "Approval Required - ccpocket",
-  "exitPlanModeNotificationBody": "The generated plan needs your review"
+  "exitPlanModeNotificationBody": "The generated plan needs your review",
+  "renderErrorFallback": "This content couldn't be displayed."
 }

--- a/apps/mobile/lib/l10n/app_ja.arb
+++ b/apps/mobile/lib/l10n/app_ja.arb
@@ -1020,5 +1020,6 @@
   "googleSearchSelectionAction": "Google で検索",
   "approvalQuestionNotificationTitle": "質問があります - ccpocket",
   "approvalRequiredNotificationTitle": "承認待ち - ccpocket",
-  "exitPlanModeNotificationBody": "作成したプランの確認が必要です"
+  "exitPlanModeNotificationBody": "作成したプランの確認が必要です",
+  "renderErrorFallback": "このコンテンツを表示できませんでした"
 }

--- a/apps/mobile/lib/l10n/app_ko.arb
+++ b/apps/mobile/lib/l10n/app_ko.arb
@@ -957,5 +957,6 @@
   "googleSearchSelectionAction": "Google 검색",
   "approvalQuestionNotificationTitle": "질문이 있습니다 - ccpocket",
   "approvalRequiredNotificationTitle": "승인 대기 중 - ccpocket",
-  "exitPlanModeNotificationBody": "작성된 계획을 확인해야 합니다"
+  "exitPlanModeNotificationBody": "작성된 계획을 확인해야 합니다",
+  "renderErrorFallback": "이 콘텐츠를 표시할 수 없습니다."
 }

--- a/apps/mobile/lib/l10n/app_localizations.dart
+++ b/apps/mobile/lib/l10n/app_localizations.dart
@@ -4415,6 +4415,12 @@ abstract class AppLocalizations {
   /// In ja, this message translates to:
   /// **'作成したプランの確認が必要です'**
   String get exitPlanModeNotificationBody;
+
+  /// No description provided for @renderErrorFallback.
+  ///
+  /// In ja, this message translates to:
+  /// **'このコンテンツを表示できませんでした'**
+  String get renderErrorFallback;
 }
 
 class _AppLocalizationsDelegate

--- a/apps/mobile/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/lib/l10n/app_localizations_en.dart
@@ -2426,4 +2426,7 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get exitPlanModeNotificationBody =>
       'The generated plan needs your review';
+
+  @override
+  String get renderErrorFallback => 'This content couldn\'t be displayed.';
 }

--- a/apps/mobile/lib/l10n/app_localizations_ja.dart
+++ b/apps/mobile/lib/l10n/app_localizations_ja.dart
@@ -2336,4 +2336,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get exitPlanModeNotificationBody => '作成したプランの確認が必要です';
+
+  @override
+  String get renderErrorFallback => 'このコンテンツを表示できませんでした';
 }

--- a/apps/mobile/lib/l10n/app_localizations_ko.dart
+++ b/apps/mobile/lib/l10n/app_localizations_ko.dart
@@ -2360,4 +2360,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get exitPlanModeNotificationBody => '작성된 계획을 확인해야 합니다';
+
+  @override
+  String get renderErrorFallback => '이 콘텐츠를 표시할 수 없습니다.';
 }

--- a/apps/mobile/lib/l10n/app_localizations_zh.dart
+++ b/apps/mobile/lib/l10n/app_localizations_zh.dart
@@ -2310,4 +2310,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get exitPlanModeNotificationBody => '生成的计划需要你确认';
+
+  @override
+  String get renderErrorFallback => '无法显示此内容。';
 }

--- a/apps/mobile/lib/l10n/app_zh.arb
+++ b/apps/mobile/lib/l10n/app_zh.arb
@@ -1100,5 +1100,6 @@
   "googleSearchSelectionAction": "用 Google 搜索",
   "approvalQuestionNotificationTitle": "有一个问题 - ccpocket",
   "approvalRequiredNotificationTitle": "等待审批 - ccpocket",
-  "exitPlanModeNotificationBody": "生成的计划需要你确认"
+  "exitPlanModeNotificationBody": "生成的计划需要你确认",
+  "renderErrorFallback": "无法显示此内容。"
 }

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -60,6 +60,7 @@ import 'theme/app_theme.dart';
 import 'services/store_screenshot_extension.dart';
 import 'theme/markdown_style.dart';
 import 'utils/platform_helper.dart';
+import 'widgets/release_error_widget.dart';
 
 /// Top-level handler for FCM background messages.
 /// Required by firebase_messaging to process messages when app is in background.
@@ -105,6 +106,7 @@ void main() async {
       details.stack,
     );
   };
+  installReleaseErrorWidget();
   // Initialize notifications eagerly so the Android notification channel is
   // created before any FCM message arrives. Without this, FCM falls back to
   // the low-importance fcm_fallback_notification_channel and notifications
@@ -473,6 +475,7 @@ class _CcpocketAppState extends State<CcpocketApp> {
             : Locale(settings.appLocaleId);
         final themeLocale =
             appLocale ?? WidgetsBinding.instance.platformDispatcher.locale;
+        updateReleaseErrorWidgetLocale(appLocale);
         return MaterialApp.router(
           title: 'CC Pocket',
           theme: AppTheme.lightThemeForLocale(themeLocale),

--- a/apps/mobile/lib/widgets/release_error_widget.dart
+++ b/apps/mobile/lib/widgets/release_error_widget.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+
+import '../l10n/app_localizations.dart';
+
+Locale? _releaseErrorLocaleOverride;
+
+@visibleForTesting
+String releaseErrorMessageForLocale(Locale locale) {
+  final languageCode =
+      AppLocalizations.supportedLocales.any(
+        (supported) => supported.languageCode == locale.languageCode,
+      )
+      ? locale.languageCode
+      : 'en';
+  return lookupAppLocalizations(Locale(languageCode)).renderErrorFallback;
+}
+
+void updateReleaseErrorWidgetLocale(Locale? locale) {
+  _releaseErrorLocaleOverride = locale;
+}
+
+@visibleForTesting
+Widget buildReleaseErrorWidget(FlutterErrorDetails _) {
+  final locale =
+      _releaseErrorLocaleOverride ??
+      WidgetsBinding.instance.platformDispatcher.locale;
+  return ReleaseErrorWidget(message: releaseErrorMessageForLocale(locale));
+}
+
+void installReleaseErrorWidget({bool isReleaseMode = kReleaseMode}) {
+  if (!isReleaseMode) return;
+  ErrorWidget.builder = buildReleaseErrorWidget;
+}
+
+class ReleaseErrorWidget extends LeafRenderObjectWidget {
+  ReleaseErrorWidget({required this.message}) : super(key: UniqueKey());
+
+  final String message;
+
+  @override
+  RenderBox createRenderObject(BuildContext context) {
+    return _RenderReleaseErrorBox(message);
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(StringProperty('message', message));
+  }
+}
+
+class _RenderReleaseErrorBox extends RenderErrorBox {
+  _RenderReleaseErrorBox(super.message);
+
+  @override
+  void describeSemanticsConfiguration(SemanticsConfiguration config) {
+    super.describeSemanticsConfiguration(config);
+    config
+      ..isSemanticBoundary = true
+      ..label = message
+      ..textDirection = TextDirection.ltr;
+  }
+}

--- a/apps/mobile/test/release_error_widget_test.dart
+++ b/apps/mobile/test/release_error_widget_test.dart
@@ -1,0 +1,141 @@
+import 'package:ccpocket/widgets/release_error_widget.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late ErrorWidgetBuilder originalBuilder;
+
+  setUp(() {
+    originalBuilder = ErrorWidget.builder;
+    updateReleaseErrorWidgetLocale(const Locale('en'));
+    addTearDown(() {
+      ErrorWidget.builder = originalBuilder;
+      updateReleaseErrorWidgetLocale(null);
+    });
+  });
+
+  test('keeps the default builder outside release mode', () {
+    installReleaseErrorWidget(isReleaseMode: false);
+
+    expect(identical(ErrorWidget.builder, originalBuilder), isTrue);
+  });
+
+  test('installs the fallback in release mode', () {
+    installReleaseErrorWidget(isReleaseMode: true);
+
+    expect(identical(ErrorWidget.builder, originalBuilder), isFalse);
+  });
+
+  test('localizes the generic message without exposing error details', () {
+    const messages = {
+      'en': "This content couldn't be displayed.",
+      'ja': 'このコンテンツを表示できませんでした',
+      'ko': '이 콘텐츠를 표시할 수 없습니다.',
+      'zh': '无法显示此内容。',
+      'fr': "This content couldn't be displayed.",
+    };
+
+    for (final entry in messages.entries) {
+      expect(releaseErrorMessageForLocale(Locale(entry.key)), entry.value);
+    }
+  });
+
+  testWidgets('replaces a widget that throws during build', (tester) async {
+    installReleaseErrorWidget(isReleaseMode: true);
+
+    try {
+      await tester.pumpWidget(
+        const Directionality(
+          textDirection: TextDirection.ltr,
+          child: _ThrowingWidget(),
+        ),
+      );
+
+      expect(tester.takeException(), isA<StateError>());
+      final fallback = tester.widget<ReleaseErrorWidget>(
+        find.byType(ReleaseErrorWidget),
+      );
+      expect(fallback.message, "This content couldn't be displayed.");
+      expect(fallback.message, isNot(contains('boom')));
+      expect(
+        fallback.toDiagnosticsNode().toStringDeep(),
+        isNot(contains('boom')),
+      );
+    } finally {
+      ErrorWidget.builder = originalBuilder;
+    }
+  });
+
+  testWidgets('reads the current system locale without an app override', (
+    tester,
+  ) async {
+    updateReleaseErrorWidgetLocale(null);
+    tester.binding.platformDispatcher.localeTestValue = const Locale('ja');
+
+    try {
+      final fallback =
+          buildReleaseErrorWidget(
+                FlutterErrorDetails(exception: StateError('boom')),
+              )
+              as ReleaseErrorWidget;
+
+      expect(fallback.message, 'このコンテンツを表示できませんでした');
+    } finally {
+      tester.binding.platformDispatcher.clearLocaleTestValue();
+    }
+  });
+
+  testWidgets('handles zero and tiny constraints without another exception', (
+    tester,
+  ) async {
+    final details = FlutterErrorDetails(exception: StateError('boom'));
+
+    for (final size in [Size.zero, const Size(1, 1)]) {
+      await tester.pumpWidget(
+        Align(
+          alignment: Alignment.topLeft,
+          child: SizedBox.fromSize(
+            size: size,
+            child: buildReleaseErrorWidget(details),
+          ),
+        ),
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(tester.getSize(find.byType(ReleaseErrorWidget)), size);
+    }
+  });
+
+  testWidgets('exposes the generic message to accessibility services', (
+    tester,
+  ) async {
+    final semantics = tester.ensureSemantics();
+    final details = FlutterErrorDetails(exception: StateError('boom'));
+
+    try {
+      await tester.pumpWidget(
+        SizedBox(
+          width: 240,
+          height: 80,
+          child: buildReleaseErrorWidget(details),
+        ),
+      );
+
+      expect(
+        tester.getSemantics(find.byType(ReleaseErrorWidget)).label,
+        "This content couldn't be displayed.",
+      );
+    } finally {
+      semantics.dispose();
+    }
+  });
+}
+
+class _ThrowingWidget extends StatelessWidget {
+  const _ThrowingWidget();
+
+  @override
+  Widget build(BuildContext context) {
+    throw StateError('boom');
+  }
+}


### PR DESCRIPTION
## Summary
- replace release-mode render failures with a leaf `RenderErrorBox` fallback that remains safe under tiny constraints
- localize the generic message in English, Japanese, Korean, and Chinese while following runtime system locale changes
- discard original exception details and expose only the generic message to semantics

This is the maintainer reimplementation of #142. Compared with the original composite Material/Text fallback, this implementation avoids rebuilding framework widgets while the tree is unstable, does not retain exception details, and keeps debug behavior unchanged.

## Validation
- `mise exec -- dart analyze apps/mobile` (exit 0; existing 35 infos and analyzer-plugin dependency warning only)
- `mise exec -- flutter test test/release_error_widget_test.dart` (7 passed)
- `mise exec -- flutter test` (1271 passed, 4 skipped)
- `mise exec -- flutter build ios --release --no-codesign`
- iPhone 17 Pro simulator + Marionette: normal debug home UI exposed 10 interactive elements; no fallback/overflow logs
- independent self-review: PASS

Co-authored commit credits 鄭伊杰 <zhengyijie@bytedance.com>.