### PR TITLE
fix(mobile): avoid duplicate background notifications

### DIFF
--- a/apps/mobile/lib/features/claude_session/claude_session_screen.dart
+++ b/apps/mobile/lib/features/claude_session/claude_session_screen.dart
@@ -551,6 +551,10 @@ class _ChatScreenBody extends HookWidget {
     final showRemoteGitStatusBadge = context.select(
       (SettingsCubit cubit) => cubit.state.showRemoteGitStatusBadge,
     );
+    final remoteNotificationsEnabled = context.select(
+      (SettingsCubit cubit) =>
+          cubit.state.fcmAvailable && cubit.state.fcmEnabled,
+    );
 
     // Custom hooks
     final lifecycleState = useAppLifecycleState();
@@ -558,6 +562,8 @@ class _ChatScreenBody extends HookWidget {
         lifecycleState != null && lifecycleState != AppLifecycleState.resumed;
     final isBackgroundRef = useRef(isBackground);
     isBackgroundRef.value = isBackground;
+    final remoteNotificationsEnabledRef = useRef(remoteNotificationsEnabled);
+    remoteNotificationsEnabledRef.value = remoteNotificationsEnabled;
     final scroll = useScrollTracking(sessionId);
 
     // Plan feedback controller (for plan approval rejection message)
@@ -672,6 +678,7 @@ class _ChatScreenBody extends HookWidget {
           effects,
           sessionId: sessionId,
           isBackground: isBackgroundRef.value,
+          remoteNotificationsEnabled: remoteNotificationsEnabledRef.value,
           approval: chatSessionCubit.state.approval,
           l: l,
           collapseToolResults: collapseToolResults,
@@ -1489,12 +1496,17 @@ void _executeSideEffects(
   Set<ChatSideEffect> effects, {
   required String sessionId,
   required bool isBackground,
+  required bool remoteNotificationsEnabled,
   required ApprovalState approval,
   required AppLocalizations l,
   required ValueNotifier<int> collapseToolResults,
   required TextEditingController planFeedbackController,
   required bool Function() isReadingHistory,
 }) {
+  final useLocalNotification = shouldUseLocalNotificationFallback(
+    isBackground: isBackground,
+    remoteNotificationsEnabled: remoteNotificationsEnabled,
+  );
   for (final effect in effects) {
     switch (effect) {
       case ChatSideEffect.heavyHaptic:
@@ -1510,7 +1522,7 @@ void _executeSideEffects(
       case ChatSideEffect.clearPlanFeedback:
         planFeedbackController.clear();
       case ChatSideEffect.notifyApprovalRequired:
-        if (isBackground) {
+        if (useLocalNotification) {
           final permission = _notificationPermissionFor(approval);
           if (permission != null) {
             NotificationService.instance.showApprovalNotification(
@@ -1522,7 +1534,7 @@ void _executeSideEffects(
           }
         }
       case ChatSideEffect.notifyAskQuestion:
-        if (isBackground) {
+        if (useLocalNotification) {
           final permission = _notificationPermissionFor(approval);
           if (permission != null) {
             NotificationService.instance.showApprovalNotification(
@@ -1534,7 +1546,7 @@ void _executeSideEffects(
           }
         }
       case ChatSideEffect.notifySessionComplete:
-        if (isBackground) {
+        if (useLocalNotification) {
           NotificationService.instance.showSessionCompleteNotification(
             body: 'Session done',
             id: 3,

--- a/apps/mobile/lib/features/codex_session/codex_session_screen.dart
+++ b/apps/mobile/lib/features/codex_session/codex_session_screen.dart
@@ -602,6 +602,10 @@ class _CodexChatBody extends HookWidget {
     final showRemoteGitStatusBadge = context.select(
       (SettingsCubit cubit) => cubit.state.showRemoteGitStatusBadge,
     );
+    final remoteNotificationsEnabled = context.select(
+      (SettingsCubit cubit) =>
+          cubit.state.fcmAvailable && cubit.state.fcmEnabled,
+    );
 
     // Custom hooks
     final lifecycleState = useAppLifecycleState();
@@ -609,6 +613,8 @@ class _CodexChatBody extends HookWidget {
         lifecycleState != null && lifecycleState != AppLifecycleState.resumed;
     final isBackgroundRef = useRef(isBackground);
     isBackgroundRef.value = isBackground;
+    final remoteNotificationsEnabledRef = useRef(remoteNotificationsEnabled);
+    remoteNotificationsEnabledRef.value = remoteNotificationsEnabled;
     final scroll = useScrollTracking(sessionId);
 
     // Chat input controller
@@ -742,6 +748,7 @@ class _CodexChatBody extends HookWidget {
           effects,
           sessionId: sessionId,
           isBackground: isBackgroundRef.value,
+          remoteNotificationsEnabled: remoteNotificationsEnabledRef.value,
           approval: chatSessionCubit.state.approval,
           l: l,
           collapseToolResults: collapseToolResults,
@@ -1655,12 +1662,17 @@ void _executeSideEffects(
   Set<ChatSideEffect> effects, {
   required String sessionId,
   required bool isBackground,
+  required bool remoteNotificationsEnabled,
   required ApprovalState approval,
   required AppLocalizations l,
   required TextEditingController planFeedbackController,
   required ValueNotifier<int> collapseToolResults,
   required bool Function() isReadingHistory,
 }) {
+  final useLocalNotification = shouldUseLocalNotificationFallback(
+    isBackground: isBackground,
+    remoteNotificationsEnabled: remoteNotificationsEnabled,
+  );
   for (final effect in effects) {
     switch (effect) {
       case ChatSideEffect.heavyHaptic:
@@ -1676,7 +1688,7 @@ void _executeSideEffects(
       case ChatSideEffect.clearPlanFeedback:
         planFeedbackController.clear();
       case ChatSideEffect.notifyApprovalRequired:
-        if (isBackground) {
+        if (useLocalNotification) {
           final permission = _notificationPermissionFor(approval);
           if (permission != null) {
             NotificationService.instance.showApprovalNotification(
@@ -1688,7 +1700,7 @@ void _executeSideEffects(
           }
         }
       case ChatSideEffect.notifyAskQuestion:
-        if (isBackground) {
+        if (useLocalNotification) {
           final permission = _notificationPermissionFor(approval);
           if (permission != null) {
             NotificationService.instance.showApprovalNotification(
@@ -1700,7 +1712,7 @@ void _executeSideEffects(
           }
         }
       case ChatSideEffect.notifySessionComplete:
-        if (isBackground) {
+        if (useLocalNotification) {
           NotificationService.instance.showSessionCompleteNotification(
             body: 'Codex session done',
             id: 3,

--- a/apps/mobile/lib/services/notification_service.dart
+++ b/apps/mobile/lib/services/notification_service.dart
@@ -5,6 +5,11 @@ import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import '../l10n/app_localizations.dart';
 import '../models/messages.dart';
 
+bool shouldUseLocalNotificationFallback({
+  required bool isBackground,
+  required bool remoteNotificationsEnabled,
+}) => isBackground && !remoteNotificationsEnabled;
+
 class NotificationService extends ChangeNotifier {
   NotificationService._();
   static final NotificationService instance = NotificationService._();

--- a/apps/mobile/test/notification_service_test.dart
+++ b/apps/mobile/test/notification_service_test.dart
@@ -1,0 +1,36 @@
+import 'package:ccpocket/services/notification_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('local notification fallback', () {
+    test('stays silent while the app is foregrounded', () {
+      expect(
+        shouldUseLocalNotificationFallback(
+          isBackground: false,
+          remoteNotificationsEnabled: false,
+        ),
+        isFalse,
+      );
+    });
+
+    test('notifies in the background when remote push is unavailable', () {
+      expect(
+        shouldUseLocalNotificationFallback(
+          isBackground: true,
+          remoteNotificationsEnabled: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('defers to remote push in the background when enabled', () {
+      expect(
+        shouldUseLocalNotificationFallback(
+          isBackground: true,
+          remoteNotificationsEnabled: true,
+        ),
+        isFalse,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- defer background approval, question, and completion alerts to FCM when remote notifications are available and enabled
- retain local notifications as a fallback when push is unavailable or disabled
- apply the same policy to Claude and Codex sessions

## Testing

- `flutter test test/notification_service_test.dart test/chat_message_handler_test.dart` (96 tests passed)
- `dart analyze apps/mobile` (no errors or warnings; 45 existing info-level lints remain)