### PR TITLE
fix(mobile): reconnect notification sessions

### DIFF
--- a/apps/mobile/lib/services/bridge_service.dart
+++ b/apps/mobile/lib/services/bridge_service.dart
@@ -1535,23 +1535,82 @@ class BridgeService implements BridgeServiceBase {
     Duration timeout = const Duration(seconds: 10),
   }) async {
     final deadline = DateTime.now().add(timeout);
-    if (!isConnected) {
-      try {
-        await connectionStatus
-            .firstWhere((state) => state == BridgeConnectionState.connected)
-            .timeout(timeout);
-      } on TimeoutException {
-        return const SessionLinkResolveResult.unavailable();
-      }
-      if (!isConnected) {
-        return const SessionLinkResolveResult.unavailable();
-      }
+    _prepareSessionLinkConnection();
+    if (!await _waitForConnection(deadline)) {
+      return const SessionLinkResolveResult.unavailable();
     }
 
-    final remaining = deadline.difference(DateTime.now());
+    var remaining = deadline.difference(DateTime.now());
     if (remaining <= Duration.zero) {
       return const SessionLinkResolveResult.unavailable();
     }
+    final firstAttemptTimeout = Duration(
+      microseconds: min(
+        remaining.inMicroseconds ~/ 2,
+        const Duration(seconds: 3).inMicroseconds,
+      ),
+    );
+    final firstResult = await _requestSessionLinkResolution(
+      sessionId,
+      provider: provider,
+      timeout: firstAttemptTimeout,
+    );
+    if (firstResult != null) return firstResult;
+
+    // A connected WebSocket can remain marked open after the app was
+    // suspended even though it no longer delivers messages. A timed-out
+    // resolution request is safe to retry after replacing that stale socket.
+    final reconnectUrl = _lastUrl;
+    if (reconnectUrl == null) {
+      return const SessionLinkResolveResult.unavailable();
+    }
+    connect(reconnectUrl);
+    if (!await _waitForConnection(deadline)) {
+      return const SessionLinkResolveResult.unavailable();
+    }
+
+    remaining = deadline.difference(DateTime.now());
+    if (remaining <= Duration.zero) {
+      return const SessionLinkResolveResult.unavailable();
+    }
+    final retryResult = await _requestSessionLinkResolution(
+      sessionId,
+      provider: provider,
+      timeout: remaining,
+    );
+    return retryResult ?? const SessionLinkResolveResult.unavailable();
+  }
+
+  void _prepareSessionLinkConnection() {
+    if (_connectionState == BridgeConnectionState.reconnecting &&
+        _lastUrl != null) {
+      // A notification tap is an active foreground request, so do not make
+      // the user wait for an exponential background reconnect delay.
+      connect(_lastUrl!);
+      return;
+    }
+    ensureConnected();
+  }
+
+  Future<bool> _waitForConnection(DateTime deadline) async {
+    if (isConnected) return true;
+    final remaining = deadline.difference(DateTime.now());
+    if (remaining <= Duration.zero) return false;
+    try {
+      await connectionStatus
+          .firstWhere((state) => state == BridgeConnectionState.connected)
+          .timeout(remaining);
+    } on TimeoutException {
+      return false;
+    }
+    return isConnected;
+  }
+
+  Future<SessionLinkResolveResult?> _requestSessionLinkResolution(
+    String sessionId, {
+    required String provider,
+    required Duration timeout,
+  }) async {
     final requestId = 'session-link-${++_nextSessionLinkRequestId}';
     final completer = Completer<SessionLinkResolveResult>();
     _pendingSessionLinkResolutions[requestId] = completer;
@@ -1563,10 +1622,9 @@ class BridgeService implements BridgeServiceBase {
       ),
     );
     try {
-      return await completer.future.timeout(
-        remaining,
-        onTimeout: () => const SessionLinkResolveResult.unavailable(),
-      );
+      return await completer.future.timeout(timeout);
+    } on TimeoutException {
+      return null;
     } finally {
       _pendingSessionLinkResolutions.remove(requestId);
       _messageQueue.removeWhere((message) {

--- a/apps/mobile/test/services/bridge_service_usage_test.dart
+++ b/apps/mobile/test/services/bridge_service_usage_test.dart
@@ -507,6 +507,74 @@ void main() {
       bridge.dispose();
     });
 
+    test('resolveSessionLink reconnects and retries a stale socket', () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      final firstSocketReady = Completer<WebSocket>();
+      final secondSocketReady = Completer<WebSocket>();
+      var connectionCount = 0;
+
+      server.transform(WebSocketTransformer()).listen((socket) {
+        connectionCount++;
+        if (connectionCount == 1) {
+          firstSocketReady.complete(socket);
+        } else if (connectionCount == 2) {
+          secondSocketReady.complete(socket);
+        }
+      });
+
+      final bridge = BridgeService();
+      bridge.connect('ws://127.0.0.1:${server.port}');
+      final firstSocket = await firstSocketReady.future;
+      final firstRequestFuture = firstSocket
+          .where((event) {
+            final json = jsonDecode(event as String) as Map<String, dynamic>;
+            return json['type'] == 'resolve_session_link';
+          })
+          .map((event) => jsonDecode(event as String) as Map<String, dynamic>)
+          .first;
+
+      final resolutionFuture = bridge.resolveSessionLink(
+        'claude-uuid',
+        provider: 'claude',
+        timeout: const Duration(seconds: 2),
+      );
+      await firstRequestFuture.timeout(const Duration(seconds: 1));
+
+      // The first socket deliberately never answers. The resolver should
+      // replace it and repeat the request instead of showing unavailable.
+      final secondSocket = await secondSocketReady.future.timeout(
+        const Duration(seconds: 2),
+      );
+      final secondRequest = await secondSocket
+          .where((event) {
+            final json = jsonDecode(event as String) as Map<String, dynamic>;
+            return json['type'] == 'resolve_session_link';
+          })
+          .map((event) => jsonDecode(event as String) as Map<String, dynamic>)
+          .first
+          .timeout(const Duration(seconds: 1));
+      secondSocket.add(
+        jsonEncode({
+          'type': 'session_link_resolution',
+          'requestId': secondRequest['requestId'],
+          'sourceSessionId': 'claude-uuid',
+          'status': 'live',
+          'bridgeSessionId': 'bridge-1',
+          'provider': 'claude',
+        }),
+      );
+
+      final result = await resolutionFuture.timeout(const Duration(seconds: 2));
+      expect(result.support, SessionLinkResolveSupport.resolved);
+      expect(result.resolution?.bridgeSessionId, 'bridge-1');
+      expect(connectionCount, 2);
+
+      bridge.disconnect();
+      await secondSocket.close();
+      await server.close(force: true);
+      bridge.dispose();
+    });
+
     test('resolveSessionLink waits for a connection without queueing a stale request', () async {
       final bridge = BridgeService();
       final outgoing = <ClientMessage>[];


### PR DESCRIPTION
## Summary

- reconnect immediately when a notification-opened session is waiting behind Bridge backoff
- retry session-link resolution once after replacing a connected but non-responsive WebSocket
- keep both attempts inside the existing resolution timeout before showing the session as unavailable

## Testing

- `flutter test test/services/bridge_service_usage_test.dart test/session_link_cubit_test.dart test/session_link_screen_test.dart` (38 tests passed)
- `dart analyze apps/mobile` (no errors or warnings; 45 existing info-level lints remain)