### PR TITLE
perf(mobile): reduce long chat rendering work

### DIFF
--- a/apps/mobile/lib/widgets/bubbles/assistant_bubble.dart
+++ b/apps/mobile/lib/widgets/bubbles/assistant_bubble.dart
@@ -86,10 +86,7 @@ class _AssistantBubbleState extends State<AssistantBubble> {
 
     if (hasOnlyTextContent && inferredErrorCode != null) {
       return ErrorBubble(
-        message: ErrorMessage(
-          message: _allText(),
-          errorCode: inferredErrorCode,
-        ),
+        message: ErrorMessage(message: allText, errorCode: inferredErrorCode),
       );
     }
 
@@ -98,7 +95,7 @@ class _AssistantBubbleState extends State<AssistantBubble> {
         contents: contents,
         hasTextContent: hasTextContent,
         resolvedPlanText: widget.resolvedPlanText,
-        allText: _allText(),
+        allText: allText,
         plainTextMode: _plainTextMode,
         onFileTap: widget.onFileTap,
         onFork: widget.onFork,
@@ -113,7 +110,7 @@ class _AssistantBubbleState extends State<AssistantBubble> {
       contents: contents,
       hasTextContent: hasTextContent,
       plainTextMode: _plainTextMode,
-      allText: _allText(),
+      allText: allText,
       onFileTap: widget.onFileTap,
       onFork: widget.onFork,
       hiddenToolUseIds: widget.hiddenToolUseIds,

--- a/apps/mobile/lib/widgets/bubbles/inline_edit_diff.dart
+++ b/apps/mobile/lib/widgets/bubbles/inline_edit_diff.dart
@@ -26,26 +26,30 @@ class InlineEditDiff extends StatelessWidget {
   Widget build(BuildContext context) {
     final appColors = Theme.of(context).extension<AppColors>()!;
 
-    // Flatten all hunk lines for inline display.
-    final allLines = <({DiffLine line, bool isSeparator})>[];
+    final totalLines =
+        diffFile.hunks.fold<int>(
+          0,
+          (total, hunk) => total + hunk.lines.length,
+        ) +
+        (diffFile.hunks.isEmpty ? 0 : diffFile.hunks.length - 1);
+    final visibleLines = <({DiffLine line, bool isSeparator})>[];
     for (var i = 0; i < diffFile.hunks.length; i++) {
+      if (visibleLines.length >= _maxInlineLines) break;
       if (i > 0) {
         // Add a visual separator between hunks (for MultiEdit).
-        allLines.add((
+        visibleLines.add((
           line: const DiffLine(type: DiffLineType.context, content: ''),
           isSeparator: true,
         ));
       }
       for (final line in diffFile.hunks[i].lines) {
-        allLines.add((line: line, isSeparator: false));
+        if (visibleLines.length >= _maxInlineLines) break;
+        visibleLines.add((line: line, isSeparator: false));
       }
     }
 
-    final isTruncated = allLines.length > _maxInlineLines;
-    final visibleLines = isTruncated
-        ? allLines.take(_maxInlineLines).toList()
-        : allLines;
-    final remaining = allLines.length - _maxInlineLines;
+    final isTruncated = totalLines > _maxInlineLines;
+    final remaining = totalLines - _maxInlineLines;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,

--- a/apps/mobile/lib/widgets/bubbles/tool_result_bubble.dart
+++ b/apps/mobile/lib/widgets/bubbles/tool_result_bubble.dart
@@ -20,6 +20,15 @@ enum ToolResultExpansion { collapsed, preview, expanded }
 
 const _imageGenerationToolName = 'ImageGeneration';
 
+final _toolResultPresentationCache = Expando<_ToolResultPresentation>(
+  'tool result presentation',
+);
+
+_ToolResultPresentation _presentationFor(ToolResultMessage message) {
+  return _toolResultPresentationCache[message] ??=
+      _ToolResultPresentation.fromMessage(message);
+}
+
 class ToolResultBubble extends StatefulWidget {
   final ToolResultMessage message;
   final String? httpBaseUrl;
@@ -145,29 +154,28 @@ class ToolResultBubbleState extends State<ToolResultBubble> {
     widget.message.toolName ?? '',
   );
 
-  String _buildSummary(String content, String? toolName, AppLocalizations l) {
-    final lines = content.split('\n');
-    final lineCount = lines.length;
-
+  String _buildSummary(
+    _ToolResultPresentation presentation,
+    String content,
+    String? toolName,
+    AppLocalizations l,
+  ) {
     if (toolName == 'Edit' ||
         toolName == 'FileEdit' ||
         toolName == 'FileChange') {
-      var added = 0;
-      var removed = 0;
-      for (final line in lines) {
-        if (line.startsWith('+') && !line.startsWith('+++')) added++;
-        if (line.startsWith('-') && !line.startsWith('---')) removed++;
-      }
-      if (added > 0 || removed > 0) {
-        return l.diffSummaryAddedRemoved(added, removed);
+      if (presentation.addedLines > 0 || presentation.removedLines > 0) {
+        return l.diffSummaryAddedRemoved(
+          presentation.addedLines,
+          presentation.removedLines,
+        );
       }
     }
 
-    if (lineCount == 1 && content.length < 40) {
+    if (presentation.lineCount == 1 && content.length < 40) {
       return content;
     }
 
-    return l.lineCountSummary(lineCount);
+    return l.lineCountSummary(presentation.lineCount);
   }
 
   /// Whether this tool result contains a viewable diff.
@@ -181,18 +189,7 @@ class ToolResultBubbleState extends State<ToolResultBubble> {
     final content = widget.message.content;
     // Check for unified diff markers
     return content.contains('---') && content.contains('+++') ||
-        _hasDiffLines(content);
-  }
-
-  static bool _hasDiffLines(String content) {
-    final lines = content.split('\n');
-    for (final line in lines) {
-      if ((line.startsWith('+') && !line.startsWith('+++')) ||
-          (line.startsWith('-') && !line.startsWith('---'))) {
-        return true;
-      }
-    }
-    return false;
+        _presentationFor(widget.message).hasDiffLines;
   }
 
   String? _extractFilePath() {
@@ -238,7 +235,9 @@ class ToolResultBubbleState extends State<ToolResultBubble> {
     }
 
     final l = AppLocalizations.of(context);
+    final presentation = _presentationFor(widget.message);
     final summary = _buildSummary(
+      presentation,
       widget.message.content,
       widget.message.toolName,
       l,
@@ -258,6 +257,7 @@ class ToolResultBubbleState extends State<ToolResultBubble> {
       httpBaseUrl: widget.httpBaseUrl,
       category: _category,
       summary: summary,
+      presentation: presentation,
       expansion: _expansion,
       onTap: _onTap,
       onLongPress: () => _copyContent(context),
@@ -362,6 +362,7 @@ class _ExpandedToolResult extends StatelessWidget {
   final String? httpBaseUrl;
   final ToolCategory category;
   final String summary;
+  final _ToolResultPresentation presentation;
   final ToolResultExpansion expansion;
   final VoidCallback onTap;
   final VoidCallback onLongPress;
@@ -373,6 +374,7 @@ class _ExpandedToolResult extends StatelessWidget {
     required this.httpBaseUrl,
     required this.category,
     required this.summary,
+    required this.presentation,
     required this.expansion,
     required this.onTap,
     required this.onLongPress,
@@ -384,11 +386,7 @@ class _ExpandedToolResult extends StatelessWidget {
     final l = AppLocalizations.of(context);
     final content = message.content;
     final toolName = message.toolName;
-    final lines = content.split('\n');
-    final hasMore = lines.length > _previewLines;
-    final previewText = hasMore
-        ? lines.take(_previewLines).join('\n')
-        : content;
+    final hasMore = presentation.lineCount > _previewLines;
 
     final chevronIcon = expansion == ToolResultExpansion.preview
         ? Icons.expand_more
@@ -453,7 +451,7 @@ class _ExpandedToolResult extends StatelessWidget {
               if (expansion == ToolResultExpansion.preview) ...[
                 const SizedBox(height: 6),
                 Text(
-                  previewText,
+                  presentation.previewText,
                   style: TextStyle(
                     fontSize: 11,
                     fontFamily: 'monospace',
@@ -467,7 +465,7 @@ class _ExpandedToolResult extends StatelessWidget {
                   Padding(
                     padding: const EdgeInsets.only(top: 4),
                     child: Text(
-                      '... ${lines.length - _previewLines} more lines',
+                      '... ${presentation.lineCount - _previewLines} more lines',
                       style: TextStyle(
                         fontSize: 10,
                         fontStyle: FontStyle.italic,
@@ -494,5 +492,75 @@ class _ExpandedToolResult extends StatelessWidget {
         ),
       ),
     );
+  }
+}
+
+class _ToolResultPresentation {
+  final int lineCount;
+  final int addedLines;
+  final int removedLines;
+  final String previewText;
+
+  const _ToolResultPresentation({
+    required this.lineCount,
+    required this.addedLines,
+    required this.removedLines,
+    required this.previewText,
+  });
+
+  bool get hasDiffLines => addedLines > 0 || removedLines > 0;
+
+  factory _ToolResultPresentation.fromMessage(ToolResultMessage message) {
+    final content = message.content;
+    final countDiffLines = switch (message.toolName) {
+      'Edit' || 'FileEdit' || 'FileChange' => true,
+      _ => false,
+    };
+    var lineCount = 1;
+    var addedLines = 0;
+    var removedLines = 0;
+    var lineStart = 0;
+    int? previewEnd;
+
+    for (var index = 0; index < content.length; index++) {
+      if (content.codeUnitAt(index) != 0x0a) continue;
+      if (countDiffLines) {
+        final type = _diffLineType(content, lineStart, index);
+        if (type == 0x2b) addedLines++;
+        if (type == 0x2d) removedLines++;
+      }
+      if (lineCount == ToolResultBubbleState._previewLines) {
+        previewEnd = index;
+      }
+      lineCount++;
+      lineStart = index + 1;
+    }
+
+    if (countDiffLines) {
+      final type = _diffLineType(content, lineStart, content.length);
+      if (type == 0x2b) addedLines++;
+      if (type == 0x2d) removedLines++;
+    }
+
+    return _ToolResultPresentation(
+      lineCount: lineCount,
+      addedLines: addedLines,
+      removedLines: removedLines,
+      previewText: previewEnd == null
+          ? content
+          : content.substring(0, previewEnd),
+    );
+  }
+
+  static int? _diffLineType(String content, int start, int end) {
+    if (start >= end) return null;
+    final first = content.codeUnitAt(start);
+    if (first != 0x2b && first != 0x2d) return null;
+    if (end - start >= 3 &&
+        content.codeUnitAt(start + 1) == first &&
+        content.codeUnitAt(start + 2) == first) {
+      return null;
+    }
+    return first;
   }
 }

--- a/apps/mobile/test/tool_result_bubble_test.dart
+++ b/apps/mobile/test/tool_result_bubble_test.dart
@@ -73,6 +73,17 @@ void main() {
       expect(find.text('3 lines'), findsOneWidget);
     });
 
+    testWidgets('large collapsed output shows its line count', (tester) async {
+      final content = List.generate(10000, (index) => 'line $index').join('\n');
+
+      await tester.pumpWidget(
+        _wrap(ToolResultBubble(message: _msg(content: content))),
+      );
+      await tester.pump();
+
+      expect(find.text('10000 lines'), findsOneWidget);
+    });
+
     testWidgets('collapsed hides images', (tester) async {
       final msg = ToolResultMessage(
         toolUseId: 'test-img',
@@ -147,6 +158,25 @@ void main() {
         return false;
       });
       expect(cardFinder, findsOneWidget);
+    });
+
+    testWidgets('large preview only renders the first five lines', (
+      tester,
+    ) async {
+      final content = List.generate(10000, (index) => 'line $index').join('\n');
+      await tester.pumpWidget(
+        _wrap(ToolResultBubble(message: _msg(content: content))),
+      );
+
+      await tester.tap(find.byType(InkWell).first);
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('line 0\nline 1\nline 2\nline 3\nline 4'),
+        findsOneWidget,
+      );
+      expect(find.text('... 9995 more lines'), findsOneWidget);
+      expect(find.textContaining('line 5'), findsNothing);
     });
   });
 

--- a/apps/mobile/test/tool_use_tile_test.dart
+++ b/apps/mobile/test/tool_use_tile_test.dart
@@ -316,6 +316,32 @@ void main() {
       // No expand_more (preview) state for edit tools
       expect(find.byIcon(Icons.expand_more), findsNothing);
     });
+
+    testWidgets('large multi-edit stops at the inline line limit', (
+      tester,
+    ) async {
+      final oldText = List.generate(10, (index) => 'old $index').join('\n');
+      final newText = List.generate(10, (index) => 'new $index').join('\n');
+
+      await tester.pumpWidget(
+        _wrap(
+          ToolUseTile(
+            name: 'MultiEdit',
+            input: {
+              'file_path': 'lib/main.dart',
+              'edits': [
+                {'old_string': oldText, 'new_string': newText},
+                {'old_string': 'second old', 'new_string': 'second new'},
+              ],
+            },
+          ),
+        ),
+      );
+
+      expect(find.text('... 3 more lines'), findsOneWidget);
+      expect(find.text('+ new 9'), findsOneWidget);
+      expect(find.textContaining('second'), findsNothing);
+    });
   });
 
   group('ToolUseTile - long press copy', () {


### PR DESCRIPTION
## Summary

- cache parsed tool-result presentation data per message
- avoid repeatedly splitting large tool output and stop collecting inline diff rows at the display limit
- reuse combined assistant text during bubble rendering

## Tests

- focused coverage for large collapsed output, previews, and multi-edit truncation included