### PR TITLE
fix(mobile): reduce repeated work in long chat histories

### DIFF
--- a/apps/mobile/lib/widgets/bubbles/assistant_bubble.dart
+++ b/apps/mobile/lib/widgets/bubbles/assistant_bubble.dart
@@ -87,7 +87,7 @@ class _AssistantBubbleState extends State<AssistantBubble> {
     if (hasOnlyTextContent && inferredErrorCode != null) {
       return ErrorBubble(
         message: ErrorMessage(
-          message: _allText(),
+          message: allText,
           errorCode: inferredErrorCode,
         ),
       );
@@ -98,7 +98,7 @@ class _AssistantBubbleState extends State<AssistantBubble> {
         contents: contents,
         hasTextContent: hasTextContent,
         resolvedPlanText: widget.resolvedPlanText,
-        allText: _allText(),
+        allText: allText,
         plainTextMode: _plainTextMode,
         onFileTap: widget.onFileTap,
         onFork: widget.onFork,
@@ -113,7 +113,7 @@ class _AssistantBubbleState extends State<AssistantBubble> {
       contents: contents,
       hasTextContent: hasTextContent,
       plainTextMode: _plainTextMode,
-      allText: _allText(),
+      allText: allText,
       onFileTap: widget.onFileTap,
       onFork: widget.onFork,
       hiddenToolUseIds: widget.hiddenToolUseIds,

--- a/apps/mobile/lib/widgets/bubbles/inline_edit_diff.dart
+++ b/apps/mobile/lib/widgets/bubbles/inline_edit_diff.dart
@@ -26,26 +26,28 @@ class InlineEditDiff extends StatelessWidget {
   Widget build(BuildContext context) {
     final appColors = Theme.of(context).extension<AppColors>()!;
 
-    // Flatten all hunk lines for inline display.
-    final allLines = <({DiffLine line, bool isSeparator})>[];
+    final totalLines = diffFile.hunks.fold<int>(
+      0,
+      (total, hunk) => total + hunk.lines.length,
+    ) + (diffFile.hunks.isEmpty ? 0 : diffFile.hunks.length - 1);
+    final visibleLines = <({DiffLine line, bool isSeparator})>[];
     for (var i = 0; i < diffFile.hunks.length; i++) {
       if (i > 0) {
         // Add a visual separator between hunks (for MultiEdit).
-        allLines.add((
+        visibleLines.add((
           line: const DiffLine(type: DiffLineType.context, content: ''),
           isSeparator: true,
         ));
       }
       for (final line in diffFile.hunks[i].lines) {
-        allLines.add((line: line, isSeparator: false));
+        if (visibleLines.length == _maxInlineLines) break;
+        visibleLines.add((line: line, isSeparator: false));
       }
+      if (visibleLines.length == _maxInlineLines) break;
     }
 
-    final isTruncated = allLines.length > _maxInlineLines;
-    final visibleLines = isTruncated
-        ? allLines.take(_maxInlineLines).toList()
-        : allLines;
-    final remaining = allLines.length - _maxInlineLines;
+    final isTruncated = totalLines > _maxInlineLines;
+    final remaining = totalLines - _maxInlineLines;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,

--- a/apps/mobile/lib/widgets/bubbles/tool_result_bubble.dart
+++ b/apps/mobile/lib/widgets/bubbles/tool_result_bubble.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -19,6 +20,17 @@ import 'image_preview.dart';
 enum ToolResultExpansion { collapsed, preview, expanded }
 
 const _imageGenerationToolName = 'ImageGeneration';
+
+@visibleForTesting
+int debugToolResultPresentationScanCount = 0;
+
+final _toolResultPresentationCache =
+    Expando<_ToolResultPresentation>('tool result presentation');
+
+_ToolResultPresentation _presentationFor(ToolResultMessage message) {
+  return _toolResultPresentationCache[message] ??=
+      _ToolResultPresentation.fromMessage(message);
+}
 
 class ToolResultBubble extends StatefulWidget {
   final ToolResultMessage message;
@@ -145,29 +157,28 @@ class ToolResultBubbleState extends State<ToolResultBubble> {
     widget.message.toolName ?? '',
   );
 
-  String _buildSummary(String content, String? toolName, AppLocalizations l) {
-    final lines = content.split('\n');
-    final lineCount = lines.length;
-
+  String _buildSummary(
+    _ToolResultPresentation presentation,
+    String content,
+    String? toolName,
+    AppLocalizations l,
+  ) {
     if (toolName == 'Edit' ||
         toolName == 'FileEdit' ||
         toolName == 'FileChange') {
-      var added = 0;
-      var removed = 0;
-      for (final line in lines) {
-        if (line.startsWith('+') && !line.startsWith('+++')) added++;
-        if (line.startsWith('-') && !line.startsWith('---')) removed++;
-      }
-      if (added > 0 || removed > 0) {
-        return l.diffSummaryAddedRemoved(added, removed);
+      if (presentation.addedLines > 0 || presentation.removedLines > 0) {
+        return l.diffSummaryAddedRemoved(
+          presentation.addedLines,
+          presentation.removedLines,
+        );
       }
     }
 
-    if (lineCount == 1 && content.length < 40) {
+    if (presentation.lineCount == 1 && content.length < 40) {
       return content;
     }
 
-    return l.lineCountSummary(lineCount);
+    return l.lineCountSummary(presentation.lineCount);
   }
 
   /// Whether this tool result contains a viewable diff.
@@ -181,18 +192,7 @@ class ToolResultBubbleState extends State<ToolResultBubble> {
     final content = widget.message.content;
     // Check for unified diff markers
     return content.contains('---') && content.contains('+++') ||
-        _hasDiffLines(content);
-  }
-
-  static bool _hasDiffLines(String content) {
-    final lines = content.split('\n');
-    for (final line in lines) {
-      if ((line.startsWith('+') && !line.startsWith('+++')) ||
-          (line.startsWith('-') && !line.startsWith('---'))) {
-        return true;
-      }
-    }
-    return false;
+        _presentationFor(widget.message).hasDiffLines;
   }
 
   String? _extractFilePath() {
@@ -238,7 +238,9 @@ class ToolResultBubbleState extends State<ToolResultBubble> {
     }
 
     final l = AppLocalizations.of(context);
+    final presentation = _presentationFor(widget.message);
     final summary = _buildSummary(
+      presentation,
       widget.message.content,
       widget.message.toolName,
       l,
@@ -258,6 +260,7 @@ class ToolResultBubbleState extends State<ToolResultBubble> {
       httpBaseUrl: widget.httpBaseUrl,
       category: _category,
       summary: summary,
+      presentation: presentation,
       expansion: _expansion,
       onTap: _onTap,
       onLongPress: () => _copyContent(context),
@@ -362,6 +365,7 @@ class _ExpandedToolResult extends StatelessWidget {
   final String? httpBaseUrl;
   final ToolCategory category;
   final String summary;
+  final _ToolResultPresentation presentation;
   final ToolResultExpansion expansion;
   final VoidCallback onTap;
   final VoidCallback onLongPress;
@@ -373,6 +377,7 @@ class _ExpandedToolResult extends StatelessWidget {
     required this.httpBaseUrl,
     required this.category,
     required this.summary,
+    required this.presentation,
     required this.expansion,
     required this.onTap,
     required this.onLongPress,
@@ -384,11 +389,7 @@ class _ExpandedToolResult extends StatelessWidget {
     final l = AppLocalizations.of(context);
     final content = message.content;
     final toolName = message.toolName;
-    final lines = content.split('\n');
-    final hasMore = lines.length > _previewLines;
-    final previewText = hasMore
-        ? lines.take(_previewLines).join('\n')
-        : content;
+    final hasMore = presentation.lineCount > _previewLines;
 
     final chevronIcon = expansion == ToolResultExpansion.preview
         ? Icons.expand_more
@@ -453,7 +454,7 @@ class _ExpandedToolResult extends StatelessWidget {
               if (expansion == ToolResultExpansion.preview) ...[
                 const SizedBox(height: 6),
                 Text(
-                  previewText,
+                  presentation.previewText,
                   style: TextStyle(
                     fontSize: 11,
                     fontFamily: 'monospace',
@@ -467,7 +468,7 @@ class _ExpandedToolResult extends StatelessWidget {
                   Padding(
                     padding: const EdgeInsets.only(top: 4),
                     child: Text(
-                      '... ${lines.length - _previewLines} more lines',
+                      '... ${presentation.lineCount - _previewLines} more lines',
                       style: TextStyle(
                         fontSize: 10,
                         fontStyle: FontStyle.italic,
@@ -494,5 +495,79 @@ class _ExpandedToolResult extends StatelessWidget {
         ),
       ),
     );
+  }
+}
+
+class _ToolResultPresentation {
+  final int lineCount;
+  final int addedLines;
+  final int removedLines;
+  final String previewText;
+
+  const _ToolResultPresentation({
+    required this.lineCount,
+    required this.addedLines,
+    required this.removedLines,
+    required this.previewText,
+  });
+
+  bool get hasDiffLines => addedLines > 0 || removedLines > 0;
+
+  factory _ToolResultPresentation.fromMessage(ToolResultMessage message) {
+    assert(() {
+      debugToolResultPresentationScanCount++;
+      return true;
+    }());
+    final content = message.content;
+    final countDiffLines = switch (message.toolName) {
+      'Edit' || 'FileEdit' || 'FileChange' => true,
+      _ => false,
+    };
+    var lineCount = 1;
+    var addedLines = 0;
+    var removedLines = 0;
+    var lineStart = 0;
+    int? previewEnd;
+
+    for (var index = 0; index < content.length; index++) {
+      if (content.codeUnitAt(index) != 0x0a) continue;
+      if (countDiffLines) {
+        final type = _diffLineType(content, lineStart, index);
+        if (type == 0x2b) addedLines++;
+        if (type == 0x2d) removedLines++;
+      }
+      if (lineCount == ToolResultBubbleState._previewLines) {
+        previewEnd = index;
+      }
+      lineCount++;
+      lineStart = index + 1;
+    }
+
+    if (countDiffLines) {
+      final type = _diffLineType(content, lineStart, content.length);
+      if (type == 0x2b) addedLines++;
+      if (type == 0x2d) removedLines++;
+    }
+
+    return _ToolResultPresentation(
+      lineCount: lineCount,
+      addedLines: addedLines,
+      removedLines: removedLines,
+      previewText: previewEnd == null
+          ? content
+          : content.substring(0, previewEnd),
+    );
+  }
+
+  static int? _diffLineType(String content, int start, int end) {
+    if (start >= end) return null;
+    final first = content.codeUnitAt(start);
+    if (first != 0x2b && first != 0x2d) return null;
+    if (end - start >= 3 &&
+        content.codeUnitAt(start + 1) == first &&
+        content.codeUnitAt(start + 2) == first) {
+      return null;
+    }
+    return first;
   }
 }

--- a/apps/mobile/test/tool_result_bubble_test.dart
+++ b/apps/mobile/test/tool_result_bubble_test.dart
@@ -73,6 +73,34 @@ void main() {
       expect(find.text('3 lines'), findsOneWidget);
     });
 
+    testWidgets('large collapsed output shows its line count', (tester) async {
+      final content = List.generate(10000, (index) => 'line $index').join('\n');
+
+      await tester.pumpWidget(
+        _wrap(ToolResultBubble(message: _msg(content: content))),
+      );
+      await tester.pump();
+
+      expect(find.text('10000 lines'), findsOneWidget);
+    });
+
+    testWidgets('recreated item reuses its large-output presentation', (
+      tester,
+    ) async {
+      final message = _msg(
+        content: List.generate(10000, (index) => 'line $index').join('\n'),
+      );
+      debugToolResultPresentationScanCount = 0;
+
+      await tester.pumpWidget(_wrap(ToolResultBubble(message: message)));
+      expect(debugToolResultPresentationScanCount, 1);
+
+      await tester.pumpWidget(_wrap(const SizedBox.shrink()));
+      await tester.pumpWidget(_wrap(ToolResultBubble(message: message)));
+
+      expect(debugToolResultPresentationScanCount, 1);
+    });
+
     testWidgets('collapsed hides images', (tester) async {
       final msg = ToolResultMessage(
         toolUseId: 'test-img',
@@ -147,6 +175,22 @@ void main() {
         return false;
       });
       expect(cardFinder, findsOneWidget);
+    });
+
+    testWidgets('large preview only renders the first five lines', (
+      tester,
+    ) async {
+      final content = List.generate(10000, (index) => 'line $index').join('\n');
+      await tester.pumpWidget(
+        _wrap(ToolResultBubble(message: _msg(content: content))),
+      );
+
+      await tester.tap(find.byType(InkWell).first);
+      await tester.pumpAndSettle();
+
+      expect(find.text('line 0\nline 1\nline 2\nline 3\nline 4'), findsOneWidget);
+      expect(find.text('... 9995 more lines'), findsOneWidget);
+      expect(find.textContaining('line 5'), findsNothing);
     });
   });
 

--- a/apps/mobile/test/tool_use_tile_test.dart
+++ b/apps/mobile/test/tool_use_tile_test.dart
@@ -316,6 +316,31 @@ void main() {
       // No expand_more (preview) state for edit tools
       expect(find.byIcon(Icons.expand_more), findsNothing);
     });
+
+    testWidgets('large edit diff renders only the inline line limit', (
+      tester,
+    ) async {
+      final oldText = List.generate(12, (index) => 'old $index').join('\n');
+      final newText = List.generate(13, (index) => 'new $index').join('\n');
+
+      await tester.pumpWidget(
+        _wrap(
+          ToolUseTile(
+            name: 'Edit',
+            input: {
+              'file_path': 'lib/main.dart',
+              'old_string': oldText,
+              'new_string': newText,
+            },
+          ),
+        ),
+      );
+
+      expect(find.text('... 5 more lines'), findsOneWidget);
+      expect(find.text('- old 11'), findsOneWidget);
+      expect(find.text('+ new 7'), findsOneWidget);
+      expect(find.textContaining('new 8'), findsNothing);
+    });
   });
 
   group('ToolUseTile - long press copy', () {


### PR DESCRIPTION
## Summary

Reduce repeated CPU and allocation work while scrolling long, already-loaded chat histories, especially histories dominated by large tool outputs and edit diffs.

This addresses a remaining concrete rendering path related to #194. The original report predates the list/keyboard fixes in mobile 1.111.2 and 1.114.1; this PR is based on current `main` and targets work those fixes did not cover.

## Why This Is A PR

- Why PR instead of Issue / Prompt Request first: #194 is already open, and the current code has bounded, testable repeated work in recycled chat items.
- Related Issue / Prompt Request: #194
- Base PR (if stacked on another open PR): None; this is based directly on `main`.

## Changes

- Analyze large tool-result content with one allocation-light pass, then cache only its line counts, diff counts, and five-line preview using the immutable message as a weak key.
- Reuse that presentation when a lazy-list item is disposed and recreated instead of splitting the full output on every visit and again for previews.
- Join assistant text once per build instead of up to three times.
- Build at most the 20 inline diff rows that can actually be displayed instead of flattening every diff line first.
- Add regression tests for large collapsed/preview output, cache reuse after widget recreation, and bounded inline diff rendering.

## Scope Check

- Single primary goal of this PR: Reduce repeated per-item rendering work in long tool/diff-heavy chat histories.
- What is intentionally out of scope: History pagination, Bridge protocol changes, Markdown parsing/layout changes, and claiming to resolve every possible device-specific source of jank.
- Can this be split into smaller PRs? The changes cover confirmed instances of the same visible-item allocation problem and share one focused regression suite; splitting would make the performance fix harder to evaluate as a unit.

## Test plan

- [ ] Bridge Server tests pass (`npm run test:bridge`) — no Bridge changes; will be covered by CI.
- [ ] Flutter tests pass (`cd apps/mobile && flutter test`) — Flutter/Dart is unavailable in the local execution environment; will be covered by CI.
- [ ] Manual testing done — no Android runtime is available in the local execution environment.
- [x] `git diff --check`
- [x] Independent code review of cache lifetime, behavior compatibility, and regression coverage

## Platform validation

- Target platform: Android (the optimized Flutter paths are shared across platforms)
- Platform version: Not locally available
- What I validated on that platform: Not locally available; reporter/maintainer device validation is requested.
- Logs / screenshots / notes: The cache regression test disposes and recreates a 10,000-line tool-result widget with the same immutable message and verifies the full presentation scan occurs only once.

## Notes

The weak-key cache retains only small derived presentation data, not a duplicate of the full tool output. When a session releases its message objects, the cached entries are eligible for collection as well.
