### PR TITLE
fix(mobile): restore completed chat summaries

### DIFF
--- a/apps/mobile/lib/features/chat_session/state/chat_session_cubit.dart
+++ b/apps/mobile/lib/features/chat_session/state/chat_session_cubit.dart
@@ -569,7 +569,9 @@ class ChatSessionCubit extends Cubit<ChatSessionState> {
 
     // --- Update hidden tool use IDs (for subagent summary compression) ---
     var hiddenToolUseIds = current.hiddenToolUseIds;
-    if (update.toolUseIdsToHide.isNotEmpty) {
+    if (update.replaceEntries) {
+      hiddenToolUseIds = _hiddenToolUseIdsFromEntries(entries);
+    } else if (update.toolUseIdsToHide.isNotEmpty) {
       hiddenToolUseIds = {...hiddenToolUseIds, ...update.toolUseIdsToHide};
     }
 
@@ -750,6 +752,18 @@ class ChatSessionCubit extends Cubit<ChatSessionState> {
           ? Duration(milliseconds: durationMs.round())
           : null,
     );
+  }
+
+  Set<String> _hiddenToolUseIdsFromEntries(List<ChatEntry> entries) {
+    final hiddenIds = <String>{};
+    for (final entry in entries) {
+      if (entry case ServerChatEntry(
+        message: ToolUseSummaryMessage(:final precedingToolUseIds),
+      )) {
+        hiddenIds.addAll(precedingToolUseIds);
+      }
+    }
+    return hiddenIds;
   }
 
   List<ChatEntry> _entriesToPreserveAfterHistoryReplace({

--- a/apps/mobile/lib/features/chat_session/widgets/chat_message_list.dart
+++ b/apps/mobile/lib/features/chat_session/widgets/chat_message_list.dart
@@ -68,6 +68,50 @@ Set<int> forkableAssistantEntryIndices(List<ChatEntry> entries) {
   return result;
 }
 
+@visibleForTesting
+Set<int> successResultFallbackEntryIndices(List<ChatEntry> entries) {
+  final fallbackIndices = <int>{};
+  final resultCandidates = <({int index, String text})>[];
+  final assistantTexts = <String>[];
+
+  void finishTurn() {
+    final combinedAssistantText = assistantTexts.join('\n\n').trim();
+    for (final candidate in resultCandidates) {
+      final isAlreadyShown =
+          assistantTexts.contains(candidate.text) ||
+          combinedAssistantText == candidate.text;
+      if (!isAlreadyShown) fallbackIndices.add(candidate.index);
+    }
+    assistantTexts.clear();
+    resultCandidates.clear();
+  }
+
+  for (var index = 0; index < entries.length; index++) {
+    final entry = entries[index];
+    if (entry is UserChatEntry) {
+      finishTurn();
+      continue;
+    }
+    if (entry is! ServerChatEntry) continue;
+    switch (entry.message) {
+      case AssistantServerMessage(:final message):
+        final text = message.content
+            .whereType<TextContent>()
+            .map((content) => content.text)
+            .join('\n\n')
+            .trim();
+        if (text.isNotEmpty) assistantTexts.add(text);
+      case ResultMessage(:final subtype, :final result)
+          when subtype == 'success' && result?.trim().isNotEmpty == true:
+        resultCandidates.add((index: index, text: result!.trim()));
+      default:
+        break;
+    }
+  }
+  finishTurn();
+  return fallbackIndices;
+}
+
 /// Displays the chat message list with [ListView.builder] (reverse: true).
 ///
 /// Reads entries directly from [ChatSessionCubit] state (SSOT).
@@ -410,6 +454,9 @@ class _ChatMessageListState extends State<ChatMessageList> {
                     resolvedPlanText: _hasExitPlanMode(entry)
                         ? derivedData.latestPlanText
                         : null,
+                    showSuccessResultText: derivedData
+                        .successResultFallbackEntryIndices
+                        .contains(entryIndex),
                     hiddenToolUseIds: effectiveHiddenToolUseIds,
                     onFileTap: (filePath) {
                       final projectPath = widget.projectPath;
@@ -499,6 +546,9 @@ class _ChatMessageListState extends State<ChatMessageList> {
         entries,
       ),
       forkableAssistantEntryIndices: forkableAssistantEntryIndices(entries),
+      successResultFallbackEntryIndices: successResultFallbackEntryIndices(
+        entries,
+      ),
       latestPlanText: _findPlanFromWriteTool(entries),
     );
     _derivedForState = chatState;
@@ -620,6 +670,7 @@ class _ChatListDerivedData {
   final Map<int, List<GeneratedImagePreviewItem>> imageItemsByAnchor;
   final Set<String> completedGeneratedImageToolUseIds;
   final Set<int> forkableAssistantEntryIndices;
+  final Set<int> successResultFallbackEntryIndices;
   final String? latestPlanText;
 
   const _ChatListDerivedData({
@@ -627,6 +678,7 @@ class _ChatListDerivedData {
     required this.imageItemsByAnchor,
     required this.completedGeneratedImageToolUseIds,
     required this.forkableAssistantEntryIndices,
+    required this.successResultFallbackEntryIndices,
     required this.latestPlanText,
   });
 }

--- a/apps/mobile/lib/widgets/bubbles/result_chip.dart
+++ b/apps/mobile/lib/widgets/bubbles/result_chip.dart
@@ -13,8 +13,14 @@ import '../../theme/markdown_style.dart';
 class ResultChip extends StatelessWidget {
   final ResultMessage message;
   final FilePathTapCallback? onFileTap;
+  final bool showSuccessResultText;
 
-  const ResultChip({super.key, required this.message, this.onFileTap});
+  const ResultChip({
+    super.key,
+    required this.message,
+    this.onFileTap,
+    this.showSuccessResultText = false,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -55,11 +61,10 @@ class ResultChip extends StatelessWidget {
         chipColor = appColors.errorChip;
     }
 
-    // Only show result text for non-success cases (errors, stopped).
-    // For success, the text is already displayed by AssistantBubble.
+    // Success text is a fallback when its assistant message is missing.
     final resultText = message.result;
     final showResultText =
-        message.subtype != 'success' &&
+        (message.subtype != 'success' || showSuccessResultText) &&
         resultText != null &&
         resultText.trim().isNotEmpty;
 

--- a/apps/mobile/lib/widgets/message_bubble.dart
+++ b/apps/mobile/lib/widgets/message_bubble.dart
@@ -29,6 +29,7 @@ class ChatEntryWidget extends StatelessWidget {
   final void Function(AssistantServerMessage)? onForkMessage;
   final ValueNotifier<int>? collapseToolResults;
   final String? resolvedPlanText;
+  final bool showSuccessResultText;
 
   /// Tool use IDs that should be hidden (replaced by a tool_use_summary).
   final Set<String> hiddenToolUseIds;
@@ -50,6 +51,7 @@ class ChatEntryWidget extends StatelessWidget {
     this.onForkMessage,
     this.collapseToolResults,
     this.resolvedPlanText,
+    this.showSuccessResultText = false,
     this.hiddenToolUseIds = const {},
     this.onImageTap,
     this.onFileTap,
@@ -68,6 +70,7 @@ class ChatEntryWidget extends StatelessWidget {
             httpBaseUrl: httpBaseUrl,
             collapseToolResults: collapseToolResults,
             resolvedPlanText: resolvedPlanText,
+            showSuccessResultText: showSuccessResultText,
             hiddenToolUseIds: hiddenToolUseIds,
             onFileTap: onFileTap,
             onForkMessage: onForkMessage,
@@ -151,6 +154,7 @@ class ServerMessageWidget extends StatelessWidget {
   final String? httpBaseUrl;
   final ValueNotifier<int>? collapseToolResults;
   final String? resolvedPlanText;
+  final bool showSuccessResultText;
 
   /// Tool use IDs that should be hidden (replaced by a tool_use_summary).
   final Set<String> hiddenToolUseIds;
@@ -166,6 +170,7 @@ class ServerMessageWidget extends StatelessWidget {
     this.httpBaseUrl,
     this.collapseToolResults,
     this.resolvedPlanText,
+    this.showSuccessResultText = false,
     this.hiddenToolUseIds = const {},
     this.onFileTap,
     this.onForkMessage,
@@ -193,7 +198,11 @@ class ServerMessageWidget extends StatelessWidget {
                 httpBaseUrl: httpBaseUrl,
                 collapseNotifier: collapseToolResults,
               ),
-      final ResultMessage msg => ResultChip(message: msg, onFileTap: onFileTap),
+      final ResultMessage msg => ResultChip(
+        message: msg,
+        onFileTap: onFileTap,
+        showSuccessResultText: showSuccessResultText,
+      ),
       final GuardianApprovalMessage msg => GuardianApprovalNotice(message: msg),
       final ErrorMessage msg => ErrorBubble(message: msg),
       SessionLinkResolutionMessage() => const SizedBox.shrink(),

--- a/apps/mobile/test/chat_message_list_fork_test.dart
+++ b/apps/mobile/test/chat_message_list_fork_test.dart
@@ -46,6 +46,40 @@ void main() {
       expect(forkableAssistantEntryIndices(entries), {0, 2});
     });
   });
+
+  group('successResultFallbackEntryIndices', () {
+    test('uses result text when the final assistant message is missing', () {
+      final entries = <ChatEntry>[
+        UserChatEntry('inspect this'),
+        ServerChatEntry(_toolAssistant('tool-call')),
+        ServerChatEntry(_toolResult('tool-call')),
+        ServerChatEntry(_result(result: 'Final summary')),
+      ];
+
+      expect(successResultFallbackEntryIndices(entries), {3});
+    });
+
+    test('does not duplicate result text already shown by an assistant', () {
+      final entries = <ChatEntry>[
+        UserChatEntry('inspect this'),
+        ServerChatEntry(_assistantWithText('final', 'Final summary')),
+        ServerChatEntry(_result(result: 'Final summary')),
+      ];
+
+      expect(successResultFallbackEntryIndices(entries), isEmpty);
+    });
+
+    test('uses result text when only a progress update exists', () {
+      final entries = <ChatEntry>[
+        UserChatEntry('inspect this'),
+        ServerChatEntry(_assistantWithText('progress', 'Checking files')),
+        ServerChatEntry(_toolResult('tool-call')),
+        ServerChatEntry(_result(result: 'Final summary')),
+      ];
+
+      expect(successResultFallbackEntryIndices(entries), {3});
+    });
+  });
 }
 
 AssistantServerMessage _assistant(String id) => AssistantServerMessage(
@@ -60,4 +94,24 @@ AssistantServerMessage _assistant(String id) => AssistantServerMessage(
 ToolResultMessage _toolResult(String id) =>
     ToolResultMessage(toolUseId: id, content: 'ok');
 
-ResultMessage _result() => const ResultMessage(subtype: 'success');
+AssistantServerMessage _assistantWithText(String id, String text) =>
+    AssistantServerMessage(
+      message: AssistantMessage(
+        id: id,
+        role: 'assistant',
+        content: [TextContent(text: text)],
+        model: 'codex',
+      ),
+    );
+
+AssistantServerMessage _toolAssistant(String id) => AssistantServerMessage(
+  message: AssistantMessage(
+    id: 'assistant-$id',
+    role: 'assistant',
+    content: [ToolUseContent(id: id, name: 'Read', input: const {})],
+    model: 'codex',
+  ),
+);
+
+ResultMessage _result({String? result}) =>
+    ResultMessage(subtype: 'success', result: result);

--- a/apps/mobile/test/chat_screen/final_result_fallback_test.dart
+++ b/apps/mobile/test/chat_screen/final_result_fallback_test.dart
@@ -1,0 +1,48 @@
+import 'package:ccpocket/models/messages.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:patrol_finders/patrol_finders.dart';
+
+import 'helpers/chat_test_helpers.dart';
+
+void main() {
+  late MockBridgeService bridge;
+
+  setUp(() {
+    bridge = MockBridgeService();
+  });
+
+  tearDown(() {
+    bridge.dispose();
+  });
+
+  patrolWidgetTest('restores a missing final answer without duplicating it', (
+    $,
+  ) async {
+    await $.pumpWidget(await buildTestChatScreen(bridge: bridge));
+    await pumpN($.tester);
+
+    await emitAndPump($.tester, bridge, [
+      const HistoryMessage(
+        messages: [
+          ToolResultMessage(
+            toolUseId: 'tool-1',
+            toolName: 'Read',
+            content: 'tool output',
+          ),
+          ResultMessage(subtype: 'success', result: 'Recovered final answer'),
+          StatusMessage(status: ProcessStatus.idle),
+        ],
+      ),
+    ]);
+    await pumpN($.tester);
+
+    expect($('Recovered final answer'), findsOneWidget);
+
+    await emitAndPump($.tester, bridge, [
+      makeAssistantMessage('assistant-1', 'Recovered final answer'),
+    ]);
+    await pumpN($.tester);
+
+    expect($('Recovered final answer'), findsOneWidget);
+  });
+}

--- a/apps/mobile/test/chat_screen/subagent_summary_advanced_test.dart
+++ b/apps/mobile/test/chat_screen/subagent_summary_advanced_test.dart
@@ -96,52 +96,45 @@ void main() {
       expect($('Analyzed entire codebase'), findsOneWidget);
     });
 
-    patrolWidgetTest(
-      'M4: Summary in history — tool results not hidden (current behavior)',
-      ($) async {
-        // _handleHistory does NOT extract toolUseIdsToHide from
-        // ToolUseSummaryMessage, so hidden IDs are empty and all tool
-        // results render normally alongside the summary bubble.
-        await $.pumpWidget(await buildTestChatScreen(bridge: bridge));
-        await pumpN($.tester);
+    patrolWidgetTest('M4: Summary in history hides its tool results', (
+      $,
+    ) async {
+      await $.pumpWidget(await buildTestChatScreen(bridge: bridge));
+      await pumpN($.tester);
 
-        final history = HistoryMessage(
-          messages: [
-            const StatusMessage(status: ProcessStatus.idle),
-            makeAssistantMessage('h1', 'Work done.'),
-            const ToolResultMessage(
-              toolUseId: 'sub-hist-1',
-              content: 'History result 1',
-            ),
-            const ToolResultMessage(
-              toolUseId: 'sub-hist-2',
-              content: 'History result 2',
-            ),
-            const ToolUseSummaryMessage(
-              summary: 'Read 2 files from history',
-              precedingToolUseIds: ['sub-hist-1', 'sub-hist-2'],
-            ),
-            const ToolResultMessage(
-              toolUseId: 'normal-hist',
-              content: 'Normal history result',
-            ),
-          ],
-        );
+      final history = HistoryMessage(
+        messages: [
+          const StatusMessage(status: ProcessStatus.idle),
+          makeAssistantMessage('h1', 'Work done.'),
+          const ToolResultMessage(
+            toolUseId: 'sub-hist-1',
+            content: 'History result 1',
+          ),
+          const ToolResultMessage(
+            toolUseId: 'sub-hist-2',
+            content: 'History result 2',
+          ),
+          const ToolUseSummaryMessage(
+            summary: 'Read 2 files from history',
+            precedingToolUseIds: ['sub-hist-1', 'sub-hist-2'],
+          ),
+          const ToolResultMessage(
+            toolUseId: 'normal-hist',
+            content: 'Normal history result',
+          ),
+        ],
+      );
 
-        await emitAndPump($.tester, bridge, [history]);
-        await pumpN($.tester);
+      await emitAndPump($.tester, bridge, [history]);
+      await pumpN($.tester);
 
-        // Summary bubble is rendered
-        expect($(ToolUseSummaryBubble), findsOneWidget);
-        expect($('Read 2 files from history'), findsOneWidget);
+      expect($(ToolUseSummaryBubble), findsOneWidget);
+      expect($('Read 2 files from history'), findsOneWidget);
 
-        // History tool results are NOT hidden (hiddenToolUseIds empty)
-        // so they render alongside the summary
-        expect($('History result 1'), findsOneWidget);
-        expect($('History result 2'), findsOneWidget);
-        expect($('Normal history result'), findsOneWidget);
-      },
-    );
+      expect($('History result 1'), findsNothing);
+      expect($('History result 2'), findsNothing);
+      expect($('Normal history result'), findsOneWidget);
+    });
 
     patrolWidgetTest('M5: Summary followed by new live tool results', (
       $,

--- a/apps/mobile/test/chat_session_cubit_test.dart
+++ b/apps/mobile/test/chat_session_cubit_test.dart
@@ -942,6 +942,64 @@ void main() {
       },
     );
 
+    test('stale history keeps live summary tool results hidden', () async {
+      final cubit = createCubit('s1');
+      addTearDown(cubit.close);
+
+      mockBridge.emitMessage(
+        const HistoryMessage(
+          messages: [
+            UserInputMessage(
+              text: 'Previous turn',
+              userMessageUuid: 'previous-turn',
+            ),
+          ],
+        ),
+        sessionId: 's1',
+      );
+      await pumpEventQueue();
+
+      mockBridge.emitMessage(
+        const UserInputMessage(
+          text: 'Current turn',
+          userMessageUuid: 'current-turn',
+        ),
+        sessionId: 's1',
+      );
+      mockBridge.emitMessage(
+        const ToolResultMessage(toolUseId: 'live-tool', content: 'live result'),
+        sessionId: 's1',
+      );
+      mockBridge.emitMessage(
+        const ToolUseSummaryMessage(
+          summary: 'Live summary',
+          precedingToolUseIds: ['live-tool'],
+        ),
+        sessionId: 's1',
+      );
+      await pumpEventQueue();
+      expect(cubit.state.hiddenToolUseIds, {'live-tool'});
+
+      mockBridge.emitMessage(
+        const HistoryMessage(
+          messages: [
+            UserInputMessage(
+              text: 'Previous turn',
+              userMessageUuid: 'previous-turn',
+            ),
+          ],
+        ),
+        sessionId: 's1',
+      );
+      await pumpEventQueue();
+
+      final messages = cubit.state.entries.whereType<ServerChatEntry>().map(
+        (entry) => entry.message,
+      );
+      expect(messages.whereType<ToolUseSummaryMessage>(), hasLength(1));
+      expect(cubit.state.hiddenToolUseIds, {'live-tool'});
+    });
+
     test(
       'history delta deduplicates current-turn messages with different ids',
       () async {


### PR DESCRIPTION
## Summary

- show successful result text as a fallback when restored history omits the final assistant message
- avoid duplicating result text when the assistant response is already present
- rebuild hidden tool-use IDs when history replaces current entries

## Tests

- focused coverage for restored summaries, deduplication, progress-only history, and hidden tool results included