### PR TITLE
fix(mobile): clarify active session progress

### DIFF
--- a/apps/mobile/lib/features/chat_session/widgets/chat_input_with_overlays.dart
+++ b/apps/mobile/lib/features/chat_session/widgets/chat_input_with_overlays.dart
@@ -34,6 +34,7 @@ import '../../../widgets/slash_command_sheet.dart'
         fallbackCodexSlashCommands,
         fallbackSlashCommands;
 import '../state/chat_session_cubit.dart';
+import 'session_composer_activity_indicator.dart';
 
 enum _CompletionOverlay { slash, dollar, file }
 
@@ -1026,6 +1027,10 @@ class ChatInputWithOverlays extends HookWidget {
               child: ChatInputBar(
                 inputController: inputController,
                 status: status,
+                activityIndicator: SessionComposerActivityIndicator(
+                  key: const ValueKey('composer_activity_state'),
+                  status: status,
+                ),
                 hasInputText:
                     !inputBlocked &&
                     (hasInputText.value ||

--- a/apps/mobile/lib/features/chat_session/widgets/session_composer_activity_indicator.dart
+++ b/apps/mobile/lib/features/chat_session/widgets/session_composer_activity_indicator.dart
@@ -1,0 +1,148 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../models/messages.dart';
+import '../../../widgets/composer_activity_indicator.dart';
+import '../state/chat_session_cubit.dart';
+import '../state/chat_session_state.dart';
+import '../state/streaming_state.dart';
+import '../state/streaming_state_cubit.dart';
+
+/// Connects composer activity feedback to the current chat session.
+class SessionComposerActivityIndicator extends StatefulWidget {
+  final ProcessStatus status;
+  final DateTime Function()? now;
+
+  const SessionComposerActivityIndicator({
+    super.key,
+    required this.status,
+    @visibleForTesting this.now,
+  });
+
+  @override
+  State<SessionComposerActivityIndicator> createState() =>
+      _SessionComposerActivityIndicatorState();
+}
+
+class _SessionComposerActivityIndicatorState
+    extends State<SessionComposerActivityIndicator> {
+  DateTime? _activeSince;
+  DateTime? _lastActivityAt;
+  var _initialized = false;
+  var _awaitingHistoryBaseline = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_initialized) return;
+    _initialized = true;
+    if (!_isActive(widget.status)) return;
+
+    final entries = context.read<ChatSessionCubit>().state.entries;
+    if (activeTurnStartedAt(entries) == null) {
+      _awaitingHistoryBaseline = true;
+      return;
+    }
+    _applyEntryBaseline(entries);
+  }
+
+  @override
+  void didUpdateWidget(SessionComposerActivityIndicator oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final wasActive = _isActive(oldWidget.status);
+    final isActive = _isActive(widget.status);
+    if (wasActive == isActive) return;
+    if (isActive) {
+      final entries = context.read<ChatSessionCubit>().state.entries;
+      if (activeTurnStartedAt(entries) == null) {
+        _activeSince = null;
+        _lastActivityAt = null;
+        _awaitingHistoryBaseline = true;
+      } else {
+        _applyEntryBaseline(entries);
+        _awaitingHistoryBaseline = false;
+      }
+    } else {
+      _activeSince = null;
+      _lastActivityAt = null;
+      _awaitingHistoryBaseline = false;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MultiBlocListener(
+      listeners: [
+        BlocListener<ChatSessionCubit, ChatSessionState>(
+          listenWhen: (previous, current) =>
+              !listEquals(previous.entries, current.entries),
+          listener: (_, state) => _handleEntriesChanged(state.entries),
+        ),
+        BlocListener<StreamingStateCubit, StreamingState>(
+          listenWhen: (previous, current) =>
+              previous.text != current.text ||
+              previous.thinking != current.thinking ||
+              previous.isStreaming != current.isStreaming,
+          listener: (_, _) => _recordActivity(),
+        ),
+      ],
+      child: ComposerActivityIndicator(
+        // Do not present a restored active status as new work until history or
+        // a live stream establishes when the current turn actually started.
+        status: _activeSince == null ? ProcessStatus.idle : widget.status,
+        startedAt: _activeSince,
+        lastActivityAt: _lastActivityAt,
+        now: widget.now,
+      ),
+    );
+  }
+
+  void _recordActivity() {
+    if (!_isActive(widget.status)) return;
+    setState(() {
+      final now = _now;
+      _activeSince ??= now;
+      _lastActivityAt = now;
+      _awaitingHistoryBaseline = false;
+    });
+  }
+
+  void _handleEntriesChanged(List<ChatEntry> entries) {
+    if (!_isActive(widget.status)) return;
+    if (_awaitingHistoryBaseline) {
+      if (activeTurnStartedAt(entries) != null) {
+        setState(() {
+          _applyEntryBaseline(entries);
+          _awaitingHistoryBaseline = false;
+        });
+      }
+      return;
+    }
+    _recordActivity();
+  }
+
+  void _applyEntryBaseline(List<ChatEntry> entries) {
+    _activeSince = activeTurnStartedAt(entries) ?? _now;
+    final latestEntryAt = entries.lastOrNull?.timestamp;
+    _lastActivityAt =
+        latestEntryAt == null || latestEntryAt.isBefore(_activeSince!)
+        ? _activeSince
+        : latestEntryAt;
+  }
+
+  DateTime get _now => widget.now?.call() ?? DateTime.now();
+}
+
+@visibleForTesting
+DateTime? activeTurnStartedAt(List<ChatEntry> entries) {
+  for (final entry in entries.reversed) {
+    if (entry is UserChatEntry) return entry.timestamp;
+  }
+  return null;
+}
+
+bool _isActive(ProcessStatus status) =>
+    status == ProcessStatus.starting ||
+    status == ProcessStatus.running ||
+    status == ProcessStatus.compacting;

--- a/apps/mobile/lib/widgets/chat_input_bar.dart
+++ b/apps/mobile/lib/widgets/chat_input_bar.dart
@@ -47,6 +47,7 @@ class ChatInputBar extends StatelessWidget {
   final VoidCallback? onClearDiffSelection;
   final VoidCallback? onTapDiffPreview;
   final String? hintText;
+  final Widget? activityIndicator;
 
   /// Callback to paste an image from clipboard (desktop only).
   /// When set, [imagePasteShortcut] attempts image paste.
@@ -93,6 +94,7 @@ class ChatInputBar extends StatelessWidget {
     this.onClearDiffSelection,
     this.onTapDiffPreview,
     this.hintText,
+    this.activityIndicator,
     this.onPasteImage,
     this.onPasteImageFromContextMenu,
     this.hasImageInClipboard,
@@ -131,6 +133,7 @@ class ChatInputBar extends StatelessWidget {
             ),
           if (attachedImages.isNotEmpty)
             _ImagePreview(images: attachedImages, onClearImage: onClearImage),
+          ?activityIndicator,
           _InputTextField(
             controller: inputController,
             status: status,

--- a/apps/mobile/lib/widgets/composer_activity_indicator.dart
+++ b/apps/mobile/lib/widgets/composer_activity_indicator.dart
@@ -1,0 +1,173 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '../l10n/app_localizations.dart';
+import '../models/messages.dart';
+import '../theme/app_theme.dart';
+
+/// Compact, active-only status shown above the chat composer.
+class ComposerActivityIndicator extends StatefulWidget {
+  final ProcessStatus status;
+  final DateTime? startedAt;
+  final DateTime? lastActivityAt;
+  final DateTime Function()? now;
+
+  const ComposerActivityIndicator({
+    super.key,
+    required this.status,
+    this.startedAt,
+    this.lastActivityAt,
+    this.now,
+  });
+
+  @override
+  State<ComposerActivityIndicator> createState() =>
+      _ComposerActivityIndicatorState();
+}
+
+class _ComposerActivityIndicatorState extends State<ComposerActivityIndicator> {
+  Timer? _timer;
+  DateTime? _fallbackStartedAt;
+
+  @override
+  void initState() {
+    super.initState();
+    _syncTimer();
+  }
+
+  @override
+  void didUpdateWidget(ComposerActivityIndicator oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final wasActive = _isActive(oldWidget.status);
+    final isActive = _isActive(widget.status);
+    if (wasActive != isActive) _syncTimer();
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  void _syncTimer() {
+    _timer?.cancel();
+    _timer = null;
+    if (!_isActive(widget.status)) {
+      _fallbackStartedAt = null;
+      return;
+    }
+    _fallbackStartedAt ??= _now;
+    _timer = Timer.periodic(const Duration(seconds: 1), (_) {
+      if (mounted) setState(() {});
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_isActive(widget.status)) return const SizedBox.shrink();
+
+    final appColors = Theme.of(context).extension<AppColors>();
+    final color = switch (widget.status) {
+      ProcessStatus.starting =>
+        appColors?.statusStarting ?? Theme.of(context).colorScheme.primary,
+      ProcessStatus.compacting =>
+        appColors?.statusCompacting ?? Theme.of(context).colorScheme.primary,
+      _ => appColors?.statusRunning ?? Theme.of(context).colorScheme.primary,
+    };
+    final now = _now;
+    final elapsed = now.difference(
+      widget.startedAt ?? _fallbackStartedAt ?? now,
+    );
+    final elapsedLabel = _formatElapsed(elapsed);
+    final lastActivityAt = widget.lastActivityAt;
+    final quietDuration = lastActivityAt == null
+        ? Duration.zero
+        : now.difference(lastActivityAt);
+    final showLastActivity = quietDuration.inMinutes >= 1;
+    final workingLabel = _withoutTrailingEllipsis(
+      AppLocalizations.of(context).working,
+    );
+    final lastActivityLabel = showLastActivity
+        ? AppLocalizations.of(context).minutesAgo(quietDuration.inMinutes)
+        : null;
+
+    return Semantics(
+      key: const ValueKey('composer_activity_indicator'),
+      container: true,
+      excludeSemantics: true,
+      label: [workingLabel, elapsedLabel, ?lastActivityLabel].join(', '),
+      child: Padding(
+        padding: const EdgeInsets.only(left: 8, right: 8, bottom: 6),
+        child: Row(
+          children: [
+            SizedBox(
+              width: 11,
+              height: 11,
+              child: CircularProgressIndicator(
+                strokeWidth: 1.5,
+                color: color,
+                backgroundColor: color.withValues(alpha: 0.16),
+              ),
+            ),
+            const SizedBox(width: 7),
+            Text(
+              workingLabel,
+              style: TextStyle(
+                color: color,
+                fontSize: 11,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            Text(
+              ' · $elapsedLabel',
+              style: TextStyle(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+                fontSize: 11,
+                fontFeatures: const [FontFeature.tabularFigures()],
+              ),
+            ),
+            if (lastActivityLabel != null) ...[
+              const SizedBox(width: 8),
+              Icon(
+                Icons.history_rounded,
+                size: 11,
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+              const SizedBox(width: 3),
+              Text(
+                lastActivityLabel,
+                style: TextStyle(
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  fontSize: 11,
+                  fontFeatures: const [FontFeature.tabularFigures()],
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  DateTime get _now => widget.now?.call() ?? DateTime.now();
+}
+
+bool _isActive(ProcessStatus status) =>
+    status == ProcessStatus.starting ||
+    status == ProcessStatus.running ||
+    status == ProcessStatus.compacting;
+
+String _withoutTrailingEllipsis(String value) =>
+    value.endsWith('...') ? value.substring(0, value.length - 3) : value;
+
+String _formatElapsed(Duration elapsed) {
+  final seconds = elapsed.inSeconds.clamp(0, 359999);
+  if (seconds < 60) return '${seconds}s';
+  final minutes = seconds ~/ 60;
+  final remainingSeconds = (seconds % 60).toString().padLeft(2, '0');
+  if (minutes < 60) return '$minutes:$remainingSeconds';
+  final hours = minutes ~/ 60;
+  final remainingMinutes = (minutes % 60).toString().padLeft(2, '0');
+  return '$hours:$remainingMinutes:$remainingSeconds';
+}

--- a/apps/mobile/test/chat_input_bar_test.dart
+++ b/apps/mobile/test/chat_input_bar_test.dart
@@ -63,6 +63,7 @@ void main() {
     bool supportsShowingSystemContextMenu = false,
     ImagePasteShortcut imagePasteShortcut = ImagePasteShortcut.ctrlV,
     KeyEventResult Function(KeyEvent event)? onCompletionKeyEvent,
+    Widget? activityIndicator,
   }) {
     return MaterialApp(
       localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -76,6 +77,7 @@ void main() {
           body: ChatInputBar(
             inputController: inputController,
             status: status,
+            activityIndicator: activityIndicator,
             hasInputText: hasInputText,
             isInputEmpty: isInputEmpty,
             isVoiceAvailable: isVoiceAvailable,
@@ -122,10 +124,24 @@ void main() {
     });
 
     testWidgets('shows stop button when running and no text', (tester) async {
-      await tester.pumpWidget(buildSubject(status: ProcessStatus.running));
+      await tester.pumpWidget(
+        buildSubject(
+          status: ProcessStatus.running,
+          activityIndicator: const SizedBox(
+            key: ValueKey('test_activity_indicator'),
+          ),
+        ),
+      );
 
       expect(find.byKey(const ValueKey('stop_button')), findsOneWidget);
       expect(find.byKey(const ValueKey('send_button')), findsNothing);
+      final activity = find.byKey(const ValueKey('test_activity_indicator'));
+      final input = find.byKey(const ValueKey('message_input'));
+      expect(activity, findsOneWidget);
+      expect(
+        tester.getBottomLeft(activity).dy,
+        lessThanOrEqualTo(tester.getTopLeft(input).dy),
+      );
     });
 
     testWidgets('shows voice button when idle, no text, and voice available', (

--- a/apps/mobile/test/composer_activity_indicator_test.dart
+++ b/apps/mobile/test/composer_activity_indicator_test.dart
@@ -1,0 +1,111 @@
+import 'package:ccpocket/features/chat_session/widgets/session_composer_activity_indicator.dart';
+import 'package:ccpocket/l10n/app_localizations.dart';
+import 'package:ccpocket/models/messages.dart';
+import 'package:ccpocket/widgets/composer_activity_indicator.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  var now = DateTime(2026, 8, 23, 12);
+  DateTime clock() => now;
+
+  Widget buildSubject(
+    ProcessStatus status, {
+    DateTime? startedAt,
+    DateTime? lastActivityAt,
+  }) {
+    return MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      locale: const Locale('en'),
+      home: Scaffold(
+        body: ComposerActivityIndicator(
+          status: status,
+          startedAt: startedAt,
+          lastActivityAt: lastActivityAt,
+          now: clock,
+        ),
+      ),
+    );
+  }
+
+  setUp(() => now = DateTime(2026, 8, 23, 12));
+
+  testWidgets('shows a compact elapsed indicator while working', (
+    tester,
+  ) async {
+    await tester.pumpWidget(buildSubject(ProcessStatus.running));
+
+    expect(
+      find.byKey(const ValueKey('composer_activity_indicator')),
+      findsOneWidget,
+    );
+    expect(find.text('Working'), findsOneWidget);
+    expect(find.text(' · 0s'), findsOneWidget);
+
+    now = now.add(const Duration(seconds: 65));
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(find.text(' · 1:05'), findsOneWidget);
+  });
+
+  testWidgets('keeps elapsed time across active status transitions', (
+    tester,
+  ) async {
+    await tester.pumpWidget(buildSubject(ProcessStatus.starting));
+    now = now.add(const Duration(seconds: 30));
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pumpWidget(buildSubject(ProcessStatus.compacting));
+    now = now.add(const Duration(seconds: 31));
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(find.text(' · 1:01'), findsOneWidget);
+  });
+
+  testWidgets('is absent when idle or waiting for approval', (tester) async {
+    await tester.pumpWidget(buildSubject(ProcessStatus.idle));
+    expect(
+      find.byKey(const ValueKey('composer_activity_indicator')),
+      findsNothing,
+    );
+
+    await tester.pumpWidget(buildSubject(ProcessStatus.waitingApproval));
+    expect(
+      find.byKey(const ValueKey('composer_activity_indicator')),
+      findsNothing,
+    );
+  });
+
+  testWidgets('shows resumed elapsed time and a quiet-activity hint', (
+    tester,
+  ) async {
+    now = DateTime(2026, 8, 23, 12, 6, 12);
+    await tester.pumpWidget(
+      buildSubject(
+        ProcessStatus.running,
+        startedAt: DateTime(2026, 8, 23, 12),
+        lastActivityAt: DateTime(2026, 8, 23, 12, 4),
+      ),
+    );
+
+    expect(find.text(' · 6:12'), findsOneWidget);
+    expect(find.byIcon(Icons.history_rounded), findsOneWidget);
+    expect(find.text('2m ago'), findsOneWidget);
+    final semantics = tester.widget<Semantics>(
+      find.byKey(const ValueKey('composer_activity_indicator')),
+    );
+    expect(semantics.properties.liveRegion, isNot(true));
+  });
+
+  test('active turn starts at the latest user prompt', () {
+    final first = DateTime(2026, 8, 23, 11);
+    final latest = DateTime(2026, 8, 23, 12);
+    final entries = <ChatEntry>[
+      UserChatEntry('first', timestamp: first),
+      StreamingChatEntry(text: 'response', timestamp: first),
+      UserChatEntry('latest', timestamp: latest),
+    ];
+
+    expect(activeTurnStartedAt(entries), latest);
+  });
+}

--- a/apps/mobile/test/session_composer_activity_indicator_test.dart
+++ b/apps/mobile/test/session_composer_activity_indicator_test.dart
@@ -1,0 +1,103 @@
+import 'dart:async';
+
+import 'package:ccpocket/features/chat_session/state/chat_session_cubit.dart';
+import 'package:ccpocket/features/chat_session/state/streaming_state_cubit.dart';
+import 'package:ccpocket/features/chat_session/widgets/session_composer_activity_indicator.dart';
+import 'package:ccpocket/l10n/app_localizations.dart';
+import 'package:ccpocket/models/messages.dart';
+import 'package:ccpocket/services/bridge_service.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _TestBridgeService extends BridgeService {
+  final _messages = StreamController<(ServerMessage, String?)>.broadcast();
+
+  void emit(ServerMessage message, {required String sessionId}) {
+    _messages.add((message, sessionId));
+  }
+
+  @override
+  Stream<ServerMessage> messagesForSession(String sessionId) => _messages.stream
+      .where((event) => event.$2 == sessionId)
+      .map((event) => event.$1);
+
+  @override
+  void dispose() {
+    _messages.close();
+    super.dispose();
+  }
+}
+
+void main() {
+  testWidgets('rebases elapsed time when history arrives after the screen', (
+    tester,
+  ) async {
+    final now = DateTime.utc(2026, 8, 23, 12, 6, 12);
+    final bridge = _TestBridgeService();
+    final streamingCubit = StreamingStateCubit();
+    final sessionCubit = ChatSessionCubit(
+      sessionId: 'late-history',
+      bridge: bridge,
+      streamingCubit: streamingCubit,
+    );
+    var disposed = false;
+    addTearDown(() async {
+      if (disposed) return;
+      await sessionCubit.close();
+      await streamingCubit.close();
+      bridge.dispose();
+    });
+
+    expect(sessionCubit.state.entries, isEmpty);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        locale: const Locale('en'),
+        home: MultiBlocProvider(
+          providers: [
+            BlocProvider<ChatSessionCubit>.value(value: sessionCubit),
+            BlocProvider<StreamingStateCubit>.value(value: streamingCubit),
+          ],
+          child: Scaffold(
+            body: SessionComposerActivityIndicator(
+              status: ProcessStatus.running,
+              now: () => now,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      find.byKey(const ValueKey('composer_activity_indicator')),
+      findsNothing,
+    );
+
+    bridge.emit(
+      const HistoryMessage(
+        messages: [
+          UserInputMessage(
+            text: 'Continue the work',
+            timestamp: '2026-08-23T12:00:00.000Z',
+          ),
+        ],
+      ),
+      sessionId: 'late-history',
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('Working'), findsOneWidget);
+    expect(find.text(' · 6:12'), findsOneWidget);
+    expect(find.text('6m ago'), findsOneWidget);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await sessionCubit.close();
+    await streamingCubit.close();
+    bridge.dispose();
+    disposed = true;
+  });
+}


### PR DESCRIPTION
## Summary

- add compact activity feedback above the composer with elapsed time
- show the age of the last session activity after a quiet minute
- preserve timing across reconnects and delayed history restoration
- prevent hidden chat events from producing orphan timestamps

## Verification

- targeted Dart analysis passed
- focused widget tests passed
- full Flutter suite passed: 1,538 tests, 4 skipped