### PR TITLE
fix(sessions): preserve active sessions across bridge restarts

### DIFF
--- a/apps/mobile/lib/features/session_list/session_list_screen.dart
+++ b/apps/mobile/lib/features/session_list/session_list_screen.dart
@@ -146,7 +146,7 @@ String buildResumeCommand(RecentSession session) {
   return 'cd ${shellQuote(cwd)} && $resumeCommand';
 }
 
-/// Filter sessions by text query (matches name, firstPrompt, lastPrompt and summary).
+/// Filter sessions by text query across all recent-session preview fields.
 List<RecentSession> filterByQuery(List<RecentSession> sessions, String query) {
   if (query.isEmpty) return sessions;
   final q = query.toLowerCase();
@@ -154,6 +154,7 @@ List<RecentSession> filterByQuery(List<RecentSession> sessions, String query) {
     return (s.name?.toLowerCase().contains(q) ?? false) ||
         s.firstPrompt.toLowerCase().contains(q) ||
         (s.lastPrompt?.toLowerCase().contains(q) ?? false) ||
+        (s.lastResponse?.toLowerCase().contains(q) ?? false) ||
         (s.summary?.toLowerCase().contains(q) ?? false);
   }).toList();
 }

--- a/apps/mobile/lib/features/session_list/widgets/home_content.dart
+++ b/apps/mobile/lib/features/session_list/widgets/home_content.dart
@@ -206,7 +206,7 @@ class HomeContentState extends State<HomeContent> {
   bool _showSupportBanner = false;
   bool _groupRecentSessions = true;
   final _searchController = TextEditingController();
-  SessionDisplayMode _displayMode = SessionDisplayMode.first;
+  SessionDisplayMode _displayMode = SessionDisplayMode.last;
   RevenueCatService? _revenueCatService;
   VoidCallback? _catalogStateListener;
   SupportBannerService? _supportBannerService;
@@ -228,7 +228,7 @@ class HomeContentState extends State<HomeContent> {
       if (modeStr != null) {
         _displayMode = SessionDisplayMode.values.firstWhere(
           (m) => m.name == modeStr,
-          orElse: () => SessionDisplayMode.first,
+          orElse: () => SessionDisplayMode.last,
         );
       }
       _groupRecentSessions = groupRecentSessions;

--- a/apps/mobile/lib/models/messages.dart
+++ b/apps/mobile/lib/models/messages.dart
@@ -3525,6 +3525,7 @@ class RecentSession {
   final String? summary;
   final String firstPrompt;
   final String? lastPrompt;
+  final String? lastResponse;
   final String created;
   final String modified;
   final String gitBranch;
@@ -3555,6 +3556,7 @@ class RecentSession {
     this.summary,
     required this.firstPrompt,
     this.lastPrompt,
+    this.lastResponse,
     required this.created,
     required this.modified,
     required this.gitBranch,
@@ -3607,6 +3609,7 @@ class RecentSession {
       summary: json['summary'] as String?,
       firstPrompt: json['firstPrompt'] as String? ?? '',
       lastPrompt: json['lastPrompt'] as String?,
+      lastResponse: json['lastResponse'] as String?,
       created: json['created'] as String? ?? '',
       modified: json['modified'] as String? ?? '',
       gitBranch: json['gitBranch'] as String? ?? '',
@@ -3669,6 +3672,7 @@ class RecentSession {
       summary: summary,
       firstPrompt: firstPrompt,
       lastPrompt: lastPrompt,
+      lastResponse: lastResponse,
       created: created,
       modified: modified,
       gitBranch: gitBranch,
@@ -3705,6 +3709,7 @@ class RecentSession {
       summary: summary,
       firstPrompt: firstPrompt,
       lastPrompt: lastPrompt,
+      lastResponse: lastResponse,
       created: created,
       modified: modified,
       gitBranch: gitBranch,

--- a/apps/mobile/lib/widgets/session_card.dart
+++ b/apps/mobile/lib/widgets/session_card.dart
@@ -2562,7 +2562,7 @@ class RecentSessionCard extends StatelessWidget {
     this.onLongPress,
     this.onShowActions,
     this.hideProjectBadge = false,
-    this.displayMode = SessionDisplayMode.first,
+    this.displayMode = SessionDisplayMode.last,
     this.draftText,
     this.isProcessing = false,
     this.isSelected = false,
@@ -2825,7 +2825,8 @@ class RecentSessionCard extends StatelessWidget {
             ? session.firstPrompt
             : session.displayText;
       case SessionDisplayMode.last:
-        final text = session.lastPrompt ?? session.firstPrompt;
+        final text =
+            session.lastResponse ?? session.lastPrompt ?? session.firstPrompt;
         raw = text.isNotEmpty ? text : '(no description)';
       case SessionDisplayMode.summary:
         final text = session.summary ?? session.firstPrompt;

--- a/apps/mobile/lib/widgets/session_card.dart
+++ b/apps/mobile/lib/widgets/session_card.dart
@@ -2826,7 +2826,10 @@ class RecentSessionCard extends StatelessWidget {
             : session.displayText;
       case SessionDisplayMode.last:
         final text =
-            session.lastResponse ?? session.lastPrompt ?? session.firstPrompt;
+            session.lastResponse ??
+            session.summary ??
+            session.lastPrompt ??
+            session.firstPrompt;
         raw = text.isNotEmpty ? text : '(no description)';
       case SessionDisplayMode.summary:
         final text = session.summary ?? session.firstPrompt;

--- a/apps/mobile/test/messages_test.dart
+++ b/apps/mobile/test/messages_test.dart
@@ -105,6 +105,7 @@ void main() {
         'projectPath': '/workspace/app',
         'gitBranch': 'main',
         'firstPrompt': 'Continue this task',
+        'lastResponse': 'The task is complete.',
         'created': '2026-07-24T00:00:00Z',
         'modified': '2026-07-24T01:00:00Z',
         'isSidechain': false,
@@ -115,6 +116,7 @@ void main() {
     expect(message.status, SessionLinkResolutionStatus.recent);
     expect(message.recentSession?.sessionId, 'claude-uuid');
     expect(message.recentSession?.projectPath, '/workspace/app');
+    expect(message.recentSession?.lastResponse, 'The task is complete.');
   });
 
   test('parses a scoped session-not-found error', () {

--- a/apps/mobile/test/session_card_test.dart
+++ b/apps/mobile/test/session_card_test.dart
@@ -1378,12 +1378,14 @@ void main() {
       },
     );
 
-    testWidgets('defaults to the last agent response', (tester) async {
+    testWidgets('defaults to the summary response from older bridges', (
+      tester,
+    ) async {
       final session = RecentSession(
         sessionId: 'recent-default-response',
+        summary: 'summary response text',
         firstPrompt: 'first prompt text',
         lastPrompt: 'last prompt text',
-        lastResponse: 'last response text',
         created: DateTime.now().toIso8601String(),
         modified: DateTime.now().toIso8601String(),
         gitBranch: 'main',
@@ -1395,7 +1397,7 @@ void main() {
         _wrap(RecentSessionCard(session: session, onTap: () {})),
       );
 
-      expect(find.text('last response text'), findsOneWidget);
+      expect(find.text('summary response text'), findsOneWidget);
       expect(find.text('first prompt text'), findsNothing);
       expect(find.text('last prompt text'), findsNothing);
     });

--- a/apps/mobile/test/session_card_test.dart
+++ b/apps/mobile/test/session_card_test.dart
@@ -1319,14 +1319,71 @@ void main() {
       );
     });
 
-    testWidgets('uses first, last, and summary fields by display mode', (
-      tester,
-    ) async {
+    testWidgets(
+      'uses first prompt, last response, and summary by display mode',
+      (tester) async {
+        final session = RecentSession(
+          sessionId: 'recent-display-mode',
+          summary: 'summary text',
+          firstPrompt: 'first prompt text',
+          lastPrompt: 'last prompt text',
+          lastResponse: 'last response text',
+          created: DateTime.now().toIso8601String(),
+          modified: DateTime.now().toIso8601String(),
+          gitBranch: 'main',
+          projectPath: '/home/user/my-app',
+          isSidechain: false,
+        );
+
+        await tester.pumpWidget(
+          _wrap(
+            RecentSessionCard(
+              session: session,
+              displayMode: SessionDisplayMode.first,
+              onTap: () {},
+            ),
+          ),
+        );
+        expect(find.text('first prompt text'), findsOneWidget);
+        expect(find.text('last prompt text'), findsNothing);
+        expect(find.text('summary text'), findsNothing);
+
+        await tester.pumpWidget(
+          _wrap(
+            RecentSessionCard(
+              session: session,
+              displayMode: SessionDisplayMode.last,
+              onTap: () {},
+            ),
+          ),
+        );
+        expect(find.text('last response text'), findsOneWidget);
+        expect(find.text('last prompt text'), findsNothing);
+        expect(find.text('first prompt text'), findsNothing);
+        expect(find.text('summary text'), findsNothing);
+
+        await tester.pumpWidget(
+          _wrap(
+            RecentSessionCard(
+              session: session,
+              displayMode: SessionDisplayMode.summary,
+              onTap: () {},
+            ),
+          ),
+        );
+        expect(find.text('summary text'), findsOneWidget);
+        expect(find.text('first prompt text'), findsNothing);
+        expect(find.text('last prompt text'), findsNothing);
+        expect(find.text('last response text'), findsNothing);
+      },
+    );
+
+    testWidgets('defaults to the last agent response', (tester) async {
       final session = RecentSession(
-        sessionId: 'recent-display-mode',
-        summary: 'summary text',
+        sessionId: 'recent-default-response',
         firstPrompt: 'first prompt text',
         lastPrompt: 'last prompt text',
+        lastResponse: 'last response text',
         created: DateTime.now().toIso8601String(),
         modified: DateTime.now().toIso8601String(),
         gitBranch: 'main',
@@ -1335,41 +1392,10 @@ void main() {
       );
 
       await tester.pumpWidget(
-        _wrap(
-          RecentSessionCard(
-            session: session,
-            displayMode: SessionDisplayMode.first,
-            onTap: () {},
-          ),
-        ),
+        _wrap(RecentSessionCard(session: session, onTap: () {})),
       );
-      expect(find.text('first prompt text'), findsOneWidget);
-      expect(find.text('last prompt text'), findsNothing);
-      expect(find.text('summary text'), findsNothing);
 
-      await tester.pumpWidget(
-        _wrap(
-          RecentSessionCard(
-            session: session,
-            displayMode: SessionDisplayMode.last,
-            onTap: () {},
-          ),
-        ),
-      );
-      expect(find.text('last prompt text'), findsOneWidget);
-      expect(find.text('first prompt text'), findsNothing);
-      expect(find.text('summary text'), findsNothing);
-
-      await tester.pumpWidget(
-        _wrap(
-          RecentSessionCard(
-            session: session,
-            displayMode: SessionDisplayMode.summary,
-            onTap: () {},
-          ),
-        ),
-      );
-      expect(find.text('summary text'), findsOneWidget);
+      expect(find.text('last response text'), findsOneWidget);
       expect(find.text('first prompt text'), findsNothing);
       expect(find.text('last prompt text'), findsNothing);
     });

--- a/packages/bridge/src/active-session-store.test.ts
+++ b/packages/bridge/src/active-session-store.test.ts
@@ -1,0 +1,99 @@
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  ActiveSessionStore,
+  type PersistedActiveSession,
+} from "./active-session-store.js";
+
+const temporaryDirectories: string[] = [];
+
+function createStore(): {
+  directory: string;
+  file: string;
+  store: ActiveSessionStore;
+} {
+  const directory = mkdtempSync(join(tmpdir(), "ccpocket-active-sessions-"));
+  temporaryDirectories.push(directory);
+  const file = join(directory, "active-sessions.json");
+  return { directory, file, store: new ActiveSessionStore(file) };
+}
+
+function session(
+  overrides: Partial<PersistedActiveSession> = {},
+): PersistedActiveSession {
+  return {
+    bridgeSessionId: "bridge-1",
+    providerSessionId: "provider-1",
+    provider: "claude",
+    projectPath: "/workspace/project",
+    createdAt: "2026-08-23T10:00:00.000Z",
+    lastActivityAt: "2026-08-23T11:00:00.000Z",
+    lastMessage: "Latest response",
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("ActiveSessionStore", () => {
+  it("persists active session metadata across store instances", () => {
+    const { file, store } = createStore();
+    store.replace([
+      session({
+        permissionMode: "acceptEdits",
+        sandboxEnabled: true,
+        worktreePath: "/workspace/project-worktrees/fix",
+        worktreeBranch: "fix/session-list",
+      }),
+    ]);
+
+    expect(new ActiveSessionStore(file).list()).toEqual([
+      session({
+        permissionMode: "acceptEdits",
+        sandboxEnabled: true,
+        worktreePath: "/workspace/project-worktrees/fix",
+        worktreeBranch: "fix/session-list",
+      }),
+    ]);
+  });
+
+  it("deduplicates a provider session using the latest record", () => {
+    const { file, store } = createStore();
+    store.replace([
+      session({ lastMessage: "Older response" }),
+      session({ bridgeSessionId: "bridge-2", lastMessage: "Latest response" }),
+    ]);
+
+    const parsed = JSON.parse(readFileSync(file, "utf-8")) as {
+      sessions: PersistedActiveSession[];
+    };
+    expect(parsed.sessions).toEqual([
+      session({ bridgeSessionId: "bridge-2", lastMessage: "Latest response" }),
+    ]);
+  });
+
+  it("ignores malformed persisted records", () => {
+    const { file } = createStore();
+    writeFileSync(
+      file,
+      JSON.stringify({
+        version: 1,
+        sessions: [session(), { provider: "claude", projectPath: "/missing-id" }],
+      }),
+      "utf-8",
+    );
+
+    expect(new ActiveSessionStore(file).list()).toEqual([session()]);
+  });
+});

--- a/packages/bridge/src/active-session-store.ts
+++ b/packages/bridge/src/active-session-store.ts
@@ -1,0 +1,124 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { randomUUID } from "node:crypto";
+import { dirname, join } from "node:path";
+import { homedir } from "node:os";
+import type { SessionInfo } from "./session.js";
+
+export interface PersistedActiveSession {
+  bridgeSessionId: string;
+  providerSessionId: string;
+  provider: "claude" | "codex";
+  projectPath: string;
+  name?: string;
+  createdAt: string;
+  lastActivityAt: string;
+  lastMessage: string;
+  worktreePath?: string;
+  worktreeBranch?: string;
+  permissionMode?: string;
+  model?: string;
+  sandboxEnabled?: boolean;
+  planMode?: boolean;
+  codexSettings?: SessionInfo["codexSettings"];
+}
+
+interface ActiveSessionStoreData {
+  version: 1;
+  sessions: PersistedActiveSession[];
+}
+
+const DEFAULT_STORE_FILE = join(
+  homedir(),
+  ".ccpocket",
+  "active-sessions.json",
+);
+
+/**
+ * Persists the provider sessions that the user still considers active.
+ * Bridge-local process IDs are intentionally omitted because they change
+ * whenever the Bridge restarts.
+ */
+export class ActiveSessionStore {
+  private data: ActiveSessionStoreData;
+
+  constructor(private readonly storeFile: string = DEFAULT_STORE_FILE) {
+    this.data = this.load();
+  }
+
+  list(): PersistedActiveSession[] {
+    return this.data.sessions.map((session) => ({
+      ...session,
+      codexSettings: session.codexSettings
+        ? { ...session.codexSettings }
+        : undefined,
+    }));
+  }
+
+  replace(sessions: PersistedActiveSession[]): void {
+    const deduped = new Map<string, PersistedActiveSession>();
+    for (const session of sessions) {
+      deduped.set(
+        `${session.provider}:${session.providerSessionId}`,
+        session,
+      );
+    }
+    const next = { version: 1 as const, sessions: [...deduped.values()] };
+    if (JSON.stringify(next) === JSON.stringify(this.data)) return;
+    this.data = next;
+    this.save();
+  }
+
+  private load(): ActiveSessionStoreData {
+    if (!existsSync(this.storeFile)) return { version: 1, sessions: [] };
+    try {
+      const parsed = JSON.parse(
+        readFileSync(this.storeFile, "utf-8"),
+      ) as Partial<ActiveSessionStoreData>;
+      if (parsed.version !== 1 || !Array.isArray(parsed.sessions)) {
+        return { version: 1, sessions: [] };
+      }
+      return {
+        version: 1,
+        sessions: parsed.sessions.filter(isPersistedActiveSession),
+      };
+    } catch {
+      return { version: 1, sessions: [] };
+    }
+  }
+
+  private save(): void {
+    const storeDir = dirname(this.storeFile);
+    mkdirSync(storeDir, { recursive: true });
+    const temporaryFile = join(
+      storeDir,
+      `active-sessions.${randomUUID()}.tmp`,
+    );
+    writeFileSync(temporaryFile, JSON.stringify(this.data, null, 2), "utf-8");
+    renameSync(temporaryFile, this.storeFile);
+  }
+}
+
+function isPersistedActiveSession(
+  value: unknown,
+): value is PersistedActiveSession {
+  if (!value || typeof value !== "object") return false;
+  const session = value as Partial<PersistedActiveSession>;
+  return (
+    (session.provider === "claude" || session.provider === "codex") &&
+    typeof session.bridgeSessionId === "string" &&
+    session.bridgeSessionId.length > 0 &&
+    typeof session.providerSessionId === "string" &&
+    session.providerSessionId.length > 0 &&
+    typeof session.projectPath === "string" &&
+    session.projectPath.length > 0 &&
+    typeof session.createdAt === "string" &&
+    typeof session.lastActivityAt === "string" &&
+    typeof session.lastMessage === "string"
+  );
+}

--- a/packages/bridge/src/session.ts
+++ b/packages/bridge/src/session.ts
@@ -67,6 +67,8 @@ export interface SessionInfo {
   createdAt: Date;
   lastActivityAt: Date;
   gitBranch: string;
+  /** Last assistant preview restored from the active-session registry. */
+  restoredLastMessage?: string;
   /** If this session uses a worktree, the path to it. */
   worktreePath?: string;
   /** Branch name of the worktree. */
@@ -303,8 +305,12 @@ export class SessionManager {
     worktreeOpts?: WorktreeOptions,
     provider?: Provider,
     codexOptions?: CodexStartOptions,
+    restoredBridgeSessionId?: string,
   ): string {
-    const id = randomUUID().slice(0, 8);
+    const id =
+      restoredBridgeSessionId && !this.sessions.has(restoredBridgeSessionId)
+        ? restoredBridgeSessionId
+        : randomUUID().slice(0, 8);
     const effectiveProvider = provider ?? "claude";
     const proc =
       effectiveProvider === "codex" ? new CodexProcess() : new SdkProcess();
@@ -1276,7 +1282,7 @@ export class SessionManager {
         }
       }
     }
-    return "";
+    return s.restoredLastMessage ?? "";
   }
 
   queueCodexInput(id: string, input: QueuedCodexInput): boolean {

--- a/packages/bridge/src/sessions-index.test.ts
+++ b/packages/bridge/src/sessions-index.test.ts
@@ -325,6 +325,7 @@ describe("scanJsonlDir", () => {
     expect(entry.sessionId).toBe("test-session-1");
     expect(entry.provider).toBe("claude");
     expect(entry.firstPrompt).toBe("hello world");
+    expect(entry.lastResponse).toBe("Hi there!");
     expect(entry.created).toBe("2026-01-01T00:00:00.000Z");
     expect(entry.modified).toBe("2026-01-01T00:00:01.000Z");
     expect(entry.gitBranch).toBe("main");
@@ -933,6 +934,7 @@ describe("codex sessions integration", () => {
     expect(entry?.provider).toBe("codex");
     expect(entry?.projectPath).toBe(mainProjectPath);
     expect(entry?.resumeCwd).toBe(worktreePath);
+    expect(entry?.lastResponse).toBe("worktree response");
 
     const mainFilter = await getAllRecentSessions({
       projectPath: mainProjectPath,
@@ -1243,6 +1245,9 @@ describe("codex sessions integration", () => {
       "thanks, now add a test",
     );
     expect(metadata.get(wantedThreadId)?.summary).toBe("done: fixed the bug");
+    expect(metadata.get(wantedThreadId)?.lastResponse).toBe(
+      "done: fixed the bug",
+    );
   });
 
   it("reads codex history from jsonl", async () => {
@@ -2203,6 +2208,70 @@ describe("claude namedOnly optimization", () => {
     expect(result.sessions).toHaveLength(1);
     expect(result.sessions[0].sessionId).toBe("named-s1");
     expect(result.sessions[0].name).toBe("My named session");
+  });
+
+  it("supplements indexed Claude sessions with the last agent response", async () => {
+    const projectDir = join(tempHome, ".claude", "projects", "-tmp-project-a");
+    mkdirSync(projectDir, { recursive: true });
+    const sessionId = "indexed-last-response";
+    const jsonlPath = join(projectDir, `${sessionId}.jsonl`);
+    writeFileSync(
+      join(projectDir, "sessions-index.json"),
+      JSON.stringify({
+        version: 1,
+        entries: [
+          {
+            sessionId,
+            fullPath: jsonlPath,
+            fileMtime: Date.now(),
+            firstPrompt: "initial request",
+            messageCount: 4,
+            created: "2026-02-13T10:00:00.000Z",
+            modified: "2026-02-13T11:00:00.000Z",
+            gitBranch: "main",
+            projectPath: "/tmp/project-a",
+            isSidechain: false,
+          },
+        ],
+      }),
+    );
+    writeFileSync(
+      jsonlPath,
+      [
+        JSON.stringify({
+          type: "user",
+          message: { role: "user", content: "initial request" },
+          timestamp: "2026-02-13T10:00:00.000Z",
+        }),
+        JSON.stringify({
+          type: "assistant",
+          message: { role: "assistant", content: [{ type: "text", text: "initial response" }] },
+          timestamp: "2026-02-13T10:01:00.000Z",
+        }),
+        JSON.stringify({
+          type: "user",
+          message: { role: "user", content: "follow-up request" },
+          timestamp: "2026-02-13T10:02:00.000Z",
+        }),
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "final agent response" }],
+          },
+          timestamp: "2026-02-13T10:03:00.000Z",
+        }),
+      ].join("\n"),
+    );
+
+    const result = await getAllRecentSessions({
+      provider: "claude",
+      limit: 20,
+    });
+
+    expect(result.sessions).toHaveLength(1);
+    expect(result.sessions[0].lastPrompt).toBe("follow-up request");
+    expect(result.sessions[0].lastResponse).toBe("final agent response");
   });
 
   it("finds an exact Claude session outside the first recent page", async () => {

--- a/packages/bridge/src/sessions-index.ts
+++ b/packages/bridge/src/sessions-index.ts
@@ -16,6 +16,8 @@ export interface SessionIndexEntry {
   summary?: string;
   firstPrompt: string;
   lastPrompt?: string;
+  /** Last assistant response text shown by recent-session cards. */
+  lastResponse?: string;
   created: string;
   modified: string;
   gitBranch: string;
@@ -71,7 +73,7 @@ export interface GetRecentSessionsOptions {
   provider?: "claude" | "codex";
   /** Show only sessions with a non-empty name. */
   namedOnly?: boolean;
-  /** Free-text search across name, firstPrompt, lastPrompt and summary. */
+  /** Free-text search across name and recent-session preview fields. */
   searchQuery?: string;
 }
 
@@ -335,6 +337,18 @@ function extractUserPromptText(entry: Record<string, unknown>): string {
   return "";
 }
 
+/** Extract all text blocks from a Claude assistant entry. */
+function extractAssistantResponseText(entry: Record<string, unknown>): string {
+  const message = entry.message as { content?: unknown } | undefined;
+  if (typeof message?.content === "string") return message.content.trim();
+  if (!Array.isArray(message?.content)) return "";
+  return (message.content as Array<{ type?: unknown; text?: unknown }>)
+    .filter((content) => content.type === "text" && typeof content.text === "string")
+    .map((content) => content.text as string)
+    .join("\n")
+    .trim();
+}
+
 /**
  * Parse head and optional tail text chunks to build a SessionIndexEntry.
  * Uses regex for most fields, JSON.parse only for first/last user lines.
@@ -353,6 +367,7 @@ function parseFromChunks(
 ): ParsedClaudeChunks {
   let firstPrompt = "";
   let lastPrompt = "";
+  let lastResponse = "";
   let created = "";
   let modified = "";
   let gitBranch = "";
@@ -416,20 +431,30 @@ function parseFromChunks(
       if (pmMatch) permissionMode = pmMatch[1];
     }
 
-    if (isUser && !firstPrompt) {
-      // JSON.parse only user lines to extract prompt text, skipping
-      // system-injected messages (e.g. <local-command-caveat>)
+    if (isUser) {
+      // Extract prompt text while skipping system-injected messages (e.g.
+      // <local-command-caveat>). For small files this also captures the last
+      // prompt without a separate tail read.
       try {
         const entry = JSON.parse(line) as Record<string, unknown>;
         const text = extractUserPromptText(entry);
         if (text && !isSystemInjectedText(text)) {
-          if (isAutoRenamePromptText(text)) {
+          if (!firstPrompt && isAutoRenamePromptText(text)) {
             isInternalAutoRename = true;
             break;
           }
-          firstPrompt = text;
-          headFoundFirstPrompt = true;
+          if (!firstPrompt) {
+            firstPrompt = text;
+            headFoundFirstPrompt = true;
+          }
+          lastPrompt = text;
         }
+      } catch { /* skip */ }
+    } else if (isAssistant) {
+      try {
+        const entry = JSON.parse(line) as Record<string, unknown>;
+        const text = extractAssistantResponseText(entry);
+        if (text) lastResponse = text;
       } catch { /* skip */ }
     }
   }
@@ -447,9 +472,11 @@ function parseFromChunks(
   if (tail) {
     const tailLines = tail.split("\n");
 
-    // Find last timestamp and last user prompt from tail (scan in reverse)
+    // Find last timestamp, user prompt, and assistant response from the tail.
     let lastUserLine: string | null = null;
+    let lastAssistantLine: string | null = null;
     let tailCustomTitle = "";
+    let foundTailTimestamp = false;
     for (let i = tailLines.length - 1; i >= 0; i--) {
       const line = tailLines[i];
       if (!line.trim()) continue;
@@ -468,29 +495,18 @@ function parseFromChunks(
       if (!isUser && !isAssistant) continue;
       hasAnyMessage = true;
 
-      // Get the last modified timestamp
-      if (!modified || true) {
-        // Always update modified from tail (tail is later in file)
+      if (!lastUserLine && isUser) lastUserLine = line;
+      if (!lastAssistantLine && isAssistant) lastAssistantLine = line;
+
+      // The first message found in reverse order is the last modified one.
+      if (!foundTailTimestamp) {
         const tsMatch = line.match(RE_TIMESTAMP);
         if (tsMatch) {
           modified = tsMatch[1];
-          // We found the last message — we're done with timestamps
-          if (isUser && !lastUserLine) lastUserLine = line;
-          break;
+          foundTailTimestamp = true;
         }
       }
-    }
-
-    // Also find last user line if not found in reverse timestamp scan
-    if (!lastUserLine) {
-      for (let i = tailLines.length - 1; i >= 0; i--) {
-        const line = tailLines[i];
-        if (!line.trim()) continue;
-        if (RE_TYPE_USER.test(line)) {
-          lastUserLine = line;
-          break;
-        }
-      }
+      if (lastUserLine && lastAssistantLine) break;
     }
 
     // JSON.parse only the last user line for lastPrompt
@@ -499,6 +515,13 @@ function parseFromChunks(
         const entry = JSON.parse(lastUserLine) as Record<string, unknown>;
         const text = extractUserPromptText(entry);
         if (text && !isSystemInjectedText(text)) lastPrompt = text;
+      } catch { /* skip */ }
+    }
+    if (lastAssistantLine) {
+      try {
+        const entry = JSON.parse(lastAssistantLine) as Record<string, unknown>;
+        const text = extractAssistantResponseText(entry);
+        if (text) lastResponse = text;
       } catch { /* skip */ }
     }
 
@@ -547,6 +570,7 @@ function parseFromChunks(
       provider: "claude",
       firstPrompt,
       ...(lastPrompt && lastPrompt !== firstPrompt ? { lastPrompt } : {}),
+      ...(lastResponse ? { lastResponse } : {}),
       ...(customTitle ? { name: customTitle } : {}),
       created,
       modified,
@@ -697,6 +721,9 @@ async function hydrateClaudeIndexedEntry(
     projectPath: base.projectPath || parsed.projectPath,
     isSidechain: base.isSidechain || parsed.isSidechain,
     ...(base.lastPrompt || !parsed.lastPrompt ? {} : { lastPrompt: parsed.lastPrompt }),
+    ...(base.lastResponse || !parsed.lastResponse
+      ? {}
+      : { lastResponse: parsed.lastResponse }),
     ...(base.permissionMode || !parsed.permissionMode ? {} : { permissionMode: parsed.permissionMode }),
   };
 }
@@ -781,36 +808,36 @@ async function extractMissingFieldsStreaming(
 }
 
 /**
- * Maximum bytes to read from file tail when searching for lastPrompt.
+ * Maximum bytes to read from a file tail when searching for recent text.
  * Claude sessions often have large tool-result lines (diffs, etc.) near the
  * end, so 8KB is rarely enough.  We grow the read window in steps up to this
  * cap to balance speed and coverage.
  */
-const LAST_PROMPT_MAX_TAIL = 131072; // 128KB
+const RECENT_TEXT_MAX_TAIL = 131072; // 128KB
 
 /**
- * Fast tail-read to extract the last user prompt from a JSONL file.
- * Starts at TAIL_BYTES and doubles up to LAST_PROMPT_MAX_TAIL until a real
- * user text prompt is found.  No full-file scan is ever performed.
- * Used to supplement sessions-index.json entries that lack lastPrompt.
+ * Fast tail-read to extract the last user prompt and assistant response from
+ * a JSONL file. The read window grows until both are found or the cap is hit.
  */
-async function extractLastPromptFromTail(
+async function extractRecentTextFromTail(
   filePath: string,
-): Promise<string> {
+): Promise<{ lastPrompt: string; lastResponse: string }> {
   let fh;
   try {
     fh = await open(filePath, "r");
   } catch {
-    return "";
+    return { lastPrompt: "", lastResponse: "" };
   }
   try {
     const fileSize = (await fh.stat()).size;
-    if (fileSize === 0) return "";
+    if (fileSize === 0) return { lastPrompt: "", lastResponse: "" };
+    let lastPrompt = "";
+    let lastResponse = "";
 
     // Grow tail window: 8KB → 16KB → 32KB → 64KB → 128KB
     for (
       let tailSize = TAIL_BYTES;
-      tailSize <= LAST_PROMPT_MAX_TAIL;
+      tailSize <= RECENT_TEXT_MAX_TAIL;
       tailSize *= 2
     ) {
       const readSize = Math.min(fileSize, tailSize);
@@ -825,25 +852,37 @@ async function extractLastPromptFromTail(
         if (nl >= 0) raw = raw.slice(nl + 1);
       }
 
-      // Scan in reverse to find the last user line with real text
+      // Scan in reverse to find the latest real user and assistant texts.
       const lines = raw.split("\n");
       for (let i = lines.length - 1; i >= 0; i--) {
         const line = lines[i];
         if (!line.trim()) continue;
-        if (!RE_TYPE_USER.test(line)) continue;
-        try {
-          const entry = JSON.parse(line) as Record<string, unknown>;
-          const text = extractUserPromptText(entry);
-          if (text && !isSystemInjectedText(text)) return text;
-        } catch {
-          // Truncated line — skip
+        if (!lastPrompt && RE_TYPE_USER.test(line)) {
+          try {
+            const entry = JSON.parse(line) as Record<string, unknown>;
+            const text = extractUserPromptText(entry);
+            if (text && !isSystemInjectedText(text)) lastPrompt = text;
+          } catch {
+            // Truncated line — retry with a larger window.
+          }
+        } else if (!lastResponse && RE_TYPE_ASSISTANT.test(line)) {
+          try {
+            const entry = JSON.parse(line) as Record<string, unknown>;
+            const text = extractAssistantResponseText(entry);
+            if (text) lastResponse = text;
+          } catch {
+            // Truncated line — retry with a larger window.
+          }
+        }
+        if (lastPrompt && lastResponse) {
+          return { lastPrompt, lastResponse };
         }
       }
 
       // If we already read the entire file, stop
       if (readSize >= fileSize) break;
     }
-    return "";
+    return { lastPrompt, lastResponse };
   } finally {
     await fh.close();
   }
@@ -1091,7 +1130,8 @@ export async function getAllRecentSessions(
         (e.modified ? 1 : 0) +
         (e.name ? 1 : 0) +
         (e.summary ? 1 : 0) +
-        (e.lastPrompt ? 1 : 0);
+        (e.lastPrompt ? 1 : 0) +
+        (e.lastResponse ? 1 : 0);
       if (score(entry) > score(existing)) {
         seen.set(entry.sessionId, entry);
       }
@@ -1125,7 +1165,7 @@ export async function getAllRecentSessions(
   }
   perfStats.counts.afterNamedOnly = filtered.length;
 
-  // Filter by search query (name, firstPrompt, lastPrompt, summary)
+  // Filter by search query across every visible preview field.
   if (options.searchQuery) {
     const q = options.searchQuery.toLowerCase();
     filtered = filtered.filter(
@@ -1133,6 +1173,7 @@ export async function getAllRecentSessions(
         e.name?.toLowerCase().includes(q) ||
         e.firstPrompt?.toLowerCase().includes(q) ||
         e.lastPrompt?.toLowerCase().includes(q) ||
+        e.lastResponse?.toLowerCase().includes(q) ||
         e.summary?.toLowerCase().includes(q),
     );
   }
@@ -1153,25 +1194,34 @@ export async function getAllRecentSessions(
   perfStats.counts.returned = sliced.length;
   markDuration(durations, "paginate", paginateStartedAt);
 
-  // Supplement missing lastPrompt for Claude sessions (sessions-index.json
-  // doesn't include lastPrompt).  Only the paginated page is processed so at
-  // most `limit` tail reads are needed — lightweight enough to keep inline.
+  // Supplement recent text for Claude sessions. sessions-index.json doesn't
+  // include the last prompt or response, so only the paginated page is read.
   const supplementStartedAt = process.hrtime.bigint();
-  const needLastPrompt = sliced.filter(
-    (e) => e.provider === "claude" && !e.lastPrompt && e.projectPath,
+  const needRecentText = sliced.filter(
+    (e) =>
+      e.provider === "claude" &&
+      (!e.lastPrompt || !e.lastResponse) &&
+      e.projectPath,
   );
-  if (needLastPrompt.length > 0) {
+  if (needRecentText.length > 0) {
     const projectsDir = join(homedir(), ".claude", "projects");
-    await parallelMap(needLastPrompt, PARALLEL_FILE_READ_LIMIT, async (entry) => {
+    await parallelMap(needRecentText, PARALLEL_FILE_READ_LIMIT, async (entry) => {
       const slug = pathToSlug(entry.projectPath);
       const jsonlPath = join(projectsDir, slug, `${entry.sessionId}.jsonl`);
-      const lp = await extractLastPromptFromTail(jsonlPath);
-      if (lp && lp !== entry.firstPrompt) {
-        entry.lastPrompt = lp;
+      const recentText = await extractRecentTextFromTail(jsonlPath);
+      if (
+        !entry.lastPrompt &&
+        recentText.lastPrompt &&
+        recentText.lastPrompt !== entry.firstPrompt
+      ) {
+        entry.lastPrompt = recentText.lastPrompt;
+      }
+      if (!entry.lastResponse && recentText.lastResponse) {
+        entry.lastResponse = recentText.lastResponse;
       }
     });
   }
-  markDuration(durations, "supplementLastPrompt", supplementStartedAt);
+  markDuration(durations, "supplementRecentText", supplementStartedAt);
 
   markDuration(durations, "total", totalStartedAt);
   logRecentSessionsPerf(options, durations, perfStats);
@@ -1201,6 +1251,8 @@ export interface CodexSessionIndexMetadata {
   lastPrompt?: string;
   /** Last assistant message text — the closest thing to a session summary. */
   summary?: string;
+  /** Last assistant response text for the recent-session card. */
+  lastResponse?: string;
 }
 
 interface CodexSessionParseResult {
@@ -1429,6 +1481,7 @@ function parseCodexSessionJsonl(raw: string, fallbackSessionId: string): CodexSe
       ...(agentNickname ? { agentNickname } : {}),
       ...(agentRole ? { agentRole } : {}),
       summary: summary || undefined,
+      lastResponse: lastAssistantText || undefined,
       firstPrompt,
       ...(lastPrompt && lastPrompt !== firstPrompt ? { lastPrompt } : {}),
       created,
@@ -1907,6 +1960,9 @@ export async function getCodexSessionIndexMetadata(
       ...(parsed.entry.firstPrompt ? { firstPrompt: parsed.entry.firstPrompt } : {}),
       ...(parsed.entry.lastPrompt ? { lastPrompt: parsed.entry.lastPrompt } : {}),
       ...(parsed.entry.summary ? { summary: parsed.entry.summary } : {}),
+      ...(parsed.entry.lastResponse
+        ? { lastResponse: parsed.entry.lastResponse }
+        : {}),
     });
   }
 
@@ -3578,10 +3634,10 @@ export async function getCodexSessionHistory(
  */
 export async function findSessionsByClaudeIds(
   ids: Set<string>,
-): Promise<Map<string, Pick<SessionIndexEntry, "summary" | "firstPrompt" | "lastPrompt" | "projectPath">>> {
+): Promise<Map<string, Pick<SessionIndexEntry, "summary" | "firstPrompt" | "lastPrompt" | "lastResponse" | "projectPath">>> {
   if (ids.size === 0) return new Map();
 
-  const result = new Map<string, Pick<SessionIndexEntry, "summary" | "firstPrompt" | "lastPrompt" | "projectPath">>();
+  const result = new Map<string, Pick<SessionIndexEntry, "summary" | "firstPrompt" | "lastPrompt" | "lastResponse" | "projectPath">>();
   const remaining = new Set(ids);
 
   const projectsDir = join(homedir(), ".claude", "projects");
@@ -3621,6 +3677,7 @@ export async function findSessionsByClaudeIds(
         summary: entry.summary as string | undefined,
         firstPrompt: (entry.firstPrompt as string) ?? "",
         lastPrompt: entry.lastPrompt as string | undefined,
+        lastResponse: entry.lastResponse as string | undefined,
         projectPath: normalizeWorktreePath((entry.projectPath as string) ?? ""),
       });
       remaining.delete(sid);

--- a/packages/bridge/src/websocket.test.ts
+++ b/packages/bridge/src/websocket.test.ts
@@ -9,7 +9,7 @@ import {
 } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
-import { resolve } from "node:path";
+import { join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolvePlatformPath } from "./path-utils.js";
 
@@ -109,8 +109,9 @@ vi.mock("./session.js", () => ({
       _worktreeOptions?: unknown,
       provider: "claude" | "codex" = "claude",
       codexOptions?: unknown,
+      restoredBridgeSessionId?: string,
     ): string {
-      const id = `s-${++this.seq}`;
+      const id = restoredBridgeSessionId ?? `s-${++this.seq}`;
       const process = {
         status: "idle",
         isRunning: true,
@@ -201,8 +202,10 @@ vi.mock("./session.js", () => ({
         historyLowWatermark: 1,
         status: "idle",
         provider,
+        name: undefined,
         createdAt: new Date(),
         lastActivityAt: new Date(),
+        restoredLastMessage: undefined,
         process,
       });
       return id;
@@ -346,11 +349,12 @@ vi.mock("./session.js", () => ({
         provider: s.provider,
         projectPath: s.projectPath,
         claudeSessionId: s.claudeSessionId,
+        name: s.name,
         status: s.status,
-        createdAt: "",
-        lastActivityAt: "",
+        createdAt: s.createdAt.toISOString(),
+        lastActivityAt: s.lastActivityAt.toISOString(),
         gitBranch: "",
-        lastMessage: "",
+        lastMessage: s.restoredLastMessage ?? "",
         codexSettings: s.codexSettings,
         queuedInput: s.codexQueuedInput,
       }));
@@ -428,6 +432,7 @@ vi.mock("./session.js", () => ({
 }));
 
 import { BridgeWebSocketServer } from "./websocket.js";
+import { ActiveSessionStore } from "./active-session-store.js";
 import { CodexProcess, CodexRpcError } from "./codex-process.js";
 
 describe("BridgeWebSocketServer resume/get_history flow", () => {
@@ -460,6 +465,54 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     vi.unstubAllEnvs();
     vi.useRealTimers();
     httpServer.close();
+  });
+
+  it("restores active sessions after restart until the user stops them", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "ccpocket-active-restore-"));
+    const projectPath = join(directory, "project");
+    mkdirSync(projectPath, { recursive: true });
+    const storeFile = join(directory, "active-sessions.json");
+    const store = new ActiveSessionStore(storeFile);
+    store.replace([
+      {
+        bridgeSessionId: "bridge-kept",
+        providerSessionId: "claude-kept",
+        provider: "claude",
+        projectPath,
+        name: "Kept conversation",
+        createdAt: "2026-08-23T10:00:00.000Z",
+        lastActivityAt: "2026-08-23T11:00:00.000Z",
+        lastMessage: "Latest agent response",
+        permissionMode: "acceptEdits",
+      },
+    ]);
+
+    try {
+      const bridge = new BridgeWebSocketServer({
+        server: httpServer,
+        allowedDirs: [directory],
+        activeSessionStore: store,
+      });
+      expect((bridge as any).sessionManager.list()).toMatchObject([
+        {
+          id: "bridge-kept",
+          claudeSessionId: "claude-kept",
+          name: "Kept conversation",
+          lastMessage: "Latest agent response",
+        },
+      ]);
+
+      const ws = { readyState: OPEN_STATE, send: vi.fn() } as any;
+      await (bridge as any).handleClientMessage(
+        { type: "stop_session", sessionId: "bridge-kept" },
+        ws,
+      );
+
+      expect(new ActiveSessionStore(storeFile).list()).toEqual([]);
+      bridge.close();
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
   });
 
   it("acknowledges push registration only after relay success", async () => {

--- a/packages/bridge/src/websocket.ts
+++ b/packages/bridge/src/websocket.ts
@@ -64,6 +64,10 @@ import {
 import type { GalleryStore } from "./gallery-store.js";
 import type { ProjectHistory } from "./project-history.js";
 import { ArchiveStore } from "./archive-store.js";
+import {
+  ActiveSessionStore,
+  type PersistedActiveSession,
+} from "./active-session-store.js";
 import { WorktreeStore } from "./worktree-store.js";
 import {
   listWorktrees,
@@ -596,6 +600,11 @@ function normalizeNonNegativeLimit(
     : fallback;
 }
 
+function parsePersistedDate(value: string, fallback: Date): Date {
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? fallback : parsed;
+}
+
 function codexThreadToRecentSession(
   thread: CodexThreadSummary,
   indexed?: CodexSessionIndexMetadata,
@@ -612,6 +621,9 @@ function codexThreadToRecentSession(
     summary: indexed?.summary || thread.preview || undefined,
     firstPrompt: indexed?.firstPrompt || thread.preview || "",
     ...(indexed?.lastPrompt ? { lastPrompt: indexed.lastPrompt } : {}),
+    ...((indexed?.lastResponse || indexed?.summary)
+      ? { lastResponse: indexed?.lastResponse || indexed?.summary }
+      : {}),
     created: threadTimestampToIso(thread.createdAt),
     modified: threadTimestampToIso(thread.updatedAt),
     gitBranch: thread.gitBranch ?? "",
@@ -660,6 +672,7 @@ export interface BridgeServerOptions {
   firebaseAuth?: FirebaseAuthClient;
   promptHistoryBackup?: PromptHistoryBackupStore;
   promptHistoryStore?: PromptHistoryStore;
+  activeSessionStore?: ActiveSessionStore | null;
   platform?: NodeJS.Platform;
   fileListMaxEntries?: number;
   fileListMaxBytes?: number;
@@ -710,6 +723,7 @@ export class BridgeWebSocketServer {
   private debugEvents = new Map<string, DebugTraceEvent[]>();
   private notifiedPermissionToolUses = new Map<string, Set<string>>();
   private archiveStore: ArchiveStore;
+  private activeSessionStore: ActiveSessionStore | null;
   private codexProfiles: string[] = [];
   private defaultCodexProfile: string | undefined;
   private codexAutoReviewDisabled = false;
@@ -771,6 +785,7 @@ export class BridgeWebSocketServer {
       firebaseAuth,
       promptHistoryBackup,
       promptHistoryStore,
+      activeSessionStore,
       platform,
       fileListMaxEntries,
       fileListMaxBytes,
@@ -788,6 +803,12 @@ export class BridgeWebSocketServer {
     this.pushRelay = new PushRelayClient({ firebaseAuth });
     this.promptHistoryBackup = promptHistoryBackup ?? null;
     this.promptHistoryStore = promptHistoryStore ?? null;
+    this.activeSessionStore =
+      activeSessionStore === undefined
+        ? process.env.NODE_ENV === "test"
+          ? null
+          : new ActiveSessionStore()
+        : activeSessionStore;
     this.platform = platform ?? process.platform;
     this.fileListMaxEntries = normalizePositiveLimit(
       fileListMaxEntries,
@@ -854,6 +875,7 @@ export class BridgeWebSocketServer {
       this.worktreeStore,
       () => this.broadcastSessionList(),
     );
+    this.restorePersistedActiveSessions();
 
     this.wss.on("connection", (ws, req) => {
       // API key authentication
@@ -2166,6 +2188,7 @@ export class BridgeWebSocketServer {
     options?: StartOptions & { permissionMode?: ClaudePermissionMode };
     pastMessages?: unknown[];
     worktreeOptions?: WorktreeOptions;
+    restoredBridgeSessionId?: string;
   }): {
     sessionId: string;
     permissionMode: ClaudePermissionMode;
@@ -2180,6 +2203,9 @@ export class BridgeWebSocketServer {
         params.options,
         params.pastMessages,
         params.worktreeOptions,
+        undefined,
+        undefined,
+        params.restoredBridgeSessionId,
       );
       return {
         sessionId,
@@ -2207,6 +2233,9 @@ export class BridgeWebSocketServer {
         fallbackOptions,
         params.pastMessages,
         params.worktreeOptions,
+        undefined,
+        undefined,
+        params.restoredBridgeSessionId,
       );
       return {
         sessionId,
@@ -2218,8 +2247,141 @@ export class BridgeWebSocketServer {
     }
   }
 
+  private restorePersistedActiveSessions(): void {
+    if (!this.activeSessionStore) return;
+    const records = this.activeSessionStore.list();
+    let restoredCount = 0;
+
+    for (const record of records) {
+      const projectPath = resolvePlatformPath(record.projectPath, this.platform);
+      if (!existsSync(projectPath) || !this.isPathAllowed(projectPath)) {
+        console.warn(
+          `[active-sessions] Skipping ${record.providerSessionId}: project path is unavailable or disallowed`,
+        );
+        continue;
+      }
+
+      let worktreeOptions: WorktreeOptions | undefined;
+      if (record.worktreePath) {
+        const worktreePath = resolvePlatformPath(
+          record.worktreePath,
+          this.platform,
+        );
+        if (!existsSync(worktreePath) || !this.isPathAllowed(worktreePath)) {
+          console.warn(
+            `[active-sessions] Skipping ${record.providerSessionId}: worktree path is unavailable or disallowed`,
+          );
+          continue;
+        }
+        worktreeOptions = {
+          existingWorktreePath: worktreePath,
+          worktreeBranch: record.worktreeBranch,
+        };
+      }
+
+      try {
+        const sessionId =
+          record.provider === "claude"
+            ? this.createClaudeSessionWithFallback({
+                projectPath,
+                options: {
+                  sessionId: record.providerSessionId,
+                  continueMode: true,
+                  permissionMode:
+                    record.permissionMode as StartOptions["permissionMode"],
+                  model: record.model,
+                  sandboxEnabled: record.sandboxEnabled,
+                },
+                worktreeOptions,
+                restoredBridgeSessionId: record.bridgeSessionId,
+              }).sessionId
+            : this.sessionManager.create(
+                projectPath,
+                undefined,
+                undefined,
+                worktreeOptions,
+                "codex",
+                this.withCodexAutoReviewPolicy({
+                  ...(record.codexSettings ?? {}),
+                  threadId: record.providerSessionId,
+                  collaborationMode: record.planMode ? "plan" : "default",
+                } as CodexStartOptions),
+                record.bridgeSessionId,
+              );
+        const session = this.sessionManager.get(sessionId);
+        if (!session) continue;
+        session.name = record.name;
+        session.restoredLastMessage = record.lastMessage;
+        session.createdAt = parsePersistedDate(record.createdAt, session.createdAt);
+        session.lastActivityAt = parsePersistedDate(
+          record.lastActivityAt,
+          session.lastActivityAt,
+        );
+        restoredCount += 1;
+      } catch (err) {
+        console.warn(
+          `[active-sessions] Failed to restore ${record.providerSessionId}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+    }
+
+    this.persistActiveSessions();
+    if (restoredCount > 0) {
+      console.log(`[active-sessions] Restored ${restoredCount} session(s)`);
+    }
+  }
+
+  private persistActiveSessions(): void {
+    if (!this.activeSessionStore) return;
+    const records: PersistedActiveSession[] = [];
+    for (const summary of this.sessionManager.list()) {
+      if (!summary.claudeSessionId) continue;
+      records.push({
+        bridgeSessionId: summary.id,
+        providerSessionId: summary.claudeSessionId,
+        provider: summary.provider,
+        projectPath: summary.projectPath,
+        ...(summary.name ? { name: summary.name } : {}),
+        createdAt: summary.createdAt,
+        lastActivityAt: summary.lastActivityAt,
+        lastMessage: summary.lastMessage,
+        ...(summary.worktreePath
+          ? { worktreePath: summary.worktreePath }
+          : {}),
+        ...(summary.worktreeBranch
+          ? { worktreeBranch: summary.worktreeBranch }
+          : {}),
+        ...(summary.permissionMode
+          ? { permissionMode: summary.permissionMode }
+          : {}),
+        ...(summary.model ? { model: summary.model } : {}),
+        ...(summary.sandboxEnabled !== undefined
+          ? { sandboxEnabled: summary.sandboxEnabled }
+          : {}),
+        ...(summary.planMode !== undefined
+          ? { planMode: summary.planMode }
+          : {}),
+        ...(summary.codexSettings
+          ? {
+              codexSettings: {
+                ...summary.codexSettings,
+                additionalWritableRoots:
+                  summary.codexSettings.additionalWritableRoots == null
+                    ? undefined
+                    : [...summary.codexSettings.additionalWritableRoots],
+              },
+            }
+          : {}),
+      });
+    }
+    this.activeSessionStore.replace(records);
+  }
+
   close(): void {
     console.log("[ws] Shutting down...");
+    this.persistActiveSessions();
     for (const operation of this.resumeOperations.values()) {
       if (operation.timeout) clearTimeout(operation.timeout);
     }
@@ -6982,6 +7144,7 @@ export class BridgeWebSocketServer {
   /** Broadcast session list to all connected clients. */
   private broadcastSessionList(): void {
     this.pruneDebugEvents();
+    this.persistActiveSessions();
     const sessions = this.sessionManager.list();
     this.broadcast({
       type: "session_list",
@@ -7021,6 +7184,9 @@ export class BridgeWebSocketServer {
     msg: ServerMessage,
     exclude?: WebSocket,
   ): void {
+    if (msg.type === "assistant") {
+      this.persistActiveSessions();
+    }
     if (this.shouldBatchDelta(msg, exclude)) {
       this.trackSessionMessage(sessionId, msg);
       const chunks = this.splitDeltaText(msg.text);


### PR DESCRIPTION
## Summary

- show the last agent response by default on recent-session cards
- remain compatible with released Bridges by using their existing summary when `lastResponse` is unavailable
- index the latest Claude and Codex agent response for recent sessions
- restore active sessions after Bridge restarts until the user explicitly stops them

## Verification

- TypeScript type-check
- 223 Bridge tests
- full Flutter suite: 1,529 passed, 4 skipped
- focused session-card suite: 44 passed
- Dart analysis (no warnings or errors)
- formatting and diff whitespace checks
