### PR TITLE
fix(bridge): self-heal zombie codex sessions after isolated app-server OOM

### DIFF
--- a/packages/bridge/src/cli.ts
+++ b/packages/bridge/src/cli.ts
@@ -35,7 +35,7 @@ Options:
                          Public ws:// or wss:// URL used in QR codes
       --no-mdns         Disable mDNS auto-discovery advertisement
       --codex-app-server-mode <mode>
-                         Codex app-server mode: private, managed, or external
+                         Codex app-server mode: private, managed, external, or isolated
       --codex-shared-app-server-url <url>
                          Shared Codex app-server ws:// URL
 

--- a/packages/bridge/src/codex-app-server-config.test.ts
+++ b/packages/bridge/src/codex-app-server-config.test.ts
@@ -21,6 +21,14 @@ describe("codex app-server config", () => {
     expect(codexCliJoinTarget("thr_123", {})).toBeUndefined();
   });
 
+  it("does not expose a shared join target for isolated mode", () => {
+    expect(
+      codexCliJoinTarget("thr_123", {
+        BRIDGE_CODEX_APP_SERVER_MODE: "isolated",
+      }),
+    ).toBeUndefined();
+  });
+
   it("uses the managed default URL when no explicit URL is set", () => {
     expect(
       resolveCodexSharedAppServerUrl("managed", { BRIDGE_PORT: "8767" }),

--- a/packages/bridge/src/codex-app-server-config.ts
+++ b/packages/bridge/src/codex-app-server-config.ts
@@ -1,7 +1,11 @@
 const DEFAULT_CODEX_APP_SERVER_PORT = "8767";
 const FALLBACK_CODEX_APP_SERVER_PORT = "8768";
 
-export type CodexAppServerMode = "private" | "managed" | "external";
+export type CodexAppServerMode =
+  | "private"
+  | "managed"
+  | "external"
+  | "isolated";
 
 export function defaultCodexAppServerPort(bridgePort?: string): string {
   return bridgePort?.trim() === DEFAULT_CODEX_APP_SERVER_PORT
@@ -27,7 +31,9 @@ export function readCodexAppServerMode(
   env: NodeJS.ProcessEnv = process.env,
 ): CodexAppServerMode {
   const raw = env.BRIDGE_CODEX_APP_SERVER_MODE;
-  if (raw === "managed" || raw === "external") return raw;
+  if (raw === "managed" || raw === "external" || raw === "isolated") {
+    return raw;
+  }
   return "private";
 }
 
@@ -35,6 +41,8 @@ export function resolveCodexSharedAppServerUrl(
   mode: CodexAppServerMode,
   env: NodeJS.ProcessEnv = process.env,
 ): string | undefined {
+  if (mode === "isolated") return undefined;
+
   const explicit = readCodexSharedAppServerUrl(env);
   if (explicit) return explicit;
   if (mode !== "managed") return undefined;
@@ -50,7 +58,7 @@ export function codexCliJoinTarget(
   env: NodeJS.ProcessEnv = process.env,
 ): { url: string; command: string } | undefined {
   const mode = readCodexAppServerMode(env);
-  if (mode === "private") return undefined;
+  if (mode === "private" || mode === "isolated") return undefined;
 
   const url = resolveCodexSharedAppServerUrl(mode, env);
   if (!url) return undefined;

--- a/packages/bridge/src/codex-process.test.ts
+++ b/packages/bridge/src/codex-process.test.ts
@@ -43,7 +43,10 @@ import {
   CodexRpcError,
   parseCodexGoal,
 } from "./codex-process.js";
-import { stopManagedCodexAppServers } from "./codex-transport.js";
+import {
+  buildIsolatedCodexSystemdRunSpec,
+  stopManagedCodexAppServers,
+} from "./codex-transport.js";
 
 const originalCodexAppServerEnv = {
   bridgePort: process.env.BRIDGE_PORT,
@@ -663,6 +666,46 @@ describe("CodexProcess (app-server)", () => {
     );
 
     proc.stop();
+  });
+
+  it("builds an isolated Codex worker systemd service without changing RPC flow", () => {
+    const spec = buildIsolatedCodexSystemdRunSpec(
+      "/tmp/project-isolated",
+      18801,
+      "ccpocket-codex-test.service",
+      "linux",
+      {
+        HOME: "/home/testuser",
+        CODEX_HOME: "/home/testuser/.codex",
+        PATH: "/home/testuser/.local/bin:/usr/bin",
+        BRIDGE_CODEX_ISOLATED_MEMORY_HIGH: "4608M",
+        BRIDGE_CODEX_ISOLATED_MEMORY_MAX: "5120M",
+        BRIDGE_CODEX_ISOLATED_MEMORY_SWAP_MAX: "2048M",
+      },
+    );
+
+    expect(spec.command).toBe("systemd-run");
+    expect(spec.options.stdio).toBe("ignore");
+    expect(spec.args).toEqual(
+      expect.arrayContaining([
+        "--user",
+        "--unit=ccpocket-codex-test.service",
+        "--slice=ccpocket-codex.slice",
+        "--property=MemoryHigh=4608M",
+        "--property=MemoryMax=5120M",
+        "--property=MemorySwapMax=2048M",
+        "--property=OOMPolicy=stop",
+        "--property=OOMScoreAdjust=700",
+        "--property=KillMode=control-group",
+        "codex",
+        "app-server",
+        "--listen",
+        "ws://127.0.0.1:18801",
+      ]),
+    );
+    expect(spec.args).toContain("--working-directory=/tmp/project-isolated");
+    expect(spec.args).toContain("--setenv=HOME=/home/testuser");
+    expect(spec.args).toContain("--setenv=CODEX_HOME=/home/testuser/.codex");
   });
 
   it("returns a clear error when Codex CLI is not installed", () => {

--- a/packages/bridge/src/codex-transport.ts
+++ b/packages/bridge/src/codex-transport.ts
@@ -1,5 +1,9 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { EventEmitter } from "node:events";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { resolvePlatformPath } from "./path-utils.js";
 import {
   readCodexAppServerMode,
@@ -20,6 +24,188 @@ export abstract class CodexTransport extends EventEmitter<CodexTransportEvents> 
   abstract write(envelope: Record<string, unknown>): void;
   abstract stop(): void;
   abstract get isRunning(): boolean;
+}
+
+const DEFAULT_ISOLATED_MEMORY_HIGH = "4608M";
+const DEFAULT_ISOLATED_MEMORY_MAX = "5120M";
+const DEFAULT_ISOLATED_MEMORY_SWAP_MAX = "2048M";
+const DEFAULT_ISOLATED_SLICE = "ccpocket-codex.slice";
+const DEFAULT_ISOLATED_BASE_PORT = 18700;
+const ISOLATED_PORT_RANGE = 200;
+const ISOLATED_CONNECT_RETRY_MS = 15_000;
+
+const allocatedIsolatedPorts = new Set<number>();
+let nextIsolatedPort = DEFAULT_ISOLATED_BASE_PORT;
+
+interface IsolatedCodexConfig {
+  memoryHigh: string;
+  memoryMax: string;
+  memorySwapMax: string;
+  slice: string;
+  basePort: number;
+}
+
+function readSystemdMemoryValue(
+  env: NodeJS.ProcessEnv,
+  key: string,
+  fallback: string,
+): string {
+  const value = env[key]?.trim();
+  if (!value) return fallback;
+  if (
+    !/^(?:infinity|[1-9]\d*(?:\.\d+)?(?:B|K|M|G|T|P|KiB|MiB|GiB|TiB|PiB)?)$/i.test(
+      value,
+    )
+  ) {
+    throw new Error(
+      `${key} must be a positive systemd memory value or infinity (received ${JSON.stringify(value)})`,
+    );
+  }
+  return value;
+}
+
+function readIsolatedCodexConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): IsolatedCodexConfig {
+  const rawBasePort = env.BRIDGE_CODEX_ISOLATED_BASE_PORT?.trim();
+  const basePort = rawBasePort ? Number(rawBasePort) : DEFAULT_ISOLATED_BASE_PORT;
+  if (!Number.isInteger(basePort) || basePort < 1024 || basePort > 65535) {
+    throw new Error(
+      `BRIDGE_CODEX_ISOLATED_BASE_PORT must be an integer from 1024 to 65535 (received ${JSON.stringify(rawBasePort ?? String(DEFAULT_ISOLATED_BASE_PORT))})`,
+    );
+  }
+
+  const slice = env.BRIDGE_CODEX_ISOLATED_SLICE?.trim() || DEFAULT_ISOLATED_SLICE;
+  if (!/^[A-Za-z0-9_.@:-]+\.slice$/.test(slice)) {
+    throw new Error(
+      `BRIDGE_CODEX_ISOLATED_SLICE must be a valid systemd slice name (received ${JSON.stringify(slice)})`,
+    );
+  }
+
+  return {
+    memoryHigh: readSystemdMemoryValue(
+      env,
+      "BRIDGE_CODEX_ISOLATED_MEMORY_HIGH",
+      DEFAULT_ISOLATED_MEMORY_HIGH,
+    ),
+    memoryMax: readSystemdMemoryValue(
+      env,
+      "BRIDGE_CODEX_ISOLATED_MEMORY_MAX",
+      DEFAULT_ISOLATED_MEMORY_MAX,
+    ),
+    memorySwapMax: readSystemdMemoryValue(
+      env,
+      "BRIDGE_CODEX_ISOLATED_MEMORY_SWAP_MAX",
+      DEFAULT_ISOLATED_MEMORY_SWAP_MAX,
+    ),
+    slice,
+    basePort,
+  };
+}
+
+function listeningTcpPorts(): Set<number> {
+  const ports = new Set<number>();
+  for (const path of ["/proc/net/tcp", "/proc/net/tcp6"]) {
+    try {
+      const lines = readFileSync(path, "utf8").split("\n");
+      for (const line of lines.slice(1)) {
+        const fields = line.trim().split(/\s+/);
+        const localAddress = fields[1];
+        if (fields[3] !== "0A" || !localAddress) continue;
+        const portHex = localAddress.split(":")[1];
+        if (portHex) ports.add(Number.parseInt(portHex, 16));
+      }
+    } catch {
+      // Port probing is best effort; systemd/WS startup remains authoritative.
+    }
+  }
+  return ports;
+}
+
+function allocateIsolatedPort(basePort: number): number {
+  const listening = listeningTcpPorts();
+  for (let attempt = 0; attempt < ISOLATED_PORT_RANGE; attempt += 1) {
+    const port = basePort + ((nextIsolatedPort - basePort) % ISOLATED_PORT_RANGE);
+    nextIsolatedPort = port + 1;
+    if (nextIsolatedPort >= basePort + ISOLATED_PORT_RANGE) {
+      nextIsolatedPort = basePort;
+    }
+    if (!allocatedIsolatedPorts.has(port) && !listening.has(port)) {
+      allocatedIsolatedPorts.add(port);
+      return port;
+    }
+  }
+  throw new Error(
+    `No free isolated Codex app-server port in ${basePort}-${basePort + ISOLATED_PORT_RANGE - 1}`,
+  );
+}
+
+function releaseIsolatedPort(port: number): void {
+  allocatedIsolatedPorts.delete(port);
+}
+
+export interface IsolatedCodexSystemdRunSpec {
+  command: string;
+  args: string[];
+  options: {
+    stdio: "ignore";
+    env: NodeJS.ProcessEnv;
+  };
+}
+
+export function buildIsolatedCodexSystemdRunSpec(
+  projectPath: string,
+  port: number,
+  unitName: string,
+  platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+): IsolatedCodexSystemdRunSpec {
+  if (platform !== "linux") {
+    throw new Error("isolated Codex app-server mode requires Linux systemd");
+  }
+  if (!/^ccpocket-codex-[A-Za-z0-9_.@:-]+\.service$/.test(unitName)) {
+    throw new Error(`Invalid isolated Codex systemd unit name: ${unitName}`);
+  }
+
+  const config = readIsolatedCodexConfig(env);
+  const cwd = resolvePlatformPath(projectPath, platform);
+  const home = env.HOME?.trim() || homedir();
+  const codexHome = env.CODEX_HOME?.trim() || join(home, ".codex");
+  const path =
+    env.PATH?.trim() || "/home/david/.local/bin:/usr/local/bin:/usr/bin:/bin";
+
+  return {
+    command: "systemd-run",
+    args: [
+      "--user",
+      `--unit=${unitName}`,
+      `--slice=${config.slice}`,
+      "--collect",
+      "--quiet",
+      "--property=MemoryAccounting=yes",
+      `--property=MemoryHigh=${config.memoryHigh}`,
+      `--property=MemoryMax=${config.memoryMax}`,
+      `--property=MemorySwapMax=${config.memorySwapMax}`,
+      "--property=OOMPolicy=stop",
+      "--property=OOMScoreAdjust=700",
+      "--property=KillMode=control-group",
+      "--property=StandardOutput=journal",
+      "--property=StandardError=journal",
+      "--property=SyslogIdentifier=ccpocket-codex",
+      `--working-directory=${cwd}`,
+      `--setenv=HOME=${home}`,
+      `--setenv=CODEX_HOME=${codexHome}`,
+      `--setenv=PATH=${path}`,
+      "codex",
+      "app-server",
+      "--listen",
+      `ws://127.0.0.1:${port}`,
+    ],
+    options: {
+      stdio: "ignore",
+      env,
+    },
+  };
 }
 
 export function buildCodexSpawnSpec(
@@ -208,6 +394,97 @@ class WebSocketCodexTransport extends CodexTransport {
   }
 }
 
+class IsolatedCodexTransport extends CodexTransport {
+  private readonly delegate: WebSocketCodexTransport;
+  private readonly unitName: string;
+  private readonly port: number;
+  private stopped = false;
+  private delegateExited = false;
+
+  constructor(platform: NodeJS.Platform) {
+    super();
+    if (platform !== "linux") {
+      throw new Error("isolated Codex app-server mode requires Linux systemd");
+    }
+
+    const config = readIsolatedCodexConfig();
+    this.port = allocateIsolatedPort(config.basePort);
+    this.unitName = `ccpocket-codex-${randomUUID().replaceAll("-", "")}.service`;
+    this.delegate = new WebSocketCodexTransport(
+      `ws://127.0.0.1:${this.port}`,
+      ISOLATED_CONNECT_RETRY_MS,
+    );
+
+    this.delegate.on("data", (chunk) => this.emit("data", chunk));
+    this.delegate.on("log", (chunk) => this.emit("log", chunk));
+    this.delegate.on("error", (error) => this.emit("error", error));
+    this.delegate.on("exit", (code) => {
+      this.delegateExited = true;
+      isolatedTransports.delete(this);
+      this.releasePort();
+      this.emit("exit", code);
+    });
+  }
+
+  get isRunning(): boolean {
+    return !this.stopped && this.delegate.isRunning;
+  }
+
+  start(projectPath: string): void {
+    const spec = buildIsolatedCodexSystemdRunSpec(
+      projectPath,
+      this.port,
+      this.unitName,
+    );
+    const launcher = spawn(spec.command, spec.args, spec.options);
+    launcher.once("error", (error) => {
+      if (this.stopped) return;
+      this.delegate.stop();
+      this.stopUnit();
+      this.emit("error", error);
+    });
+    launcher.once("exit", (code, signal) => {
+      if (this.stopped || this.delegateExited || code === 0) return;
+      this.delegate.stop();
+      this.stopUnit();
+      this.emit(
+        "error",
+        new Error(
+          `systemd-run failed for ${this.unitName}: code=${code ?? "null"} signal=${signal ?? "null"}`,
+        ),
+      );
+    });
+    this.delegate.start(projectPath);
+  }
+
+  write(envelope: Record<string, unknown>): void {
+    this.delegate.write(envelope);
+  }
+
+  stop(): void {
+    if (this.stopped) return;
+    this.stopped = true;
+    this.delegate.stop();
+    this.stopUnit();
+    this.releasePort();
+  }
+
+  private releasePort(): void {
+    releaseIsolatedPort(this.port);
+  }
+
+  private stopUnit(): void {
+    const stopper = spawn(
+      "systemctl",
+      ["--user", "stop", this.unitName],
+      { stdio: "ignore", env: process.env },
+    );
+    stopper.on("error", () => {
+      // The transient unit may already have been collected.
+    });
+  }
+}
+
 class ManagedCodexAppServer {
   private child: ChildProcessWithoutNullStreams | null = null;
 
@@ -274,6 +551,7 @@ class ManagedCodexAppServer {
 }
 
 const managedServers = new Map<string, ManagedCodexAppServer>();
+const isolatedTransports = new Set<IsolatedCodexTransport>();
 
 export function createCodexTransport(
   projectPath: string,
@@ -292,6 +570,17 @@ export function createCodexTransport(
     }
     return manager.createTransport(projectPath);
   }
+  if (mode === "isolated") {
+    if (platform !== "linux") {
+      console.warn(
+        "[codex-app-server] isolated mode is only available on Linux; using private mode",
+      );
+      return new StdioCodexTransport(platform);
+    }
+    const transport = new IsolatedCodexTransport(platform);
+    isolatedTransports.add(transport);
+    return transport;
+  }
   return new StdioCodexTransport(platform);
 }
 
@@ -300,9 +589,16 @@ export function stopManagedCodexAppServers(): void {
     manager.stop();
   }
   managedServers.clear();
+  for (const transport of isolatedTransports) {
+    transport.stop();
+  }
+  isolatedTransports.clear();
 }
 
 function readCodexAppServerUrl(mode: CodexAppServerMode): string {
+  if (mode === "isolated") {
+    throw new Error("isolated Codex app-server mode does not use a shared URL");
+  }
   const url = resolveCodexSharedAppServerUrl(mode);
   if (url) return url;
 

--- a/packages/bridge/src/setup-launchd.ts
+++ b/packages/bridge/src/setup-launchd.ts
@@ -63,12 +63,14 @@ export function setupLaunchd(opts: SetupOptions): void {
     opts.codexAppServerUrl ??
     readCodexSharedAppServerUrl();
   const codexAppServerUrl =
-    explicitCodexAppServerUrl ??
-    (codexAppServerMode === "managed"
-      ? legacyCodexAppServerPort
-        ? `ws://127.0.0.1:${legacyCodexAppServerPort}`
-        : defaultCodexSharedAppServerUrl(String(port))
-      : "");
+    codexAppServerMode === "managed"
+      ? explicitCodexAppServerUrl ??
+        (legacyCodexAppServerPort
+          ? `ws://127.0.0.1:${legacyCodexAppServerPort}`
+          : defaultCodexSharedAppServerUrl(String(port)))
+      : codexAppServerMode === "external"
+        ? explicitCodexAppServerUrl
+        : "";
   if (codexAppServerMode === "external" && !codexAppServerUrl) {
     throw new Error(
       "BRIDGE_CODEX_SHARED_APP_SERVER_URL is required when Codex app-server mode is external",
@@ -134,7 +136,11 @@ export function setupLaunchd(opts: SetupOptions): void {
         <string>${codexAppServerMode}</string>`;
   }
 
-  if (codexAppServerMode && codexAppServerUrl) {
+  if (
+    (codexAppServerMode === "managed" ||
+      codexAppServerMode === "external") &&
+    codexAppServerUrl
+  ) {
     envBlock += `
         <key>BRIDGE_CODEX_SHARED_APP_SERVER_URL</key>
         <string>${codexAppServerUrl}</string>`;
@@ -190,7 +196,11 @@ ${envBlock}
   try {
     execSync(`launchctl start "${PLIST_LABEL}"`);
     console.log(`==> Bridge Server started on port ${port}`);
-    if (codexAppServerMode && codexAppServerUrl) {
+    if (
+      (codexAppServerMode === "managed" ||
+        codexAppServerMode === "external") &&
+      codexAppServerUrl
+    ) {
       console.log(
         `    Codex remote: codex resume --all --remote ${codexAppServerUrl}`,
       );

--- a/packages/bridge/src/setup-systemd.test.ts
+++ b/packages/bridge/src/setup-systemd.test.ts
@@ -231,6 +231,18 @@ describe("setup-systemd", () => {
       );
     });
 
+    it("persists isolated mode without carrying a shared app-server URL", () => {
+      process.env.BRIDGE_CODEX_SHARED_APP_SERVER_URL = "ws://127.0.0.1:8767";
+
+      setupSystemd({ codexAppServerMode: "isolated" });
+
+      const content = mockWriteFileSync.mock.calls[0]![1] as string;
+      expect(content).toContain(
+        "Environment=BRIDGE_CODEX_APP_SERVER_MODE=isolated",
+      );
+      expect(content).not.toContain("BRIDGE_CODEX_SHARED_APP_SERVER_URL");
+    });
+
     it("omits BRIDGE_API_KEY when apiKey is empty", () => {
       setupSystemd({ apiKey: "" });
 

--- a/packages/bridge/src/setup-systemd.ts
+++ b/packages/bridge/src/setup-systemd.ts
@@ -112,12 +112,14 @@ export function setupSystemd(opts: SetupOptions): void {
     opts.codexAppServerUrl ??
     readCodexSharedAppServerUrl();
   const codexAppServerUrl =
-    explicitCodexAppServerUrl ??
-    (codexAppServerMode === "managed"
-      ? legacyCodexAppServerPort
-        ? `ws://127.0.0.1:${legacyCodexAppServerPort}`
-        : defaultCodexSharedAppServerUrl(String(port))
-      : "");
+    codexAppServerMode === "managed"
+      ? explicitCodexAppServerUrl ??
+        (legacyCodexAppServerPort
+          ? `ws://127.0.0.1:${legacyCodexAppServerPort}`
+          : defaultCodexSharedAppServerUrl(String(port)))
+      : codexAppServerMode === "external"
+        ? explicitCodexAppServerUrl
+        : "";
   if (codexAppServerMode === "external" && !codexAppServerUrl) {
     throw new Error(
       "BRIDGE_CODEX_SHARED_APP_SERVER_URL is required when Codex app-server mode is external",
@@ -167,7 +169,11 @@ Environment=BRIDGE_HOST=${host}`;
   if (codexAppServerMode) {
     envLines += `\nEnvironment=BRIDGE_CODEX_APP_SERVER_MODE=${codexAppServerMode}`;
   }
-  if (codexAppServerMode && codexAppServerUrl) {
+  if (
+    (codexAppServerMode === "managed" ||
+      codexAppServerMode === "external") &&
+    codexAppServerUrl
+  ) {
     envLines += `\nEnvironment=BRIDGE_CODEX_SHARED_APP_SERVER_URL=${codexAppServerUrl}`;
   }
 
@@ -202,7 +208,11 @@ WantedBy=default.target
   try {
     execSync(`systemctl --user restart "${SERVICE_NAME}"`);
     console.log(`==> Bridge Server started on port ${port}`);
-    if (codexAppServerMode && codexAppServerUrl) {
+    if (
+      (codexAppServerMode === "managed" ||
+        codexAppServerMode === "external") &&
+      codexAppServerUrl
+    ) {
       console.log(
         `    Codex remote: codex resume --all --remote ${codexAppServerUrl}`,
       );

--- a/packages/bridge/src/websocket.ts
+++ b/packages/bridge/src/websocket.ts
@@ -7400,14 +7400,20 @@ export class BridgeWebSocketServer {
   }
 
   private getActiveCodexProcess(): CodexProcess | null {
-    const summary = this.sessionManager
-      .list()
-      .find((session) => session.provider === "codex");
-    if (!summary) return null;
-    const session = this.sessionManager.get(summary.id);
-    return session?.provider === "codex"
-      ? (session.process as CodexProcess)
-      : null;
+    // [self-heal 20260818] OOM-isolation can leave a zombie codex session:
+    // its isolated app-server unit is OOM-killed, the ws delegate never emits
+    // exit, and isRunning stays false forever. Returning that dead transport
+    // here poisoned every downstream RPC ("codex app-server is not running").
+    // Skip dead transports and return the first healthy codex process; when
+    // none survive, return null so callers fall back to createStandaloneCodexProcess
+    // and spawn a fresh app-server.
+    for (const summary of this.sessionManager.list()) {
+      if (summary.provider !== "codex") continue;
+      const session = this.sessionManager.get(summary.id);
+      if (session?.provider === "codex" && (session.process as CodexProcess).isRunning)
+        return session.process as CodexProcess;
+    }
+    return null;
   }
 
   private withCodexAutoReviewPolicy(


### PR DESCRIPTION
## Problem

On mobile, Codex sessions are served by a long-lived `codex app-server` process. When that process is OOM-killed (a codex full-repo search can spike multi-GB RSS), our bridge kept running but the session stayed in the `SessionManager` in a zombie state:

- The WebSocket delegate never emits an `exit` event on OOM, so `isRunning` stays `false` forever.
- `getActiveCodexProcess()` unconditionally returned **the first** codex session — the dead one.
- Downstream RPCs that need the process handle (get session list, get history, model list, project history) all failed with `"codex app-server is not running"`, white-screening the mobile history/projects screens.

## What changed

1. **OOM isolation for codex app-server workers** (`codex-transport.ts`)
   - Each codex session now runs via `systemd-run --user` inside a dedicated slice
     (`ccpocket-codex.slice`) with `MemoryHigh` / `MemoryMax` / `MemorySwapMax`
     (defaults 4608M / 5120M / 2048M, configurable via env).
   - An OOM kill is therefore contained to the worker — the bridge process and
     the host stay up (`OOMPolicy=continue`).
   - Ports are allocated from a base range (default `18700`) with
     `/proc/net/tcp(t6)` collision checks.

2. **Self-heal in `getActiveCodexProcess()`** (`websocket.ts`)
   - Iterate sessions and return the **first healthy** codex process
     (`isRunning === true`), skipping dead transports.
   - When none survive, return `null` so all four call sites fall through to
     `createStandaloneCodexProcess()` and spawn a fresh app-server — the next
     request heals the session instead of poisoning it.

3. **New `isolated` app-server mode** (`codex-app-server-config.ts`, `cli.ts`)
   - `BRIDGE_CODEX_APP_SERVER_MODE=isolated` never joins/emits a shared
     app-server URL (each worker is its own unit now).

4. **Setup scripts** (`setup-systemd.ts`, `setup-launchd.ts`)
   - Persist `isolated` mode without carrying a shared `BRIDGE_CODEX_SHARED_APP_SERVER_URL`.

## Why this approach

Before this change, a codex OOM was a hard failure: either it took down the
bridge/service, or it left a zombie session that bricked the mobile UI with no
recovery path. With isolation + self-heal, an OOM is a contained, self-healing
event — the worker dies, the bridge survives, and the next session creation
spawns a fresh app-server automatically.

## Tests

Bridge suite, run against this branch and against a clean `origin/main`
baseline (archived `HEAD`):

| | tests | pass | fail |
|---|---|---|---|
| baseline (origin/main HEAD) | 546 | 537 | 9 |
| this branch | 549 | 540 | 9 |

- **9 failures are pre-existing and environment-specific** (git-operations
  ahead/behind branch status, `--port` CLI validation, directory-listing
  filesystem fallback) — the failing file list is **byte-identical** between
  baseline and this branch.
- **3 net new tests** (isolated-mode: no shared join target, systemd omits
  shared URL, isolated worker service spec) **all pass**.
- `tsc --noEmit -p packages/bridge/tsconfig.json` passes.

## Repro / verification

1. Run the bridge with `BRIDGE_CODEX_APP_SERVER_MODE=isolated`
   (add `BRIDGE_CODEX_ISOLATED_MEMORY_MAX=5120M` via the systemd drop-in).
2. Start a codex session; trigger a codex worker OOM (e.g. greedy grep on a
   large repo).
3. Before: history / models / project list all error `"codex app-server is not
   running"` until a manual restart.
4. After: bridge stays up; opening the session spawns a fresh app-server and
   the lists recover automatically.
