### PR TITLE
fix(codex): reload custom permissions on resume

### DIFF
--- a/apps/mobile/lib/services/chat_message_handler.dart
+++ b/apps/mobile/lib/services/chat_message_handler.dart
@@ -851,6 +851,16 @@ class ChatMessageHandler {
           permissionMode: msg.permissionMode,
           approvalPolicy: msg.approvalPolicy,
         );
+        if (isCodex || msg.provider == Provider.codex.value) {
+          codexApprovalPolicy =
+              codexApprovalPolicyFromRaw(
+                resolveCodexApprovalPolicy(
+                  approvalPolicy: msg.approvalPolicy,
+                  executionMode: msg.executionMode,
+                ),
+              ) ??
+              codexApprovalPolicyFromLegacyExecutionMode(msg.executionMode);
+        }
       }
       if (hasPlanSignals(msg)) {
         planMode = derivePlanMode(

--- a/apps/mobile/test/chat_message_handler_test.dart
+++ b/apps/mobile/test/chat_message_handler_test.dart
@@ -338,6 +338,23 @@ void main() {
   });
 
   group('SystemMessage handling', () {
+    test('Codex init applies approval policy without permission mode', () {
+      final update = handler.handle(
+        const SystemMessage(
+          subtype: 'init',
+          provider: 'codex',
+          approvalPolicy: 'never',
+          codexPermissionsMode: 'custom',
+        ),
+        isBackground: false,
+        isCodex: true,
+      );
+
+      expect(update.codexApprovalPolicy, CodexApprovalPolicy.never);
+      expect(update.codexPermissionsMode, CodexPermissionsMode.custom);
+      expect(update.executionMode, ExecutionMode.fullAccess);
+    });
+
     test('set_permission_mode plan updates inPlanMode', () {
       final update = handler.handle(
         const SystemMessage(

--- a/packages/bridge/src/codex-process.test.ts
+++ b/packages/bridge/src/codex-process.test.ts
@@ -831,6 +831,155 @@ describe("CodexProcess (app-server)", () => {
     proc.stop();
   });
 
+  it("reloads config permissions when resuming a custom thread", async () => {
+    const proc = new CodexProcess("linux");
+    const messages: unknown[] = [];
+    proc.on("message", (msg) => messages.push(msg));
+
+    proc.start("/tmp/project-custom-resume", {
+      threadId: "thr_existing",
+      codexPermissionsMode: "custom",
+    });
+
+    const child = fakeChildren[0];
+    await tick();
+
+    const initReq = nextOutgoingRequest(child);
+    child.stdout.emit(
+      "data",
+      `${JSON.stringify({ id: initReq.id, result: {} })}\n`,
+    );
+
+    await tick();
+    nextOutgoingNotification(child);
+
+    const configReq = nextOutgoingRequest(child);
+    expect(configReq).toMatchObject({
+      method: "config/read",
+      params: {
+        cwd: "/tmp/project-custom-resume",
+        includeLayers: false,
+      },
+    });
+    child.stdout.emit(
+      "data",
+      `${JSON.stringify({
+        id: configReq.id,
+        result: {
+          config: {
+            approval_policy: "never",
+            approvals_reviewer: "user",
+            sandbox_mode: "danger-full-access",
+          },
+        },
+      })}\n`,
+    );
+
+    await tick();
+    const resumeReq = nextOutgoingRequest(child);
+    expect(resumeReq.method).toBe("thread/resume");
+    expect(resumeReq.params).toMatchObject({
+      cwd: "/tmp/project-custom-resume",
+      threadId: "thr_existing",
+      approvalPolicy: "never",
+      approvalsReviewer: "user",
+      sandbox: "danger-full-access",
+    });
+
+    child.stdout.emit(
+      "data",
+      `${JSON.stringify({
+        id: resumeReq.id,
+        result: {
+          thread: { id: "thr_existing" },
+          approvalPolicy: "never",
+          approvalsReviewer: "user",
+          sandbox: { type: "dangerFullAccess" },
+        },
+      })}\n`,
+    );
+    await tick();
+
+    expect(messages).toContainEqual(
+      expect.objectContaining({
+        type: "system",
+        subtype: "init",
+        sessionId: "thr_existing",
+        approvalPolicy: "never",
+        approvalsReviewer: "user",
+        sandboxMode: "danger-full-access",
+        codexPermissionsMode: "custom",
+      }),
+    );
+
+    proc.stop();
+  });
+
+  it("applies selected profile permissions when resuming a custom thread", async () => {
+    const proc = new CodexProcess("linux");
+    proc.start("/tmp/project-profile-resume", {
+      threadId: "thr_profile",
+      codexPermissionsMode: "custom",
+      profile: "unrestricted",
+    });
+
+    const child = fakeChildren[0];
+    await tick();
+
+    const initReq = nextOutgoingRequest(child);
+    child.stdout.emit(
+      "data",
+      `${JSON.stringify({ id: initReq.id, result: {} })}\n`,
+    );
+
+    await tick();
+    nextOutgoingNotification(child);
+
+    const configReq = nextOutgoingRequest(child);
+    expect(configReq.method).toBe("config/read");
+    child.stdout.emit(
+      "data",
+      `${JSON.stringify({
+        id: configReq.id,
+        result: {
+          config: {
+            approval_policy: "on-request",
+            sandbox_mode: "workspace-write",
+            profiles: {
+              unrestricted: {
+                approval_policy: "never",
+                sandbox_mode: "danger-full-access",
+              },
+            },
+          },
+        },
+      })}\n`,
+    );
+
+    await tick();
+    const resumeReq = nextOutgoingRequest(child);
+    expect(resumeReq).toMatchObject({
+      method: "thread/resume",
+      params: {
+        threadId: "thr_profile",
+        approvalPolicy: "never",
+        approvalsReviewer: "user",
+        sandbox: "danger-full-access",
+        config: { profile: "unrestricted" },
+      },
+    });
+
+    child.stdout.emit(
+      "data",
+      `${JSON.stringify({
+        id: resumeReq.id,
+        result: { thread: { id: "thr_profile" } },
+      })}\n`,
+    );
+    await tick();
+    proc.stop();
+  });
+
   it("handles managed app-server spawn errors without crashing", () => {
     process.env.BRIDGE_CODEX_APP_SERVER_MODE = "managed";
     process.env.BRIDGE_CODEX_SHARED_APP_SERVER_URL = "ws://127.0.0.1:18767";

--- a/packages/bridge/src/codex-process.ts
+++ b/packages/bridge/src/codex-process.ts
@@ -245,6 +245,12 @@ interface CodexResolvedSettings {
   webSearchMode?: string;
 }
 
+interface CodexConfigPermissions {
+  approvalPolicy?: NonNullable<CodexStartOptions["approvalPolicy"]>;
+  approvalsReviewer: NonNullable<CodexStartOptions["approvalsReviewer"]>;
+  sandboxMode?: NonNullable<CodexStartOptions["sandboxMode"]>;
+}
+
 export interface CodexProfileConfig {
   profiles: string[];
   defaultProfile?: string;
@@ -1425,13 +1431,22 @@ export class CodexProcess extends EventEmitter<CodexProcessEvents> {
           ? (await this.readConfigRequirements()).autoReviewDisabled
           : options?.autoReviewDisabledByPolicy === true;
       this._autoReviewDisabledByPolicy = autoReviewDisabled;
-      const effectiveApprovalsReviewer = autoReviewDisabled
-        ? "user"
-        : options?.approvalsReviewer;
       const effectiveCodexPermissionsMode =
         autoReviewDisabled && options?.codexPermissionsMode === "autoReview"
           ? "default"
           : options?.codexPermissionsMode;
+      // thread/resume preserves the thread's prior permission overrides when
+      // these fields are omitted. Custom mode means the current config.toml
+      // should win, so resolve it and pass the values explicitly on resume.
+      const customResumePermissions =
+        options?.threadId &&
+        effectiveCodexPermissionsMode === "custom"
+          ? await this.readConfigPermissions(projectPath, options.profile)
+          : undefined;
+      const effectiveApprovalsReviewer = autoReviewDisabled
+        ? "user"
+        : (customResumePermissions?.approvalsReviewer ??
+          options?.approvalsReviewer);
       if (autoReviewDisabled) {
         console.warn(
           "[codex-process] Auto-review disabled by managed Browser Use policy",
@@ -1445,8 +1460,10 @@ export class CodexProcess extends EventEmitter<CodexProcessEvents> {
             );
       this._codexPermissionsMode = effectiveCodexPermissionsMode;
 
-      const requestedApprovalPolicy = options?.approvalPolicy
-        ? normalizeApprovalPolicy(options.approvalPolicy)
+      const configuredApprovalPolicy =
+        customResumePermissions?.approvalPolicy ?? options?.approvalPolicy;
+      const requestedApprovalPolicy = configuredApprovalPolicy
+        ? normalizeApprovalPolicy(configuredApprovalPolicy)
         : undefined;
       const requestedApprovalsReviewer =
         effectiveApprovalsReviewer === undefined
@@ -1456,8 +1473,10 @@ export class CodexProcess extends EventEmitter<CodexProcessEvents> {
             );
       const requestedClientApprovalsReviewer =
         normalizeApprovalsReviewerForClient(effectiveApprovalsReviewer);
-      const requestedSandboxMode = options?.sandboxMode
-        ? normalizeSandboxMode(options.sandboxMode)
+      const configuredSandboxMode =
+        customResumePermissions?.sandboxMode ?? options?.sandboxMode;
+      const requestedSandboxMode = configuredSandboxMode
+        ? normalizeSandboxMode(configuredSandboxMode)
         : undefined;
 
       const threadParams: Record<string, unknown> = {
@@ -1657,6 +1676,17 @@ export class CodexProcess extends EventEmitter<CodexProcessEvents> {
       [...configuredRoots, ...normalizedAdditional],
       this.platform,
     );
+  }
+
+  private async readConfigPermissions(
+    projectPath: string,
+    profile?: string,
+  ): Promise<CodexConfigPermissions> {
+    const response = await this.request("config/read", {
+      includeLayers: false,
+      cwd: projectPath,
+    });
+    return extractPermissionsFromConfigRead(response, profile);
   }
 
   private async initializeRpcConnection(): Promise<void> {
@@ -3435,6 +3465,66 @@ function extractWritableRootsFromConfigRead(response: unknown): string[] {
   return writableRoots.filter(
     (root): root is string => typeof root === "string",
   );
+}
+
+function extractPermissionsFromConfigRead(
+  response: unknown,
+  profile?: string,
+): CodexConfigPermissions {
+  const config = asRecord(asRecord(response)?.config);
+  const profiles = asRecord(config?.profiles);
+  const profileConfig = profile ? asRecord(profiles?.[profile]) : undefined;
+  const configuredValue = (key: string): unknown =>
+    profileConfig?.[key] ?? config?.[key];
+  return {
+    approvalPolicy: parseConfigApprovalPolicy(
+      configuredValue("approval_policy"),
+    ),
+    approvalsReviewer:
+      parseConfigApprovalsReviewer(configuredValue("approvals_reviewer")) ??
+      "user",
+    sandboxMode: parseConfigSandboxMode(configuredValue("sandbox_mode")),
+  };
+}
+
+function parseConfigApprovalPolicy(
+  value: unknown,
+): CodexConfigPermissions["approvalPolicy"] {
+  switch (value) {
+    case "never":
+    case "on-request":
+    case "on-failure":
+    case "untrusted":
+      return value;
+    default:
+      return undefined;
+  }
+}
+
+function parseConfigApprovalsReviewer(
+  value: unknown,
+): CodexConfigPermissions["approvalsReviewer"] | undefined {
+  switch (value) {
+    case "user":
+    case "auto_review":
+    case "guardian_subagent":
+      return value;
+    default:
+      return undefined;
+  }
+}
+
+function parseConfigSandboxMode(
+  value: unknown,
+): CodexConfigPermissions["sandboxMode"] {
+  switch (value) {
+    case "read-only":
+    case "workspace-write":
+    case "danger-full-access":
+      return value;
+    default:
+      return undefined;
+  }
 }
 
 function normalizeWritableRoots(


### PR DESCRIPTION
## Summary

- refresh effective `config.toml` permissions before resuming an existing Codex thread in Custom mode
- pass the resolved approval policy, reviewer, and sandbox explicitly so stale thread-level overrides do not survive a resume
- apply selected Codex profile permission overrides when present
- sync the mobile session state from the resolved init message

## Root cause

Fresh Custom threads already read the current config correctly. Existing threads did not: `thread/resume` preserved the saved thread-level approval policy when CC Pocket omitted permission fields, producing combinations such as Custom + danger-full-access + on-request.

## Verification

- `npm run test --workspace=packages/bridge -- --reporter=dot` (898 tests passed)
- `npx tsc --noEmit -p packages/bridge/tsconfig.json`
- `flutter test test/chat_message_handler_test.dart` (95 tests passed)
- `git diff --check`