### PR TITLE
fix(mobile): stabilize Android keyboard transitions

### DIFF
--- a/apps/mobile/lib/features/chat_session/widgets/maintain_reading_position_physics.dart
+++ b/apps/mobile/lib/features/chat_session/widgets/maintain_reading_position_physics.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/foundation.dart' show ValueGetter, clampDouble;
 import 'package:flutter/widgets.dart';
 
-/// Keeps the content being read fixed when the viewport itself changes size,
+/// Keeps the reverse-list offset stable when the viewport itself changes size,
 /// for example when the keyboard or a bottom overlay opens.
 ///
 /// Message-content changes are deliberately ignored here. A lazy list's
@@ -46,8 +46,10 @@ class MaintainReadingPositionOnResizePhysics extends ScrollPhysics {
         oldPosition.viewportDimension - newPosition.viewportDimension;
     if (viewportDelta.abs() <= dimensionChangeTolerance) return adjusted;
 
+    // Animated IME resizing can produce unstable lazy-list extent estimates.
+    // Keep the reverse-list offset unchanged until resizing settles.
     return clampDouble(
-      newPosition.pixels + viewportDelta,
+      newPosition.pixels,
       newPosition.minScrollExtent,
       newPosition.maxScrollExtent,
     );

--- a/apps/mobile/lib/widgets/chat_input_bar.dart
+++ b/apps/mobile/lib/widgets/chat_input_bar.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -677,12 +678,15 @@ class _InputTextField extends StatefulWidget {
   State<_InputTextField> createState() => _InputTextFieldState();
 }
 
-class _InputTextFieldState extends State<_InputTextField> {
+class _InputTextFieldState extends State<_InputTextField>
+    with WidgetsBindingObserver {
   late final FocusNode _focusNode;
+  var _androidImeResetPending = false;
 
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
     _focusNode = FocusNode(onKeyEvent: _handleKeyEvent);
     _focusNode.addListener(_syncNativePasteBridge);
   }
@@ -697,10 +701,45 @@ class _InputTextFieldState extends State<_InputTextField> {
 
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     NativePasteBridge.instance.deactivate(this);
     _focusNode.removeListener(_syncNativePasteBridge);
     _focusNode.dispose();
     super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (kIsWeb || defaultTargetPlatform != TargetPlatform.android) return;
+    switch (state) {
+      case AppLifecycleState.hidden ||
+          AppLifecycleState.paused ||
+          AppLifecycleState.detached:
+        if (_androidImeResetPending || !_focusNode.hasFocus) return;
+        _androidImeResetPending = true;
+        _resetAndroidIme();
+      case AppLifecycleState.resumed:
+        if (!_androidImeResetPending) return;
+        _androidImeResetPending = false;
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted) _resetAndroidIme();
+        });
+      case AppLifecycleState.inactive:
+        break;
+    }
+  }
+
+  void _resetAndroidIme() {
+    _focusNode.unfocus();
+    unawaited(_hideAndroidIme());
+  }
+
+  Future<void> _hideAndroidIme() async {
+    try {
+      await SystemChannels.textInput.invokeMethod<void>('TextInput.hide');
+    } catch (_) {
+      // The text input channel may already be disconnected.
+    }
   }
 
   void _syncNativePasteBridge() {

--- a/apps/mobile/test/bottom_overlay_layout_test.dart
+++ b/apps/mobile/test/bottom_overlay_layout_test.dart
@@ -26,7 +26,7 @@ void main() {
     expect(contentBuilds, 1);
   });
 
-  testWidgets('keyboard open and close preserves a paused reading position', (
+  testWidgets('keyboard open and close preserves a paused scroll offset', (
     tester,
   ) async {
     addTearDown(tester.view.resetViewInsets);
@@ -41,22 +41,14 @@ void main() {
     await tester.pump();
 
     final initialPixels = controller.position.pixels;
-    final initialMaxExtent = controller.position.maxScrollExtent;
-
     tester.view.viewInsets = const FakeViewPadding(bottom: 300);
     await tester.pumpAndSettle();
 
-    final extentGrowth = controller.position.maxScrollExtent - initialMaxExtent;
-    expect(extentGrowth, greaterThan(0));
-    expect(
-      controller.position.pixels,
-      closeTo(initialPixels + extentGrowth, 1),
-    );
+    expect(controller.position.pixels, closeTo(initialPixels, 1));
 
     tester.view.viewInsets = FakeViewPadding.zero;
     await tester.pumpAndSettle();
 
-    expect(controller.position.maxScrollExtent, closeTo(initialMaxExtent, 1));
     expect(controller.position.pixels, closeTo(initialPixels, 1));
   });
 
@@ -115,6 +107,53 @@ void main() {
     await tester.pumpAndSettle();
     expect(controller.position.pixels, 0);
   });
+
+  testWidgets(
+    'three scroll and back-dismiss cycles do not accumulate position drift',
+    (tester) async {
+      addTearDown(tester.view.resetViewInsets);
+      final controller = ScrollController();
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(
+        _KeyboardScrollHarness(controller: controller, isReadingHistory: true),
+      );
+      await tester.pumpAndSettle();
+
+      for (var cycle = 0; cycle < 3; cycle++) {
+        await tester.drag(find.byType(ListView), const Offset(0, 120));
+        await tester.pumpAndSettle();
+        final positionBeforeKeyboard = controller.position.pixels;
+
+        for (final inset in [100.0, 200.0, 300.0]) {
+          tester.view.viewInsets = FakeViewPadding(bottom: inset);
+          await tester.pump(const Duration(milliseconds: 16));
+        }
+        expect(
+          controller.position.pixels,
+          closeTo(positionBeforeKeyboard, 1),
+          reason: 'keyboard open cycle ${cycle + 1}',
+        );
+
+        for (final inset in [200.0, 100.0, 0.0]) {
+          tester.view.viewInsets = FakeViewPadding(bottom: inset);
+          await tester.pump(const Duration(milliseconds: 16));
+        }
+        await tester.pumpAndSettle();
+
+        expect(
+          controller.position.pixels,
+          closeTo(positionBeforeKeyboard, 1),
+          reason: 'back-dismiss cycle ${cycle + 1}',
+        );
+        expect(
+          controller.position.pixels,
+          lessThan(controller.position.maxScrollExtent),
+          reason: 'cycle ${cycle + 1} must not jump to the oldest message',
+        );
+      }
+    },
+  );
 }
 
 class _BuildCounter extends StatelessWidget {

--- a/apps/mobile/test/chat_input_bar_test.dart
+++ b/apps/mobile/test/chat_input_bar_test.dart
@@ -279,6 +279,36 @@ void main() {
       expect(find.byKey(const ValueKey('message_input')), findsOneWidget);
     });
 
+    testWidgets('Android backgrounding releases input focus for IME recovery', (
+      tester,
+    ) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+      inputController.text = 'draft stays intact';
+      await tester.pumpWidget(buildSubject());
+      await tester.tap(find.byKey(const ValueKey('message_input')));
+      await tester.pump();
+
+      final input = tester.widget<TextField>(
+        find.byKey(const ValueKey('message_input')),
+      );
+      expect(input.focusNode!.hasFocus, isTrue);
+
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.hidden);
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+      await tester.pump();
+
+      expect(input.focusNode!.hasFocus, isFalse);
+      expect(inputController.text, 'draft stays intact');
+
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.hidden);
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+      await tester.pump();
+      expect(input.focusNode!.hasFocus, isFalse);
+      debugDefaultTargetPlatformOverride = null;
+    });
+
     testWidgets('completion handler suppresses Tab indentation', (
       tester,
     ) async {

--- a/apps/mobile/test/maintain_reading_position_physics_test.dart
+++ b/apps/mobile/test/maintain_reading_position_physics_test.dart
@@ -20,7 +20,7 @@ void main() {
       expect(adjusted, 240);
     });
 
-    test('compensates for a smaller viewport while reading', () {
+    test('preserves the offset while the viewport changes', () {
       final physics = MaintainReadingPositionOnResizePhysics(
         shouldMaintain: () => true,
       );
@@ -40,7 +40,7 @@ void main() {
         velocity: 0,
       );
 
-      expect(adjusted, 540);
+      expect(adjusted, 240);
     });
 
     test('does not compensate at latest', () {
@@ -87,6 +87,32 @@ void main() {
       );
 
       expect(adjusted, 240);
+    });
+
+    test('ignores unstable lazy-list estimates during a viewport resize', () {
+      final physics = MaintainReadingPositionOnResizePhysics(
+        shouldMaintain: () => true,
+      );
+
+      var pixels = 2120.0;
+      for (final estimatedMax in [28141.0, 31107.0, 40434.0, 31151.0]) {
+        pixels = physics.adjustPositionForNewDimensions(
+          oldPosition: _metrics(
+            pixels: 2120,
+            maxScrollExtent: 28632,
+            viewportDimension: 364,
+          ),
+          newPosition: _metrics(
+            pixels: pixels,
+            maxScrollExtent: estimatedMax,
+            viewportDimension: 537,
+          ),
+          isScrolling: false,
+          velocity: 0,
+        );
+      }
+
+      expect(pixels, 2120);
     });
   });
 }


### PR DESCRIPTION
## Summary

- keep the reverse chat-list offset stable while Android IME resizing changes the viewport
- release and reset text-input focus across Android background and resume transitions
- add regression coverage for keyboard layout, lifecycle, and scroll physics behavior

## Tests

- focused widget and scroll-physics tests included