### PR TITLE
fix(mobile): anchor active streaming content

### DIFF
--- a/apps/mobile/lib/features/chat_session/widgets/anchor_maintaining_auto_scroll_controller.dart
+++ b/apps/mobile/lib/features/chat_session/widgets/anchor_maintaining_auto_scroll_controller.dart
@@ -26,6 +26,36 @@ class AnchorMaintainingAutoScrollController extends SimpleAutoScrollController {
   /// does not notify regular scroll listeners.
   ValueChanged<double>? onLayoutAnchorCorrected;
 
+  int _streamingExtentCorrectionGeneration = 0;
+  int? _pendingStreamingExtentCorrection;
+
+  /// Requests a one-frame fallback that preserves the reverse-list position
+  /// when the active streaming row itself is the content being read.
+  int requestStreamingExtentCorrection() {
+    final generation = ++_streamingExtentCorrectionGeneration;
+    _pendingStreamingExtentCorrection = generation;
+    return generation;
+  }
+
+  void clearStreamingExtentCorrection(int generation) {
+    if (_pendingStreamingExtentCorrection == generation) {
+      _pendingStreamingExtentCorrection = null;
+    }
+  }
+
+  void _clearStreamingExtentCorrection() {
+    _pendingStreamingExtentCorrection = null;
+  }
+
+  double? _takeStreamingExtentCorrection(
+    ScrollMetrics oldPosition,
+    ScrollMetrics newPosition,
+  ) {
+    if (_pendingStreamingExtentCorrection == null) return null;
+    _pendingStreamingExtentCorrection = null;
+    return newPosition.maxScrollExtent - oldPosition.maxScrollExtent;
+  }
+
   @override
   ScrollPosition createScrollPosition(
     ScrollPhysics physics,
@@ -67,6 +97,7 @@ class _AnchorMaintainingScrollPosition extends ScrollPositionWithSingleContext {
   ) {
     final correction = controller.layoutAnchorCorrection?.call();
     if (correction != null) {
+      controller._clearStreamingExtentCorrection();
       final target = clampDouble(
         pixels + correction,
         newPosition.minScrollExtent,
@@ -80,6 +111,23 @@ class _AnchorMaintainingScrollPosition extends ScrollPositionWithSingleContext {
       // The measured anchor already accounts for every layout change in this
       // frame, including a simultaneous viewport resize. Do not apply the
       // resize physics a second time when the correction has converged.
+      return true;
+    }
+    final streamingCorrection = controller._takeStreamingExtentCorrection(
+      oldPosition,
+      newPosition,
+    );
+    if (streamingCorrection != null) {
+      final target = clampDouble(
+        pixels + streamingCorrection,
+        newPosition.minScrollExtent,
+        newPosition.maxScrollExtent,
+      );
+      if ((target - pixels).abs() > 0.5) {
+        correctPixels(target);
+        controller.onLayoutAnchorCorrected?.call(target);
+        return false;
+      }
       return true;
     }
     return super.correctForNewDimensions(oldPosition, newPosition);

--- a/apps/mobile/lib/features/chat_session/widgets/chat_message_list.dart
+++ b/apps/mobile/lib/features/chat_session/widgets/chat_message_list.dart
@@ -220,12 +220,17 @@ class _ChatMessageListState extends State<ChatMessageList> {
   /// Records one measured, visible message before a state change. After the
   /// next layout, the same keyed message is restored to the same screen Y.
   /// This avoids relying on the lazy list's estimated maxScrollExtent.
-  void _captureVisibleAnchor() {
+  void _captureVisibleAnchor({bool allowStreamingExtentFallback = false}) {
     if (!widget.isReadingHistory ||
         !widget.scrollController.hasClients ||
         widget.scrollController.isAutoScrolling ||
-        widget.scrollController.position.isScrollingNotifier.value ||
         _anchorCorrectionScheduled) {
+      return;
+    }
+    if (widget.scrollController.position.isScrollingNotifier.value) {
+      if (allowStreamingExtentFallback) {
+        _scheduleStreamingExtentCorrection();
+      }
       return;
     }
 
@@ -259,12 +264,26 @@ class _ChatMessageListState extends State<ChatMessageList> {
         );
       }
     }
-    if (best == null) return;
+    if (best == null) {
+      if (allowStreamingExtentFallback) {
+        _scheduleStreamingExtentCorrection();
+      }
+      return;
+    }
 
     _pendingAnchor = best;
     _anchorCorrectionScheduled = true;
     WidgetsBinding.instance.addPostFrameCallback(
       (_) => _restoreVisibleAnchor(),
+    );
+  }
+
+  void _scheduleStreamingExtentCorrection() {
+    final controller = widget.scrollController;
+    if (controller is! AnchorMaintainingAutoScrollController) return;
+    final generation = controller.requestStreamingExtentCorrection();
+    WidgetsBinding.instance.addPostFrameCallback(
+      (_) => controller.clearStreamingExtentCorrection(generation),
     );
   }
 
@@ -403,7 +422,8 @@ class _ChatMessageListState extends State<ChatMessageList> {
           listener: (_, _) => _captureVisibleAnchor(),
         ),
         BlocListener<StreamingStateCubit, StreamingState>(
-          listener: (_, _) => _captureVisibleAnchor(),
+          listener: (_, _) =>
+              _captureVisibleAnchor(allowStreamingExtentFallback: true),
         ),
       ],
       child: NotificationListener<ScrollMetricsNotification>(

--- a/apps/mobile/test/chat_message_list_scroll_anchor_test.dart
+++ b/apps/mobile/test/chat_message_list_scroll_anchor_test.dart
@@ -123,6 +123,87 @@ void main() {
     expect(tester.getTopLeft(target).dy, closeTo(beforeCombinedResize, 1));
     expect(tester.takeException(), isNull);
   });
+
+  testWidgets('streaming keeps text fixed while reading inside its own row', (
+    tester,
+  ) async {
+    final bridge = _ScrollTestBridge();
+    final streamingCubit = StreamingStateCubit();
+    final chatCubit = ChatSessionCubit(
+      sessionId: 'scroll-anchor',
+      bridge: bridge,
+      streamingCubit: streamingCubit,
+    );
+    final controller = AnchorMaintainingAutoScrollController();
+    addTearDown(controller.dispose);
+    addTearDown(chatCubit.close);
+    addTearDown(streamingCubit.close);
+    addTearDown(bridge.dispose);
+
+    streamingCubit.appendText(
+      List.generate(100, (index) => 'streaming line $index').join('\n\n'),
+    );
+    await tester.pumpWidget(
+      MultiRepositoryProvider(
+        providers: [RepositoryProvider<BridgeService>.value(value: bridge)],
+        child: MultiBlocProvider(
+          providers: [
+            BlocProvider<ChatSessionCubit>.value(value: chatCubit),
+            BlocProvider<StreamingStateCubit>.value(value: streamingCubit),
+          ],
+          child: MaterialApp(
+            theme: AppTheme.darkTheme,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            locale: const Locale('en'),
+            home: Scaffold(
+              body: ChatMessageList(
+                sessionId: 'scroll-anchor',
+                scrollController: controller,
+                httpBaseUrl: null,
+                onRetryMessage: null,
+                collapseToolResults: null,
+                isReadingHistory: true,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    bridge.emit(const StatusMessage(status: ProcessStatus.idle));
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(controller.position.maxScrollExtent, greaterThan(500));
+    controller.jumpTo(400);
+    await tester.pump();
+    final streamingEntry = find.byWidgetPredicate(
+      (widget) =>
+          widget is ChatEntryWidget && widget.entry is StreamingChatEntry,
+    );
+
+    final topBefore = tester.getTopLeft(streamingEntry).dy;
+    final offsetBefore = controller.offset;
+    streamingCubit.appendText(
+      List.generate(12, (index) => '\n\nnew line $index').join(),
+    );
+    await tester.pump();
+
+    expect(tester.getTopLeft(streamingEntry).dy, closeTo(topBefore, 1));
+    expect(controller.offset, greaterThan(offsetBefore));
+
+    final gesture = await tester.startGesture(const Offset(200, 300));
+    await gesture.moveBy(const Offset(0, -24));
+    await tester.pump();
+    final topDuringDrag = tester.getTopLeft(streamingEntry).dy;
+    streamingCubit.appendText(
+      List.generate(8, (index) => '\n\nmore line $index').join(),
+    );
+    await tester.pump();
+
+    expect(tester.getTopLeft(streamingEntry).dy, closeTo(topDuringDrag, 1));
+    await gesture.up();
+  });
 }
 
 class _ScrollTestBridge extends BridgeService {


### PR DESCRIPTION
## Summary

- preserve the visible reading position when the active streaming response itself grows
- use the exact reverse-list extent change only when no completed message can provide a measured anchor
- keep content fixed during both stationary reading and an active drag gesture

## Testing

- `flutter test test/chat_message_list_scroll_anchor_test.dart test/hooks/use_scroll_tracking_test.dart test/maintain_reading_position_physics_test.dart` (20 tests passed)
- `dart analyze apps/mobile` (no errors or warnings; 45 existing info-level lints remain)