### PR TITLE
fix(bridge): derive session titles from user text

### DIFF
--- a/packages/bridge/src/auto-rename.test.ts
+++ b/packages/bridge/src/auto-rename.test.ts
@@ -54,7 +54,7 @@ describe("auto rename", () => {
     );
   });
 
-  it("builds transcript from first real user input and assistant text", () => {
+  it("builds transcript from the first user input only", () => {
     const history = [
       { type: "status", status: "running" },
       {
@@ -64,7 +64,7 @@ describe("auto rename", () => {
       },
       {
         type: "user_input",
-        text: "未プッシュ差分をレビューして",
+        text: "Fix Android push notifications",
         timestamp: "2026-05-01T00:00:00.000Z",
       },
       {
@@ -73,7 +73,7 @@ describe("auto rename", () => {
           role: "assistant",
           content: [
             { type: "tool_use", id: "t1", name: "Read", input: {} },
-            { type: "text", text: "差分を確認してレビューします。" },
+            { type: "text", text: "SSHログインに失敗しました。" },
           ],
         },
       },
@@ -87,12 +87,13 @@ describe("auto rename", () => {
     const transcript = buildAutoRenameTranscript(history);
 
     expect(transcript).toEqual({
-      userText: "未プッシュ差分をレビューして",
-      assistantText: "差分を確認してレビューします。",
+      userText: "Fix Android push notifications",
     });
     const prompt = buildAutoRenamePrompt(transcript!);
     expect(prompt).toContain("Never translate it");
     expect(prompt).toContain("natural, specific noun phrase");
+    expect(prompt).toContain("Use only the USER text");
+    expect(prompt).not.toContain("SSHログインに失敗しました");
     expect(prompt).not.toContain("secret tool output");
     expect(prompt).not.toContain("tool_use");
     expect(prompt).not.toContain("second turn should be ignored");
@@ -123,7 +124,6 @@ describe("auto rename", () => {
       model: "claude-haiku-4-6",
       transcript: {
         userText: "依存関係を更新して",
-        assistantText: "pubspecを確認します。",
       },
     });
 
@@ -134,7 +134,7 @@ describe("auto rename", () => {
         "-p",
         "--model",
         "claude-haiku-4-6",
-        expect.stringContaining("Use assistant text only to disambiguate"),
+        expect.stringContaining("Use only the USER text"),
       ],
       expect.objectContaining({
         cwd: resolve("/tmp/project"),
@@ -154,7 +154,6 @@ describe("auto rename", () => {
       model: "gpt-5.5",
       transcript: {
         userText: "Claude Agent SDKを更新して",
-        assistantText: "現在のSDKバージョンを確認します。",
       },
     });
 
@@ -178,7 +177,7 @@ describe("auto rename", () => {
       }),
     );
     expect(execFileSyncMock.mock.calls[0][2].input).toContain(
-      "Use assistant text only to disambiguate",
+      "Use only the USER text",
     );
     expect(readFileSyncMock).toHaveBeenCalledWith(
       "/tmp/ccpocket-auto-rename-1/session-name.txt",

--- a/packages/bridge/src/auto-rename.ts
+++ b/packages/bridge/src/auto-rename.ts
@@ -18,7 +18,7 @@ Rules:
 - Match the primary language of the USER text. Never translate it. If USER is Japanese, the name must be Japanese.
 - Write a natural, specific noun phrase rather than a sentence or a list of keywords.
 - Prefer the user's intended outcome over implementation details.
-- Use assistant text only to disambiguate the goal or target area.
+- Use only the USER text to choose the name's language and subject.
 - Keep it short: 2-8 English words or about 6-20 Japanese/Chinese/Korean characters when practical.
 - For Japanese, use particles such as の when they improve readability; avoid unnatural keyword concatenation.
 - Preserve meaningful product, library, and feature names.
@@ -31,12 +31,10 @@ Rules:
 - Output only the name. No quotes, JSON, markdown, or explanation.`;
 
 const MAX_TRANSCRIPT_CHARS = 2400;
-const MAX_ASSISTANT_CHARS = 1200;
 const MAX_NAME_CHARS = 60;
 
 export interface AutoRenameTranscript {
   userText: string;
-  assistantText?: string;
 }
 
 export interface AutoRenameOptions {
@@ -55,33 +53,15 @@ export function buildAutoRenameTranscript(
     .find(Boolean);
   if (!userText) return null;
 
-  const assistantText = history
-    .filter((msg) => msg.type === "assistant")
-    .map((msg) =>
-      msg.message.content
-        .filter((content) => content.type === "text")
-        .map((content) => ("text" in content ? content.text : ""))
-        .join("\n")
-        .trim(),
-    )
-    .find(Boolean);
-
   return {
     userText: limitText(userText, MAX_TRANSCRIPT_CHARS),
-    ...(assistantText
-      ? { assistantText: limitText(assistantText, MAX_ASSISTANT_CHARS) }
-      : {}),
   };
 }
 
 export function buildAutoRenamePrompt(
   transcript: AutoRenameTranscript,
 ): string {
-  const sections = [`USER:\n${transcript.userText}`];
-  if (transcript.assistantText) {
-    sections.push(`ASSISTANT:\n${transcript.assistantText}`);
-  }
-  return `${AUTO_RENAME_PROMPT}\n\nTranscript:\n${sections.join("\n\n")}`;
+  return `${AUTO_RENAME_PROMPT}\n\nUSER:\n${transcript.userText}`;
 }
 
 export function isAutoRenamePromptText(text: string): boolean {


### PR DESCRIPTION
## Summary

- derive automatic session titles from the first user message only
- prevent assistant and error output from changing the title language
- add a regression test for an English request followed by a Japanese SSH error

Existing saved titles are unchanged and remain manually editable.

## Testing

- Bridge tests: 915 passed
- TypeScript: npx tsc --noEmit -p packages/bridge/tsconfig.json