### PR TITLE
fix: restore long-running sessions reliably

### DIFF
--- a/apps/mobile/lib/features/chat_session/state/chat_session_cubit.dart
+++ b/apps/mobile/lib/features/chat_session/state/chat_session_cubit.dart
@@ -157,6 +157,7 @@ class ChatSessionCubit extends Cubit<ChatSessionState> {
                .take(10)
                .toList(),
            projectPath: initialProjectPath,
+           bulkLoading: true,
          ),
        ) {
     _respondedToolUseIds.addAll(_bridge.respondedToolUseIds(sessionId));
@@ -184,7 +185,7 @@ class ChatSessionCubit extends Cubit<ChatSessionState> {
 
   void _startStatusRefreshTimer() {
     _statusRefreshTimer = Timer.periodic(const Duration(seconds: 3), (_) {
-      if (state.status != ProcessStatus.starting) {
+      if (state.status != ProcessStatus.starting && !state.bulkLoading) {
         _statusRefreshTimer?.cancel();
         _statusRefreshTimer = null;
         return;
@@ -208,7 +209,7 @@ class ChatSessionCubit extends Cubit<ChatSessionState> {
         isCodex: isCodex,
         ignoredToolUseIds: _respondedToolUseIds,
       );
-      _applyUpdate(update, history);
+      _applyUpdate(update, history, isCachedRestore: true);
     } catch (e, st) {
       logger.error(
         '[session:$sessionId] Failed to restore cached runtime messages',
@@ -241,7 +242,7 @@ class ChatSessionCubit extends Cubit<ChatSessionState> {
       if (_isSessionNotFound(msg)) {
         _statusRefreshTimer?.cancel();
         _statusRefreshTimer = null;
-        emit(state.copyWith(sessionUnavailable: true));
+        emit(state.copyWith(sessionUnavailable: true, bulkLoading: false));
         return;
       }
     }
@@ -287,7 +288,11 @@ class ChatSessionCubit extends Cubit<ChatSessionState> {
     }
   }
 
-  void _applyUpdate(ChatStateUpdate update, ServerMessage originalMsg) {
+  void _applyUpdate(
+    ChatStateUpdate update,
+    ServerMessage originalMsg, {
+    bool isCachedRestore = false,
+  }) {
     final current = state;
 
     // --- Streaming state (separate cubit) ---
@@ -563,7 +568,9 @@ class ChatSessionCubit extends Cubit<ChatSessionState> {
     }
 
     // Stop status refresh timer when status changes from starting
-    if (update.status != null && update.status != ProcessStatus.starting) {
+    if (!isCachedRestore &&
+        update.status != null &&
+        update.status != ProcessStatus.starting) {
       _statusRefreshTimer?.cancel();
       _statusRefreshTimer = null;
     }
@@ -571,6 +578,9 @@ class ChatSessionCubit extends Cubit<ChatSessionState> {
     // --- Update hidden tool use IDs (for subagent summary compression) ---
     var hiddenToolUseIds = current.hiddenToolUseIds;
     if (update.replaceEntries) {
+      // A history snapshot is authoritative. Rebuild the derived hidden IDs
+      // from the final merged entries so restored summaries hide their tool
+      // results and rewinds do not leave stale IDs behind.
       hiddenToolUseIds = _hiddenToolUseIdsFromEntries(entries);
     } else if (update.toolUseIdsToHide.isNotEmpty) {
       hiddenToolUseIds = {...hiddenToolUseIds, ...update.toolUseIdsToHide};
@@ -685,6 +695,12 @@ class ChatSessionCubit extends Cubit<ChatSessionState> {
         status: update.status ?? current.status,
         entries: nextEntries,
         approval: approval,
+        // The Bridge sends the authoritative status after restored history.
+        // Until then, the state's default `starting` value only means that
+        // the screen is waiting for its session baseline.
+        bulkLoading: isCachedRestore || update.status == null
+            ? current.bulkLoading
+            : false,
         totalCost: usage.totalCost,
         totalDuration: usage.totalDuration,
         inPlanMode: update.inPlanMode ?? current.inPlanMode,

--- a/apps/mobile/lib/features/chat_session/widgets/chat_input_with_overlays.dart
+++ b/apps/mobile/lib/features/chat_session/widgets/chat_input_with_overlays.dart
@@ -33,6 +33,7 @@ import '../../../widgets/slash_command_sheet.dart'
         fallbackCodexSlashCommands,
         fallbackSlashCommands;
 import '../state/chat_session_cubit.dart';
+import 'session_composer_activity_indicator.dart';
 
 enum _CompletionOverlay { slash, dollar, file }
 
@@ -1018,6 +1019,10 @@ class ChatInputWithOverlays extends HookWidget {
               child: ChatInputBar(
                 inputController: inputController,
                 status: status,
+                activityIndicator: SessionComposerActivityIndicator(
+                  key: const ValueKey('composer_activity_state'),
+                  status: status,
+                ),
                 hasInputText:
                     !inputBlocked &&
                     (hasInputText.value ||

--- a/apps/mobile/lib/features/chat_session/widgets/chat_message_list.dart
+++ b/apps/mobile/lib/features/chat_session/widgets/chat_message_list.dart
@@ -141,6 +141,31 @@ Set<int> successResultFallbackEntryIndices(List<ChatEntry> entries) {
   return fallbackIndices;
 }
 
+@visibleForTesting
+({List<ChatEntry?> previousEntries, ChatEntry? lastVisibleEntry})
+deriveVisibleChatSequence(
+  List<ChatEntry> entries, {
+  Set<String> hiddenToolUseIds = const {},
+  Set<int> externallyHiddenIndices = const {},
+  Set<int> externallyVisibleIndices = const {},
+}) {
+  final previousEntries = List<ChatEntry?>.filled(entries.length, null);
+  ChatEntry? previousVisibleEntry;
+  for (var index = 0; index < entries.length; index++) {
+    previousEntries[index] = previousVisibleEntry;
+    if (externallyHiddenIndices.contains(index)) continue;
+    final entry = entries[index];
+    if (externallyVisibleIndices.contains(index) ||
+        chatEntryHasVisibleContent(entry, hiddenToolUseIds: hiddenToolUseIds)) {
+      previousVisibleEntry = entry;
+    }
+  }
+  return (
+    previousEntries: previousEntries,
+    lastVisibleEntry: previousVisibleEntry,
+  );
+}
+
 /// Displays the chat message list with [ListView.builder] (reverse: true).
 ///
 /// Reads entries directly from [ChatSessionCubit] state (SSOT).
@@ -201,6 +226,7 @@ class _ChatMessageListState extends State<ChatMessageList> {
   String? _derivedForHttpBaseUrl;
   ProcessStatus? _derivedForProcessStatus;
   String? _derivedForActivePermissionId;
+  Set<String>? _derivedForHiddenToolUseIds;
   _ChatListDerivedData? _derivedData;
   _VisibleAnchor? _pendingAnchor;
   bool _anchorCorrectionScheduled = false;
@@ -545,7 +571,7 @@ class _ChatMessageListState extends State<ChatMessageList> {
                       }
                       return ChatEntryWidget(
                         entry: StreamingChatEntry(text: streamingState.text),
-                        previous: null,
+                        previous: derivedData.lastVisibleEntry,
                         httpBaseUrl: widget.httpBaseUrl,
                         onRetryMessage: null,
                         collapseToolResults: null,
@@ -557,9 +583,7 @@ class _ChatMessageListState extends State<ChatMessageList> {
                 }
 
                 final entry = allEntries[entryIndex];
-                final previous = entryIndex > 0
-                    ? allEntries[entryIndex - 1]
-                    : null;
+                final previous = derivedData.previousVisibleEntries[entryIndex];
                 final onForkMessage =
                     widget.isCodex &&
                         derivedData.forkableAssistantEntryIndices.contains(
@@ -675,7 +699,8 @@ class _ChatMessageListState extends State<ChatMessageList> {
       if (previousEntries != null &&
           listEquals(previousEntries, entries) &&
           _derivedForProcessStatus == chatState.status &&
-          _derivedForActivePermissionId == activePermissionId) {
+          _derivedForActivePermissionId == activePermissionId &&
+          setEquals(_derivedForHiddenToolUseIds, chatState.hiddenToolUseIds)) {
         _derivedForState = chatState;
         return cached;
       }
@@ -694,21 +719,47 @@ class _ChatMessageListState extends State<ChatMessageList> {
       imageItemsByAnchor[group.anchorEntryIndex] = items;
       imageGroupMemberIndices.addAll(group.memberEntryIndices);
     }
+    final completedImageToolUseIds = completedGeneratedImageToolUseIds(entries);
+    final permissionTranscriptStatuses = derivePermissionTranscriptStatuses(
+      entries,
+      processStatus: chatState.status,
+      activeToolUseId: activePermissionId,
+    );
+    final externallyHiddenIndices = <int>{};
+    for (var index = 0; index < entries.length; index++) {
+      if (imageGroupMemberIndices.contains(index) &&
+          !imageItemsByAnchor.containsKey(index)) {
+        externallyHiddenIndices.add(index);
+        continue;
+      }
+      final entry = entries[index];
+      if (entry case ServerChatEntry(message: final ToolResultMessage result)) {
+        if (permissionTranscriptStatuses.containsKey(result.toolUseId) &&
+            isSyntheticPermissionOutcome(result)) {
+          externallyHiddenIndices.add(index);
+        }
+      }
+    }
+    final visibleSequence = deriveVisibleChatSequence(
+      entries,
+      hiddenToolUseIds: {
+        ...chatState.hiddenToolUseIds,
+        ...completedImageToolUseIds,
+      },
+      externallyHiddenIndices: externallyHiddenIndices,
+      externallyVisibleIndices: imageItemsByAnchor.keys.toSet(),
+    );
     final next = _ChatListDerivedData(
       imageGroupMemberIndices: imageGroupMemberIndices,
       imageItemsByAnchor: imageItemsByAnchor,
-      completedGeneratedImageToolUseIds: completedGeneratedImageToolUseIds(
-        entries,
-      ),
+      completedGeneratedImageToolUseIds: completedImageToolUseIds,
+      previousVisibleEntries: visibleSequence.previousEntries,
+      lastVisibleEntry: visibleSequence.lastVisibleEntry,
       forkableAssistantEntryIndices: forkableAssistantEntryIndices(entries),
       successResultFallbackEntryIndices: successResultFallbackEntryIndices(
         entries,
       ),
-      permissionTranscriptStatuses: derivePermissionTranscriptStatuses(
-        entries,
-        processStatus: chatState.status,
-        activeToolUseId: activePermissionId,
-      ),
+      permissionTranscriptStatuses: permissionTranscriptStatuses,
       latestPlanText: _findPlanFromWriteTool(entries),
     );
     _derivedForState = chatState;
@@ -716,6 +767,7 @@ class _ChatMessageListState extends State<ChatMessageList> {
     _derivedForHttpBaseUrl = widget.httpBaseUrl;
     _derivedForProcessStatus = chatState.status;
     _derivedForActivePermissionId = activePermissionId;
+    _derivedForHiddenToolUseIds = Set.of(chatState.hiddenToolUseIds);
     _derivedData = next;
     stopwatch?.stop();
     if (stopwatch != null) {
@@ -834,6 +886,8 @@ class _ChatListDerivedData {
   final Set<int> imageGroupMemberIndices;
   final Map<int, List<GeneratedImagePreviewItem>> imageItemsByAnchor;
   final Set<String> completedGeneratedImageToolUseIds;
+  final List<ChatEntry?> previousVisibleEntries;
+  final ChatEntry? lastVisibleEntry;
   final Set<int> forkableAssistantEntryIndices;
   final Set<int> successResultFallbackEntryIndices;
   final Map<String, PermissionTranscriptStatus> permissionTranscriptStatuses;
@@ -843,6 +897,8 @@ class _ChatListDerivedData {
     required this.imageGroupMemberIndices,
     required this.imageItemsByAnchor,
     required this.completedGeneratedImageToolUseIds,
+    required this.previousVisibleEntries,
+    required this.lastVisibleEntry,
     required this.forkableAssistantEntryIndices,
     required this.successResultFallbackEntryIndices,
     required this.permissionTranscriptStatuses,

--- a/apps/mobile/lib/features/chat_session/widgets/session_composer_activity_indicator.dart
+++ b/apps/mobile/lib/features/chat_session/widgets/session_composer_activity_indicator.dart
@@ -1,0 +1,148 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../models/messages.dart';
+import '../../../widgets/composer_activity_indicator.dart';
+import '../state/chat_session_cubit.dart';
+import '../state/chat_session_state.dart';
+import '../state/streaming_state.dart';
+import '../state/streaming_state_cubit.dart';
+
+/// Connects composer activity feedback to the current chat session.
+class SessionComposerActivityIndicator extends StatefulWidget {
+  final ProcessStatus status;
+  final DateTime Function()? now;
+
+  const SessionComposerActivityIndicator({
+    super.key,
+    required this.status,
+    @visibleForTesting this.now,
+  });
+
+  @override
+  State<SessionComposerActivityIndicator> createState() =>
+      _SessionComposerActivityIndicatorState();
+}
+
+class _SessionComposerActivityIndicatorState
+    extends State<SessionComposerActivityIndicator> {
+  DateTime? _activeSince;
+  DateTime? _lastActivityAt;
+  var _initialized = false;
+  var _awaitingHistoryBaseline = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_initialized) return;
+    _initialized = true;
+    if (!_isActive(widget.status)) return;
+
+    final entries = context.read<ChatSessionCubit>().state.entries;
+    if (activeTurnStartedAt(entries) == null) {
+      _awaitingHistoryBaseline = true;
+      return;
+    }
+    _applyEntryBaseline(entries);
+  }
+
+  @override
+  void didUpdateWidget(SessionComposerActivityIndicator oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final wasActive = _isActive(oldWidget.status);
+    final isActive = _isActive(widget.status);
+    if (wasActive == isActive) return;
+    if (isActive) {
+      _activeSince = _now;
+      _lastActivityAt = _activeSince;
+      _awaitingHistoryBaseline = false;
+    } else {
+      _activeSince = null;
+      _lastActivityAt = null;
+      _awaitingHistoryBaseline = false;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isLoadingSession = context.select<ChatSessionCubit, bool>(
+      (cubit) => cubit.state.bulkLoading,
+    );
+    return MultiBlocListener(
+      listeners: [
+        BlocListener<ChatSessionCubit, ChatSessionState>(
+          listenWhen: (previous, current) =>
+              !listEquals(previous.entries, current.entries),
+          listener: (_, state) => _handleEntriesChanged(state.entries),
+        ),
+        BlocListener<StreamingStateCubit, StreamingState>(
+          listenWhen: (previous, current) =>
+              previous.text != current.text ||
+              previous.thinking != current.thinking ||
+              previous.isStreaming != current.isStreaming,
+          listener: (_, _) => _recordActivity(),
+        ),
+      ],
+      child: ComposerActivityIndicator(
+        // A newly opened session starts in ProcessStatus.starting while its
+        // history is still loading. Do not present that placeholder state as
+        // active agent work until a turn or stream confirms activity.
+        status: isLoadingSession || _activeSince == null
+            ? ProcessStatus.idle
+            : widget.status,
+        startedAt: _activeSince,
+        lastActivityAt: _lastActivityAt,
+        now: widget.now,
+      ),
+    );
+  }
+
+  void _recordActivity() {
+    if (!_isActive(widget.status)) return;
+    setState(() {
+      final now = _now;
+      _activeSince ??= now;
+      _lastActivityAt = now;
+      _awaitingHistoryBaseline = false;
+    });
+  }
+
+  void _handleEntriesChanged(List<ChatEntry> entries) {
+    if (!_isActive(widget.status)) return;
+    if (_awaitingHistoryBaseline) {
+      if (activeTurnStartedAt(entries) != null) {
+        setState(() {
+          _applyEntryBaseline(entries);
+          _awaitingHistoryBaseline = false;
+        });
+      }
+      return;
+    }
+    _recordActivity();
+  }
+
+  void _applyEntryBaseline(List<ChatEntry> entries) {
+    _activeSince = activeTurnStartedAt(entries) ?? _now;
+    final latestEntryAt = entries.lastOrNull?.timestamp;
+    _lastActivityAt =
+        latestEntryAt == null || latestEntryAt.isBefore(_activeSince!)
+        ? _activeSince
+        : latestEntryAt;
+  }
+
+  DateTime get _now => widget.now?.call() ?? DateTime.now();
+}
+
+@visibleForTesting
+DateTime? activeTurnStartedAt(List<ChatEntry> entries) {
+  for (final entry in entries.reversed) {
+    if (entry is UserChatEntry) return entry.timestamp;
+  }
+  return null;
+}
+
+bool _isActive(ProcessStatus status) =>
+    status == ProcessStatus.starting ||
+    status == ProcessStatus.running ||
+    status == ProcessStatus.compacting;

--- a/apps/mobile/lib/features/session_list/session_list_screen.dart
+++ b/apps/mobile/lib/features/session_list/session_list_screen.dart
@@ -146,7 +146,7 @@ String buildResumeCommand(RecentSession session) {
   return 'cd ${shellQuote(cwd)} && $resumeCommand';
 }
 
-/// Filter sessions by text query (matches name, firstPrompt, lastPrompt and summary).
+/// Filter sessions by text query across all recent-session preview fields.
 List<RecentSession> filterByQuery(List<RecentSession> sessions, String query) {
   if (query.isEmpty) return sessions;
   final q = query.toLowerCase();
@@ -154,6 +154,7 @@ List<RecentSession> filterByQuery(List<RecentSession> sessions, String query) {
     return (s.name?.toLowerCase().contains(q) ?? false) ||
         s.firstPrompt.toLowerCase().contains(q) ||
         (s.lastPrompt?.toLowerCase().contains(q) ?? false) ||
+        (s.lastResponse?.toLowerCase().contains(q) ?? false) ||
         (s.summary?.toLowerCase().contains(q) ?? false);
   }).toList();
 }

--- a/apps/mobile/lib/features/session_list/widgets/home_content.dart
+++ b/apps/mobile/lib/features/session_list/widgets/home_content.dart
@@ -206,7 +206,7 @@ class HomeContentState extends State<HomeContent> {
   bool _showSupportBanner = false;
   bool _groupRecentSessions = true;
   final _searchController = TextEditingController();
-  SessionDisplayMode _displayMode = SessionDisplayMode.first;
+  SessionDisplayMode _displayMode = SessionDisplayMode.last;
   RevenueCatService? _revenueCatService;
   VoidCallback? _catalogStateListener;
   SupportBannerService? _supportBannerService;
@@ -228,7 +228,7 @@ class HomeContentState extends State<HomeContent> {
       if (modeStr != null) {
         _displayMode = SessionDisplayMode.values.firstWhere(
           (m) => m.name == modeStr,
-          orElse: () => SessionDisplayMode.first,
+          orElse: () => SessionDisplayMode.last,
         );
       }
       _groupRecentSessions = groupRecentSessions;

--- a/apps/mobile/lib/models/messages.dart
+++ b/apps/mobile/lib/models/messages.dart
@@ -3525,6 +3525,7 @@ class RecentSession {
   final String? summary;
   final String firstPrompt;
   final String? lastPrompt;
+  final String? lastResponse;
   final String created;
   final String modified;
   final String gitBranch;
@@ -3555,6 +3556,7 @@ class RecentSession {
     this.summary,
     required this.firstPrompt,
     this.lastPrompt,
+    this.lastResponse,
     required this.created,
     required this.modified,
     required this.gitBranch,
@@ -3607,6 +3609,7 @@ class RecentSession {
       summary: json['summary'] as String?,
       firstPrompt: json['firstPrompt'] as String? ?? '',
       lastPrompt: json['lastPrompt'] as String?,
+      lastResponse: json['lastResponse'] as String?,
       created: json['created'] as String? ?? '',
       modified: json['modified'] as String? ?? '',
       gitBranch: json['gitBranch'] as String? ?? '',
@@ -3669,6 +3672,7 @@ class RecentSession {
       summary: summary,
       firstPrompt: firstPrompt,
       lastPrompt: lastPrompt,
+      lastResponse: lastResponse,
       created: created,
       modified: modified,
       gitBranch: gitBranch,
@@ -3705,6 +3709,7 @@ class RecentSession {
       summary: summary,
       firstPrompt: firstPrompt,
       lastPrompt: lastPrompt,
+      lastResponse: lastResponse,
       created: created,
       modified: modified,
       gitBranch: gitBranch,

--- a/apps/mobile/lib/services/bridge_service.dart
+++ b/apps/mobile/lib/services/bridge_service.dart
@@ -361,6 +361,7 @@ class BridgeService implements BridgeServiceBase {
   static const _inFlightPendingVisibilityDelay = Duration(milliseconds: 600);
 
   Future<void>? _offlineQueueRestore;
+  Future<void> _offlinePendingPersistence = Future<void>.value();
   int _offlineQueueGeneration = 0;
 
   void _setBridgeConnectionState(BridgeConnectionState state) {
@@ -804,20 +805,7 @@ class BridgeService implements BridgeServiceBase {
     _offlinePendingActions = const [];
     _offlinePendingActionsController.add(_offlinePendingActions);
     _offlineQueueRestore = Future.value();
-    unawaited(_clearPersistedOfflinePendingMessages());
-  }
-
-  Future<void> _clearPersistedOfflinePendingMessages() async {
-    try {
-      final prefs = await SharedPreferences.getInstance();
-      await prefs.remove(_prefKeyOfflinePendingMessages);
-    } catch (error, stackTrace) {
-      logger.warning(
-        'Failed to clear offline pending messages',
-        error,
-        stackTrace,
-      );
-    }
+    unawaited(_persistOfflinePendingMessages());
   }
 
   int? _readHistorySeq(Object? value) {
@@ -976,7 +964,7 @@ class BridgeService implements BridgeServiceBase {
     }
     _inFlightPendingMessages[dedupeKey] = message;
     if (pendingAction != null) {
-    _scheduleInFlightPendingVisibility(dedupeKey);
+      _scheduleInFlightPendingVisibility(dedupeKey);
     }
     if (_isPersistableOfflineMessage(message)) {
       unawaited(_persistOfflinePendingMessages());
@@ -1429,12 +1417,10 @@ class BridgeService implements BridgeServiceBase {
         return true;
       });
       removed = before != _messageQueue.length;
-      if (removed) {
-        unawaited(_persistOfflinePendingMessages());
-      }
     }
     if (removed) {
       _publishOfflinePendingActions();
+      unawaited(_persistOfflinePendingMessages());
     }
   }
 
@@ -1491,12 +1477,10 @@ class BridgeService implements BridgeServiceBase {
         return true;
       });
       removed = didRemove;
-      if (removed) {
-        unawaited(_persistOfflinePendingMessages());
-      }
     }
     if (removed) {
       _publishOfflinePendingActions();
+      unawaited(_persistOfflinePendingMessages());
     }
   }
 
@@ -1558,10 +1542,8 @@ class BridgeService implements BridgeServiceBase {
     removed = removed || removedQueued;
 
     if (!removed) return;
-    if (removedQueued) {
-      unawaited(_persistOfflinePendingMessages());
-    }
     _publishOfflinePendingActions();
+    unawaited(_persistOfflinePendingMessages());
   }
 
   Future<void> _restoreOfflinePendingMessages() async {
@@ -1621,18 +1603,26 @@ class BridgeService implements BridgeServiceBase {
     return message.contains('Binding has not yet been initialized');
   }
 
-  Future<void> _persistOfflinePendingMessages() async {
-    await _ensureOfflineQueueRestored();
-    final pendingByKey = <String, String>{};
-    for (final message in [
-      ..._messageQueue,
-      ..._inFlightPendingMessages.values,
-    ].where(_isPersistableOfflineMessage)) {
-      pendingByKey[_offlineMessageDedupeKey(message) ?? message.toJson()] =
-          message.toJson();
-    }
-    final pending = pendingByKey.values.toList();
+  Future<void> _persistOfflinePendingMessages() {
+    final persistence = _offlinePendingPersistence.then(
+      (_) => _writeOfflinePendingMessages(),
+    );
+    _offlinePendingPersistence = persistence;
+    return persistence;
+  }
+
+  Future<void> _writeOfflinePendingMessages() async {
     try {
+      await _ensureOfflineQueueRestored();
+      final pendingByKey = <String, String>{};
+      for (final message in [
+        ..._messageQueue,
+        ..._inFlightPendingMessages.values,
+      ].where(_isPersistableOfflineMessage)) {
+        pendingByKey[_offlineMessageDedupeKey(message) ?? message.toJson()] =
+            message.toJson();
+      }
+      final pending = pendingByKey.values.toList();
       final prefs = await SharedPreferences.getInstance();
       if (pending.isEmpty) {
         await prefs.remove(_prefKeyOfflinePendingMessages);

--- a/apps/mobile/lib/services/bridge_service.dart
+++ b/apps/mobile/lib/services/bridge_service.dart
@@ -137,6 +137,7 @@ class BridgeService implements BridgeServiceBase {
   UsageResultMessage? _lastUsageResult;
   final SessionRuntimeStore _runtimeStore = SessionRuntimeStore();
   final Map<String, int> _pendingHistoryDeltaSinceSeq = {};
+  final Set<String> _sessionHistoryRequestsInFlight = {};
   final Map<String, ClientMessage> _inFlightPendingMessages = {};
   final Map<String, ClientMessage> _inFlightInputMessages = {};
   final Map<String, Timer> _inFlightPendingVisibilityTimers = {};
@@ -399,6 +400,9 @@ class BridgeService implements BridgeServiceBase {
             final sessionId = json['sessionId'] as String?;
             final msg = ServerMessage.fromJson(json);
             _clearDeliveredNonReplayableToolAction(msg, sessionId: sessionId);
+            if (sessionId != null && msg is HistoryMessage) {
+              _sessionHistoryRequestsInFlight.remove(sessionId);
+            }
             if (sessionId != null && msg is HistoryDeltaMessage) {
               _handleHistoryDelta(sessionId, msg);
               return;
@@ -620,6 +624,7 @@ class BridgeService implements BridgeServiceBase {
                 _messageController.add(msg);
               case ResultMessage(:final subtype) when subtype == 'stopped':
                 if (sessionId != null) {
+                  _clearPendingStop(sessionId);
                   clearExplorerHistory(sessionId);
                   _sessions = _sessions
                       .where((session) => session.id != sessionId)
@@ -631,6 +636,11 @@ class BridgeService implements BridgeServiceBase {
                 _taggedMessageController.add((msg, sessionId));
                 _messageController.add(msg);
               case ErrorMessage(:final message):
+                if (sessionId == null) {
+                  _sessionHistoryRequestsInFlight.clear();
+                } else {
+                  _sessionHistoryRequestsInFlight.remove(sessionId);
+                }
                 if (msg.errorCode == 'unsupported_message' &&
                     message == 'get_history_delta') {
                   _fallbackPendingHistoryDeltaRequests();
@@ -660,6 +670,7 @@ class BridgeService implements BridgeServiceBase {
             }
           } catch (e, st) {
             logger.error('WS parse error', e, st);
+            _sessionHistoryRequestsInFlight.clear();
             final errorMsg = ErrorMessage(message: 'Parse error: $e');
             _taggedMessageController.add((errorMsg, null));
             _messageController.add(errorMsg);
@@ -668,6 +679,7 @@ class BridgeService implements BridgeServiceBase {
         onError: (error, stackTrace) {
           if (epoch != _connectionEpoch) return;
           logger.error('WS stream error', error, stackTrace);
+          _sessionHistoryRequestsInFlight.clear();
           _setBridgeConnectionState(BridgeConnectionState.disconnected);
           _requeueInFlightInputMessages();
           _requeueInFlightPendingMessages();
@@ -676,6 +688,7 @@ class BridgeService implements BridgeServiceBase {
         onDone: () {
           if (epoch != _connectionEpoch) return;
           _channel = null;
+          _sessionHistoryRequestsInFlight.clear();
           if (!_intentionalDisconnect) {
             _setBridgeConnectionState(BridgeConnectionState.disconnected);
             _requeueInFlightInputMessages();
@@ -755,6 +768,7 @@ class BridgeService implements BridgeServiceBase {
     _promptHistoryBridgeId = null;
     _lastUsageResult = null;
     _pendingHistoryDeltaSinceSeq.clear();
+    _sessionHistoryRequestsInFlight.clear();
     _inFlightNonReplayableToolActions.clear();
     _respondedToolUseIds.clear();
     _deliveryPendingInputs.clear();
@@ -822,6 +836,7 @@ class BridgeService implements BridgeServiceBase {
         ((previousCachedSeq == 0 && msg.fromSeq <= 1) ||
             (msg.fromSeq <= previousCachedSeq + 1 &&
                 msg.fromSeq <= previousLatestSeq));
+    _sessionHistoryRequestsInFlight.remove(sessionId);
     _pendingHistoryDeltaSinceSeq.remove(sessionId);
     _runtimeStore.applyServerMessage(sessionId, msg);
 
@@ -850,6 +865,7 @@ class BridgeService implements BridgeServiceBase {
   }
 
   void _handleHistorySnapshot(String sessionId, HistorySnapshotMessage msg) {
+    _sessionHistoryRequestsInFlight.remove(sessionId);
     _pendingHistoryDeltaSinceSeq.remove(sessionId);
     _runtimeStore.applyServerMessage(sessionId, msg);
 
@@ -874,6 +890,7 @@ class BridgeService implements BridgeServiceBase {
     final sessionIds = List<String>.from(_pendingHistoryDeltaSinceSeq.keys);
     _pendingHistoryDeltaSinceSeq.clear();
     for (final sessionId in sessionIds) {
+      _sessionHistoryRequestsInFlight.add(sessionId);
       send(ClientMessage.getHistory(sessionId));
     }
   }
@@ -945,7 +962,9 @@ class BridgeService implements BridgeServiceBase {
 
   bool _trackInFlightPendingMessage(ClientMessage message) {
     final dedupeKey = _offlineMessageDedupeKey(message);
-    if (dedupeKey == null || _offlinePendingActionFor(message) == null) {
+    final pendingAction = _offlinePendingActionFor(message);
+    if (dedupeKey == null ||
+        (pendingAction == null && message.type != 'stop_session')) {
       return true;
     }
     final isQueued = _messageQueue.any((queued) {
@@ -956,7 +975,12 @@ class BridgeService implements BridgeServiceBase {
       return false;
     }
     _inFlightPendingMessages[dedupeKey] = message;
+    if (pendingAction != null) {
     _scheduleInFlightPendingVisibility(dedupeKey);
+    }
+    if (_isPersistableOfflineMessage(message)) {
+      unawaited(_persistOfflinePendingMessages());
+    }
     return true;
   }
 
@@ -1199,6 +1223,7 @@ class BridgeService implements BridgeServiceBase {
       'rename_session' ||
       'update_queued_input' ||
       'cancel_queued_input' => true,
+      'stop_session' => true,
       _ => false,
     };
   }
@@ -1211,8 +1236,22 @@ class BridgeService implements BridgeServiceBase {
       'resume_session' =>
         'resume:${json['provider'] ?? 'claude'}:${json['sessionId']}',
       'start' => 'start:${_canonicalJson(json)}',
+      'stop_session' => 'stop:${json['sessionId']}',
       _ => null,
     };
+  }
+
+  void _clearPendingStop(String sessionId) {
+    final dedupeKey = 'stop:$sessionId';
+    final removedInFlight = _inFlightPendingMessages.containsKey(dedupeKey);
+    if (removedInFlight) _clearInFlightPendingMessage(dedupeKey);
+    final before = _messageQueue.length;
+    _messageQueue.removeWhere(
+      (message) => _offlineMessageDedupeKey(message) == dedupeKey,
+    );
+    if (removedInFlight || before != _messageQueue.length) {
+      unawaited(_persistOfflinePendingMessages());
+    }
   }
 
   String _offlinePendingActionId(ClientMessage message) {
@@ -1584,10 +1623,15 @@ class BridgeService implements BridgeServiceBase {
 
   Future<void> _persistOfflinePendingMessages() async {
     await _ensureOfflineQueueRestored();
-    final pending = _messageQueue
-        .where(_isPersistableOfflineMessage)
-        .map((message) => message.toJson())
-        .toList();
+    final pendingByKey = <String, String>{};
+    for (final message in [
+      ..._messageQueue,
+      ..._inFlightPendingMessages.values,
+    ].where(_isPersistableOfflineMessage)) {
+      pendingByKey[_offlineMessageDedupeKey(message) ?? message.toJson()] =
+          message.toJson();
+    }
+    final pending = pendingByKey.values.toList();
     try {
       final prefs = await SharedPreferences.getInstance();
       if (pending.isEmpty) {
@@ -1911,6 +1955,7 @@ class BridgeService implements BridgeServiceBase {
 
   @override
   void requestSessionHistory(String sessionId) {
+    if (!_sessionHistoryRequestsInFlight.add(sessionId)) return;
     final snapshot = _runtimeStore.snapshot(sessionId);
     if (snapshot.messages.isNotEmpty) {
       _pendingHistoryDeltaSinceSeq[sessionId] = snapshot.cachedHistorySeq;

--- a/apps/mobile/lib/services/chat_message_handler.dart
+++ b/apps/mobile/lib/services/chat_message_handler.dart
@@ -425,7 +425,7 @@ class ChatMessageHandler {
 
     // Inject accumulated thinking text
     ServerMessage displayMsg = msg;
-    if (currentThinkingText.isNotEmpty) {
+    if (currentThinkingText.trim().isNotEmpty) {
       final hasThinking = message.content.any((c) => c is ThinkingContent);
       if (!hasThinking) {
         displayMsg = AssistantServerMessage(
@@ -440,8 +440,8 @@ class ChatMessageHandler {
           ),
         );
       }
-      currentThinkingText = '';
     }
+    currentThinkingText = '';
 
     // Build entry — replace streaming if present
     final entry = ServerChatEntry(displayMsg);
@@ -902,9 +902,13 @@ class ChatMessageHandler {
         msg.tipCode == 'git_not_available') {
       _gitTipShown = true;
     }
-    // Add init and tip as visible chat entries; session_created and
-    // supported_commands are internal metadata messages.
-    final addEntry = subtype == 'init' || subtype == 'tip';
+    // Claude init is internal session plumbing. Codex init carries the useful
+    // environment summary shown at the start of its transcript.
+    final addEntry =
+        subtype == 'tip' ||
+        (subtype == 'init' &&
+            msg is SystemMessage &&
+            msg.provider == Provider.codex.value);
     return ChatStateUpdate(
       entriesToAdd: addEntry ? [ServerChatEntry(msg)] : [],
       permissionMode: permissionMode,

--- a/apps/mobile/lib/services/chat_message_handler.dart
+++ b/apps/mobile/lib/services/chat_message_handler.dart
@@ -586,6 +586,7 @@ class ChatMessageHandler {
     CodexSpeed? codexSpeed;
     QueuedInputItem? queuedInput;
     var clearQueuedInput = false;
+    final toolUseIdsToHide = <String>{};
 
     // Track last known timestamp from user messages so server entries
     // (which don't carry timestamps) inherit a realistic time instead of
@@ -731,6 +732,9 @@ class ChatMessageHandler {
           lastAskToolUseId = null;
           lastAskInput = null;
         }
+        if (m case ToolUseSummaryMessage(:final precedingToolUseIds)) {
+          toolUseIdsToHide.addAll(precedingToolUseIds);
+        }
       }
     }
 
@@ -757,6 +761,7 @@ class ChatMessageHandler {
       codexSpeed: codexSpeed,
       queuedInput: queuedInput,
       clearQueuedInput: clearQueuedInput,
+      toolUseIdsToHide: toolUseIdsToHide,
     );
   }
 

--- a/apps/mobile/lib/services/chat_message_handler.dart
+++ b/apps/mobile/lib/services/chat_message_handler.dart
@@ -630,7 +630,8 @@ class ChatMessageHandler {
         if (m is! SystemMessage ||
             (m.subtype != 'supported_commands' &&
                 m.subtype != 'session_created' &&
-                m.subtype != 'codex_settings')) {
+                m.subtype != 'codex_settings' &&
+                (m.subtype != 'init' || m.provider == Provider.codex.value))) {
           entries.add(ServerChatEntry(m, timestamp: lastKnownTs));
         }
         // Restore slash commands from history (init, supported_commands, or

--- a/apps/mobile/lib/widgets/bubbles/ask_user_question_widget.dart
+++ b/apps/mobile/lib/widgets/bubbles/ask_user_question_widget.dart
@@ -339,8 +339,8 @@ class _AskUserQuestionWidgetState extends State<AskUserQuestionWidget> {
 
     final totalPages = _isMultiQuestion ? questions.length + 1 : 1;
 
-    final availableHeight = MediaQuery.of(context).size.height;
-    final keyboardHeight = MediaQuery.of(context).viewInsets.bottom;
+    final availableHeight = MediaQuery.sizeOf(context).height;
+    final keyboardHeight = MediaQuery.viewInsetsOf(context).bottom;
 
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),

--- a/apps/mobile/lib/widgets/bubbles/assistant_bubble.dart
+++ b/apps/mobile/lib/widgets/bubbles/assistant_bubble.dart
@@ -69,7 +69,12 @@ class _AssistantBubbleState extends State<AssistantBubble> {
 
   @override
   Widget build(BuildContext context) {
-    final contents = widget.message.message.content;
+    final contents = widget.message.message.content
+        .where(
+          (content) =>
+              content is! ThinkingContent || content.thinking.trim().isNotEmpty,
+        )
+        .toList(growable: false);
     final hasTextContent = contents.any((c) => c is TextContent);
     final hasPlanExit = contents.any(
       (c) => c is ToolUseContent && c.name == 'ExitPlanMode',

--- a/apps/mobile/lib/widgets/bubbles/user_bubble.dart
+++ b/apps/mobile/lib/widgets/bubbles/user_bubble.dart
@@ -142,7 +142,7 @@ class _StandardBubble extends StatelessWidget {
                 ),
                 constraints: BoxConstraints(
                   maxWidth:
-                      MediaQuery.of(context).size.width *
+                      MediaQuery.sizeOf(context).width *
                       AppSpacing.maxBubbleWidthFraction,
                 ),
                 decoration: BoxDecoration(
@@ -266,7 +266,7 @@ class _CommandBubble extends StatelessWidget {
                 ),
                 constraints: BoxConstraints(
                   maxWidth:
-                      MediaQuery.of(context).size.width *
+                      MediaQuery.sizeOf(context).width *
                       AppSpacing.maxBubbleWidthFraction,
                 ),
                 decoration: BoxDecoration(

--- a/apps/mobile/lib/widgets/chat_input_bar.dart
+++ b/apps/mobile/lib/widgets/chat_input_bar.dart
@@ -47,6 +47,7 @@ class ChatInputBar extends StatelessWidget {
   final VoidCallback? onClearDiffSelection;
   final VoidCallback? onTapDiffPreview;
   final String? hintText;
+  final Widget? activityIndicator;
 
   /// Callback to paste an image from clipboard (desktop only).
   /// When set, [imagePasteShortcut] attempts image paste.
@@ -87,6 +88,7 @@ class ChatInputBar extends StatelessWidget {
     this.onClearDiffSelection,
     this.onTapDiffPreview,
     this.hintText,
+    this.activityIndicator,
     this.onPasteImage,
     this.imagePasteShortcut = ImagePasteShortcut.ctrlV,
     this.onCompletionKeyEvent,
@@ -123,6 +125,7 @@ class ChatInputBar extends StatelessWidget {
             ),
           if (attachedImages.isNotEmpty)
             _ImagePreview(images: attachedImages, onClearImage: onClearImage),
+          ?activityIndicator,
           _InputTextField(
             controller: inputController,
             status: status,

--- a/apps/mobile/lib/widgets/composer_activity_indicator.dart
+++ b/apps/mobile/lib/widgets/composer_activity_indicator.dart
@@ -1,0 +1,173 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '../l10n/app_localizations.dart';
+import '../models/messages.dart';
+import '../theme/app_theme.dart';
+
+/// Compact, active-only status shown above the chat composer.
+class ComposerActivityIndicator extends StatefulWidget {
+  final ProcessStatus status;
+  final DateTime? startedAt;
+  final DateTime? lastActivityAt;
+  final DateTime Function()? now;
+
+  const ComposerActivityIndicator({
+    super.key,
+    required this.status,
+    this.startedAt,
+    this.lastActivityAt,
+    this.now,
+  });
+
+  @override
+  State<ComposerActivityIndicator> createState() =>
+      _ComposerActivityIndicatorState();
+}
+
+class _ComposerActivityIndicatorState extends State<ComposerActivityIndicator> {
+  Timer? _timer;
+  DateTime? _fallbackStartedAt;
+
+  @override
+  void initState() {
+    super.initState();
+    _syncTimer();
+  }
+
+  @override
+  void didUpdateWidget(ComposerActivityIndicator oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final wasActive = _isActive(oldWidget.status);
+    final isActive = _isActive(widget.status);
+    if (wasActive != isActive) _syncTimer();
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  void _syncTimer() {
+    _timer?.cancel();
+    _timer = null;
+    if (!_isActive(widget.status)) {
+      _fallbackStartedAt = null;
+      return;
+    }
+    _fallbackStartedAt ??= _now;
+    _timer = Timer.periodic(const Duration(seconds: 1), (_) {
+      if (mounted) setState(() {});
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_isActive(widget.status)) return const SizedBox.shrink();
+
+    final appColors = Theme.of(context).extension<AppColors>();
+    final color = switch (widget.status) {
+      ProcessStatus.starting =>
+        appColors?.statusStarting ?? Theme.of(context).colorScheme.primary,
+      ProcessStatus.compacting =>
+        appColors?.statusCompacting ?? Theme.of(context).colorScheme.primary,
+      _ => appColors?.statusRunning ?? Theme.of(context).colorScheme.primary,
+    };
+    final now = _now;
+    final elapsed = now.difference(
+      widget.startedAt ?? _fallbackStartedAt ?? now,
+    );
+    final elapsedLabel = _formatElapsed(elapsed);
+    final lastActivityAt = widget.lastActivityAt;
+    final quietDuration = lastActivityAt == null
+        ? Duration.zero
+        : now.difference(lastActivityAt);
+    final showLastActivity = quietDuration.inMinutes >= 1;
+    final workingLabel = _withoutTrailingEllipsis(
+      AppLocalizations.of(context).working,
+    );
+    final lastActivityLabel = showLastActivity
+        ? AppLocalizations.of(context).minutesAgo(quietDuration.inMinutes)
+        : null;
+
+    return Semantics(
+      key: const ValueKey('composer_activity_indicator'),
+      container: true,
+      excludeSemantics: true,
+      label: [workingLabel, elapsedLabel, ?lastActivityLabel].join(', '),
+      child: Padding(
+        padding: const EdgeInsets.only(left: 8, right: 8, bottom: 6),
+        child: Row(
+          children: [
+            SizedBox(
+              width: 11,
+              height: 11,
+              child: CircularProgressIndicator(
+                strokeWidth: 1.5,
+                color: color,
+                backgroundColor: color.withValues(alpha: 0.16),
+              ),
+            ),
+            const SizedBox(width: 7),
+            Text(
+              workingLabel,
+              style: TextStyle(
+                color: color,
+                fontSize: 11,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            Text(
+              ' · $elapsedLabel',
+              style: TextStyle(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+                fontSize: 11,
+                fontFeatures: const [FontFeature.tabularFigures()],
+              ),
+            ),
+            if (lastActivityLabel != null) ...[
+              const SizedBox(width: 8),
+              Icon(
+                Icons.history_rounded,
+                size: 11,
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+              const SizedBox(width: 3),
+              Text(
+                lastActivityLabel,
+                style: TextStyle(
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  fontSize: 11,
+                  fontFeatures: const [FontFeature.tabularFigures()],
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  DateTime get _now => widget.now?.call() ?? DateTime.now();
+}
+
+bool _isActive(ProcessStatus status) =>
+    status == ProcessStatus.starting ||
+    status == ProcessStatus.running ||
+    status == ProcessStatus.compacting;
+
+String _withoutTrailingEllipsis(String value) =>
+    value.endsWith('...') ? value.substring(0, value.length - 3) : value;
+
+String _formatElapsed(Duration elapsed) {
+  final seconds = elapsed.inSeconds.clamp(0, 359999);
+  if (seconds < 60) return '${seconds}s';
+  final minutes = seconds ~/ 60;
+  final remainingSeconds = (seconds % 60).toString().padLeft(2, '0');
+  if (minutes < 60) return '$minutes:$remainingSeconds';
+  final hours = minutes ~/ 60;
+  final remainingMinutes = (minutes % 60).toString().padLeft(2, '0');
+  return '$hours:$remainingMinutes:$remainingSeconds';
+}

--- a/apps/mobile/lib/widgets/message_bubble.dart
+++ b/apps/mobile/lib/widgets/message_bubble.dart
@@ -63,9 +63,13 @@ class ChatEntryWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final hasVisibleContent = chatEntryHasVisibleContent(
+      entry,
+      hiddenToolUseIds: hiddenToolUseIds,
+    );
     return Column(
       children: [
-        if (_shouldShowTimestamp())
+        if (hasVisibleContent && _shouldShowTimestamp())
           _TimestampWidget(timestamp: entry.timestamp),
         switch (entry) {
           ServerChatEntry(:final message) => ServerMessageWidget(
@@ -124,6 +128,92 @@ class ChatEntryWidget extends StatelessWidget {
     return diff.inMinutes >= 2;
   }
 }
+
+/// Whether [entry] produces visible chat content for layout and timestamping.
+bool chatEntryHasVisibleContent(
+  ChatEntry entry, {
+  Set<String> hiddenToolUseIds = const {},
+}) => switch (entry) {
+  UserChatEntry() => true,
+  StreamingChatEntry(:final text) => text.trim().isNotEmpty,
+  ServerChatEntry(:final message) => switch (message) {
+    AssistantServerMessage(:final message) => message.content.any(
+      (content) => switch (content) {
+        ToolUseContent(:final id, :final name) =>
+          name != 'ImageGeneration' || !hiddenToolUseIds.contains(id),
+        _ => true,
+      },
+    ),
+    ToolResultMessage(:final toolUseId) => !hiddenToolUseIds.contains(
+      toolUseId,
+    ),
+    PermissionRequestMessage(:final toolName) =>
+      toolName != 'ExitPlanMode' &&
+          toolName != 'AskUserQuestion' &&
+          toolName != 'McpElicitation' &&
+          toolName != 'ToolSuggestion',
+    PushRegistrationResultMessage() ||
+    SessionLinkResolutionMessage() ||
+    StatusMessage() ||
+    HistoryMessage() ||
+    HistoryDeltaMessage() ||
+    HistorySnapshotMessage() ||
+    PermissionResolvedMessage() ||
+    StreamDeltaMessage() ||
+    ThinkingDeltaMessage() ||
+    RecentSessionsMessage() ||
+    PastHistoryMessage() ||
+    SessionListMessage() ||
+    GalleryListMessage() ||
+    GalleryNewImageMessage() ||
+    FileListMessage() ||
+    FileContentMessage() ||
+    ProjectHistoryMessage() ||
+    DirectoryListingMessage() ||
+    DiffResultMessage() ||
+    DiffImageResultMessage() ||
+    WorktreeListMessage() ||
+    WorktreeRemovedMessage() ||
+    WindowListMessage() ||
+    ScreenshotResultMessage() ||
+    DebugBundleMessage() ||
+    RewindPreviewMessage() ||
+    RewindResultMessage() ||
+    UserInputMessage() ||
+    InputAckMessage() ||
+    InputRejectedMessage() ||
+    ConversationQueueMessage() ||
+    GoalStateMessage() ||
+    UsageResultMessage() ||
+    RecordingListMessage() ||
+    RecordingContentMessage() ||
+    MessageImagesResultMessage() ||
+    PromptHistoryBackupResultMessage() ||
+    PromptHistoryRestoreResultMessage() ||
+    PromptHistoryBackupInfoMessage() ||
+    PromptHistorySyncResultMessage() ||
+    PromptHistoryMutationResultMessage() ||
+    PromptHistoryStatusMessage() ||
+    RenameResultMessage() ||
+    ArchiveResultMessage() ||
+    BranchUpdateMessage() ||
+    GitStageResultMessage() ||
+    GitUnstageResultMessage() ||
+    GitUnstageHunksResultMessage() ||
+    GitCommitResultMessage() ||
+    GitPushResultMessage() ||
+    GitBranchesResultMessage() ||
+    GitCreateBranchResultMessage() ||
+    GitCheckoutBranchResultMessage() ||
+    GitRevertFileResultMessage() ||
+    GitRevertHunksResultMessage() ||
+    GitFetchResultMessage() ||
+    GitPullResultMessage() ||
+    GitStatusResultMessage() ||
+    GitRemoteStatusResultMessage() => false,
+    _ => true,
+  },
+};
 
 class _TimestampWidget extends StatelessWidget {
   final DateTime timestamp;

--- a/apps/mobile/lib/widgets/session_card.dart
+++ b/apps/mobile/lib/widgets/session_card.dart
@@ -2562,7 +2562,7 @@ class RecentSessionCard extends StatelessWidget {
     this.onLongPress,
     this.onShowActions,
     this.hideProjectBadge = false,
-    this.displayMode = SessionDisplayMode.first,
+    this.displayMode = SessionDisplayMode.last,
     this.draftText,
     this.isProcessing = false,
     this.isSelected = false,
@@ -2825,7 +2825,8 @@ class RecentSessionCard extends StatelessWidget {
             ? session.firstPrompt
             : session.displayText;
       case SessionDisplayMode.last:
-        final text = session.lastPrompt ?? session.firstPrompt;
+        final text =
+            session.lastResponse ?? session.lastPrompt ?? session.firstPrompt;
         raw = text.isNotEmpty ? text : '(no description)';
       case SessionDisplayMode.summary:
         final text = session.summary ?? session.firstPrompt;

--- a/apps/mobile/test/chat_input_bar_test.dart
+++ b/apps/mobile/test/chat_input_bar_test.dart
@@ -8,6 +8,7 @@ import 'package:ccpocket/models/image_paste_shortcut.dart';
 import 'package:ccpocket/models/messages.dart';
 import 'package:ccpocket/utils/diff_parser.dart';
 import 'package:ccpocket/widgets/chat_input_bar.dart';
+import 'package:ccpocket/widgets/composer_activity_indicator.dart';
 
 void main() {
   const nativePasteBridgeChannel = MethodChannel(
@@ -67,6 +68,7 @@ void main() {
         body: ChatInputBar(
           inputController: inputController,
           status: status,
+          activityIndicator: ComposerActivityIndicator(status: status),
           hasInputText: hasInputText,
           isInputEmpty: isInputEmpty,
           isVoiceAvailable: isVoiceAvailable,
@@ -106,6 +108,15 @@ void main() {
 
       expect(find.byKey(const ValueKey('stop_button')), findsOneWidget);
       expect(find.byKey(const ValueKey('send_button')), findsNothing);
+      final activity = find.byKey(
+        const ValueKey('composer_activity_indicator'),
+      );
+      final input = find.byKey(const ValueKey('message_input'));
+      expect(activity, findsOneWidget);
+      expect(
+        tester.getBottomLeft(activity).dy,
+        lessThanOrEqualTo(tester.getTopLeft(input).dy),
+      );
     });
 
     testWidgets('shows voice button when idle, no text, and voice available', (

--- a/apps/mobile/test/chat_message_handler_test.dart
+++ b/apps/mobile/test/chat_message_handler_test.dart
@@ -541,6 +541,31 @@ void main() {
   });
 
   group('History handling — pending state restoration', () {
+    test('hides Claude init metadata but preserves Codex init history', () {
+      final update = handler.handle(
+        const HistoryMessage(
+          messages: [
+            SystemMessage(
+              subtype: 'init',
+              provider: 'claude',
+              sessionId: 'claude-session',
+            ),
+            SystemMessage(subtype: 'init', provider: 'codex'),
+          ],
+        ),
+        isBackground: false,
+      );
+
+      final visibleMessages = update.entriesToAdd
+          .whereType<ServerChatEntry>()
+          .map((entry) => entry.message)
+          .toList();
+      expect(visibleMessages, hasLength(1));
+      expect(visibleMessages.single, isA<SystemMessage>());
+      expect((visibleMessages.single as SystemMessage).provider, 'codex');
+      expect(update.claudeSessionId, 'claude-session');
+    });
+
     test('restores project path from session metadata in history', () {
       final update = handler.handle(
         const HistoryMessage(

--- a/apps/mobile/test/chat_message_handler_test.dart
+++ b/apps/mobile/test/chat_message_handler_test.dart
@@ -1107,6 +1107,25 @@ void main() {
       expect(update.entriesToAdd, hasLength(1));
       expect(update.toolUseIdsToHide, isEmpty);
     });
+
+    test('history restores the tool uses hidden by summaries', () {
+      final update = handler.handle(
+        const HistoryMessage(
+          messages: [
+            ToolResultMessage(toolUseId: 'tu-1', content: 'first'),
+            ToolResultMessage(toolUseId: 'tu-2', content: 'second'),
+            ToolUseSummaryMessage(
+              summary: 'Read two files',
+              precedingToolUseIds: ['tu-1', 'tu-2'],
+            ),
+          ],
+        ),
+        isBackground: false,
+      );
+
+      expect(update.replaceEntries, isTrue);
+      expect(update.toolUseIdsToHide, {'tu-1', 'tu-2'});
+    });
   });
 
   group('PermissionRequestMessage for AskUserQuestion', () {

--- a/apps/mobile/test/chat_message_handler_test.dart
+++ b/apps/mobile/test/chat_message_handler_test.dart
@@ -338,6 +338,20 @@ void main() {
   });
 
   group('SystemMessage handling', () {
+    test('Claude init updates metadata without adding a transcript chip', () {
+      final update = handler.handle(
+        const SystemMessage(
+          subtype: 'init',
+          provider: 'claude',
+          sessionId: 'claude-session',
+        ),
+        isBackground: false,
+      );
+
+      expect(update.entriesToAdd, isEmpty);
+      expect(update.claudeSessionId, 'claude-session');
+    });
+
     test('Codex init applies approval policy without permission mode', () {
       final update = handler.handle(
         const SystemMessage(
@@ -1018,10 +1032,11 @@ void main() {
   });
 
   group('SystemMessage slash command handling', () {
-    test('init with slashCommands populates commands and adds entry', () {
+    test('Codex init with slashCommands populates commands and adds entry', () {
       final update = handler.handle(
         const SystemMessage(
           subtype: 'init',
+          provider: 'codex',
           slashCommands: ['compact', 'review', 'test-flutter'],
           skills: ['test-flutter'],
         ),

--- a/apps/mobile/test/chat_session_cubit_test.dart
+++ b/apps/mobile/test/chat_session_cubit_test.dart
@@ -157,6 +157,7 @@ void main() {
       expect(cubit.state.entries, isEmpty);
       expect(cubit.state.approval, isA<ApprovalNone>());
       expect(cubit.state.totalCost, 0.0);
+      expect(cubit.state.bulkLoading, isTrue);
     });
 
     test('status message updates state.status', () async {
@@ -171,6 +172,7 @@ void main() {
       await Future.microtask(() {});
 
       expect(cubit.state.status, ProcessStatus.running);
+      expect(cubit.state.bulkLoading, isFalse);
     });
 
     test(
@@ -942,22 +944,19 @@ void main() {
       },
     );
 
-    test('stale history keeps live summary tool results hidden', () async {
+    test('history replace rebuilds summarized tool visibility', () async {
       final cubit = createCubit('s1');
       addTearDown(cubit.close);
 
       mockBridge.emitMessage(
-        const HistoryMessage(
-          messages: [
-            UserInputMessage(
-              text: 'Previous turn',
-              userMessageUuid: 'previous-turn',
-            ),
-          ],
+        const ToolUseSummaryMessage(
+          summary: 'Old summary',
+          precedingToolUseIds: ['old-tool'],
         ),
         sessionId: 's1',
       );
       await pumpEventQueue();
+      expect(cubit.state.hiddenToolUseIds, {'old-tool'});
 
       mockBridge.emitMessage(
         const UserInputMessage(
@@ -966,26 +965,19 @@ void main() {
         ),
         sessionId: 's1',
       );
-      mockBridge.emitMessage(
-        const ToolResultMessage(toolUseId: 'live-tool', content: 'live result'),
-        sessionId: 's1',
-      );
-      mockBridge.emitMessage(
-        const ToolUseSummaryMessage(
-          summary: 'Live summary',
-          precedingToolUseIds: ['live-tool'],
-        ),
-        sessionId: 's1',
-      );
       await pumpEventQueue();
-      expect(cubit.state.hiddenToolUseIds, {'live-tool'});
 
       mockBridge.emitMessage(
         const HistoryMessage(
           messages: [
             UserInputMessage(
-              text: 'Previous turn',
-              userMessageUuid: 'previous-turn',
+              text: 'Current turn',
+              userMessageUuid: 'current-turn',
+            ),
+            ToolResultMessage(toolUseId: 'new-tool', content: 'new result'),
+            ToolUseSummaryMessage(
+              summary: 'Restored summary',
+              precedingToolUseIds: ['new-tool'],
             ),
           ],
         ),
@@ -993,11 +985,7 @@ void main() {
       );
       await pumpEventQueue();
 
-      final messages = cubit.state.entries.whereType<ServerChatEntry>().map(
-        (entry) => entry.message,
-      );
-      expect(messages.whereType<ToolUseSummaryMessage>(), hasLength(1));
-      expect(cubit.state.hiddenToolUseIds, {'live-tool'});
+      expect(cubit.state.hiddenToolUseIds, {'new-tool'});
     });
 
     test(
@@ -1988,7 +1976,9 @@ void main() {
       expect(cubit.state.status, ProcessStatus.idle);
     });
 
-    test('restores cached runtime messages before requesting history', () {
+    test(
+      'restores cached runtime messages before requesting history',
+      () async {
       mockBridge.cachedMessagesBySession['s1'] = [
         const StatusMessage(status: ProcessStatus.running),
         AssistantServerMessage(
@@ -2006,6 +1996,7 @@ void main() {
 
       expect(mockBridge.requestSessionHistoryCallCount, 1);
       expect(cubit.state.status, ProcessStatus.running);
+        expect(cubit.state.bulkLoading, isTrue);
       expect(cubit.state.entries, hasLength(1));
       final entry = cubit.state.entries.single as ServerChatEntry;
       final msg = entry.message as AssistantServerMessage;
@@ -2013,7 +2004,16 @@ void main() {
         (msg.message.content.single as TextContent).text,
         'Cached response',
       );
-    });
+
+        mockBridge.emitMessage(
+          const StatusMessage(status: ProcessStatus.running),
+          sessionId: 's1',
+        );
+        await Future.microtask(() {});
+
+        expect(cubit.state.bulkLoading, isFalse);
+      },
+    );
 
     test('restores cached queue state without visible ack entries', () {
       mockBridge.cachedMessagesBySession['s1'] = [
@@ -2104,6 +2104,33 @@ void main() {
     );
 
     test(
+      'cached running status keeps retrying until live history status arrives',
+      () async {
+        mockBridge.cachedMessagesBySession['s1'] = [
+          const StatusMessage(status: ProcessStatus.running),
+        ];
+        final cubit = createCubit('s1');
+        addTearDown(cubit.close);
+
+        expect(cubit.state.status, ProcessStatus.running);
+        expect(cubit.state.bulkLoading, isTrue);
+        expect(mockBridge.requestSessionHistoryCallCount, 1);
+
+        await Future<void>.delayed(const Duration(milliseconds: 3100));
+
+        expect(mockBridge.requestSessionHistoryCallCount, greaterThan(1));
+        expect(cubit.state.bulkLoading, isTrue);
+
+        mockBridge.emitMessage(
+          const StatusMessage(status: ProcessStatus.running),
+          sessionId: 's1',
+        );
+        await Future.microtask(() {});
+        expect(cubit.state.bulkLoading, isFalse);
+      },
+    );
+
+    test(
       'session-not-found stops history refresh and marks session unavailable',
       () async {
         final cubit = createCubit('missing-session');
@@ -2122,6 +2149,7 @@ void main() {
         await Future<void>.delayed(const Duration(milliseconds: 3100));
 
         expect(cubit.state.sessionUnavailable, isTrue);
+        expect(cubit.state.bulkLoading, isFalse);
         expect(mockBridge.requestSessionHistoryCallCount, 1);
       },
     );

--- a/apps/mobile/test/composer_activity_indicator_test.dart
+++ b/apps/mobile/test/composer_activity_indicator_test.dart
@@ -1,0 +1,111 @@
+import 'package:ccpocket/features/chat_session/widgets/session_composer_activity_indicator.dart';
+import 'package:ccpocket/l10n/app_localizations.dart';
+import 'package:ccpocket/models/messages.dart';
+import 'package:ccpocket/widgets/composer_activity_indicator.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  var now = DateTime(2026, 8, 23, 12);
+  DateTime clock() => now;
+
+  Widget buildSubject(
+    ProcessStatus status, {
+    DateTime? startedAt,
+    DateTime? lastActivityAt,
+  }) {
+    return MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      locale: const Locale('en'),
+      home: Scaffold(
+        body: ComposerActivityIndicator(
+          status: status,
+          startedAt: startedAt,
+          lastActivityAt: lastActivityAt,
+          now: clock,
+        ),
+      ),
+    );
+  }
+
+  setUp(() => now = DateTime(2026, 8, 23, 12));
+
+  testWidgets('shows a compact elapsed indicator while working', (
+    tester,
+  ) async {
+    await tester.pumpWidget(buildSubject(ProcessStatus.running));
+
+    expect(
+      find.byKey(const ValueKey('composer_activity_indicator')),
+      findsOneWidget,
+    );
+    expect(find.text('Working'), findsOneWidget);
+    expect(find.text(' · 0s'), findsOneWidget);
+
+    now = now.add(const Duration(seconds: 65));
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(find.text(' · 1:05'), findsOneWidget);
+  });
+
+  testWidgets('keeps elapsed time across active status transitions', (
+    tester,
+  ) async {
+    await tester.pumpWidget(buildSubject(ProcessStatus.starting));
+    now = now.add(const Duration(seconds: 30));
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pumpWidget(buildSubject(ProcessStatus.compacting));
+    now = now.add(const Duration(seconds: 31));
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(find.text(' · 1:01'), findsOneWidget);
+  });
+
+  testWidgets('is absent when idle or waiting for approval', (tester) async {
+    await tester.pumpWidget(buildSubject(ProcessStatus.idle));
+    expect(
+      find.byKey(const ValueKey('composer_activity_indicator')),
+      findsNothing,
+    );
+
+    await tester.pumpWidget(buildSubject(ProcessStatus.waitingApproval));
+    expect(
+      find.byKey(const ValueKey('composer_activity_indicator')),
+      findsNothing,
+    );
+  });
+
+  testWidgets('shows resumed elapsed time and a quiet-activity hint', (
+    tester,
+  ) async {
+    now = DateTime(2026, 8, 23, 12, 6, 12);
+    await tester.pumpWidget(
+      buildSubject(
+        ProcessStatus.running,
+        startedAt: DateTime(2026, 8, 23, 12),
+        lastActivityAt: DateTime(2026, 8, 23, 12, 4),
+      ),
+    );
+
+    expect(find.text(' · 6:12'), findsOneWidget);
+    expect(find.byIcon(Icons.history_rounded), findsOneWidget);
+    expect(find.text('2m ago'), findsOneWidget);
+    final semantics = tester.widget<Semantics>(
+      find.byKey(const ValueKey('composer_activity_indicator')),
+    );
+    expect(semantics.properties.liveRegion, isNot(true));
+  });
+
+  test('active turn starts at the latest user prompt', () {
+    final first = DateTime(2026, 8, 23, 11);
+    final latest = DateTime(2026, 8, 23, 12);
+    final entries = <ChatEntry>[
+      UserChatEntry('first', timestamp: first),
+      StreamingChatEntry(text: 'response', timestamp: first),
+      UserChatEntry('latest', timestamp: latest),
+    ];
+
+    expect(activeTurnStartedAt(entries), latest);
+  });
+}

--- a/apps/mobile/test/message_action_bar_test.dart
+++ b/apps/mobile/test/message_action_bar_test.dart
@@ -236,5 +236,24 @@ void main() {
 
       expect(captured.last, equals('First\n\nSecond'));
     });
+
+    testWidgets('does not render an empty thinking card', (tester) async {
+      const message = AssistantServerMessage(
+        message: AssistantMessage(
+          id: 'msg-empty-thinking',
+          role: 'assistant',
+          content: [
+            ThinkingContent(thinking: ' \n '),
+            TextContent(text: 'Visible response'),
+          ],
+          model: 'claude-opus-4-5-20251101',
+        ),
+      );
+
+      await tester.pumpWidget(_wrap(const AssistantBubble(message: message)));
+
+      expect(find.text('Thinking'), findsNothing);
+      expect(find.text('Visible response'), findsOneWidget);
+    });
   });
 }

--- a/apps/mobile/test/message_timestamp_visibility_test.dart
+++ b/apps/mobile/test/message_timestamp_visibility_test.dart
@@ -1,5 +1,6 @@
 import 'package:ccpocket/features/chat_session/widgets/chat_message_list.dart';
 import 'package:ccpocket/models/messages.dart';
+import 'package:ccpocket/theme/app_theme.dart';
 import 'package:ccpocket/widgets/message_bubble.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -10,6 +11,7 @@ void main() {
 
   Widget buildSubject(ChatEntry entry, {Set<String> hiddenIds = const {}}) {
     return MaterialApp(
+      theme: AppTheme.darkTheme,
       home: Scaffold(
         body: ChatEntryWidget(entry: entry, hiddenToolUseIds: hiddenIds),
       ),

--- a/apps/mobile/test/message_timestamp_visibility_test.dart
+++ b/apps/mobile/test/message_timestamp_visibility_test.dart
@@ -1,0 +1,121 @@
+import 'package:ccpocket/features/chat_session/widgets/chat_message_list.dart';
+import 'package:ccpocket/models/messages.dart';
+import 'package:ccpocket/widgets/message_bubble.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const timestampText = '12:34';
+  final timestamp = DateTime(2026, 8, 23, 12, 34);
+
+  Widget buildSubject(ChatEntry entry, {Set<String> hiddenIds = const {}}) {
+    return MaterialApp(
+      home: Scaffold(
+        body: ChatEntryWidget(entry: entry, hiddenToolUseIds: hiddenIds),
+      ),
+    );
+  }
+
+  testWidgets('does not render a timestamp for an empty streaming row', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      buildSubject(StreamingChatEntry(text: '', timestamp: timestamp)),
+    );
+
+    expect(find.text(timestampText), findsNothing);
+  });
+
+  testWidgets('does not render a timestamp for a hidden server event', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      buildSubject(
+        ServerChatEntry(
+          const StatusMessage(status: ProcessStatus.running),
+          timestamp: timestamp,
+        ),
+      ),
+    );
+
+    expect(find.text(timestampText), findsNothing);
+  });
+
+  testWidgets('does not render a timestamp for an empty assistant event', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      buildSubject(
+        ServerChatEntry(
+          const AssistantServerMessage(
+            message: AssistantMessage(
+              id: 'assistant-1',
+              role: 'assistant',
+              content: [],
+              model: 'codex',
+            ),
+          ),
+          timestamp: timestamp,
+        ),
+      ),
+    );
+
+    expect(find.text(timestampText), findsNothing);
+  });
+
+  testWidgets('does not render a timestamp for a summarized tool result', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      buildSubject(
+        ServerChatEntry(
+          const ToolResultMessage(toolUseId: 'tool-1', content: 'hidden'),
+          timestamp: timestamp,
+        ),
+        hiddenIds: const {'tool-1'},
+      ),
+    );
+
+    expect(find.text(timestampText), findsNothing);
+  });
+
+  test('timestamp grouping skips hidden entries', () {
+    final firstVisible = UserChatEntry(
+      'question',
+      timestamp: DateTime(2026, 8, 23, 12),
+    );
+    final hidden = ServerChatEntry(
+      const StatusMessage(status: ProcessStatus.running),
+      timestamp: DateTime(2026, 8, 23, 12, 1),
+    );
+    final nextVisible = UserChatEntry(
+      'follow-up',
+      timestamp: DateTime(2026, 8, 23, 12, 3),
+    );
+
+    final sequence = deriveVisibleChatSequence([
+      firstVisible,
+      hidden,
+      nextVisible,
+    ]);
+
+    expect(sequence.previousEntries[1], same(firstVisible));
+    expect(sequence.previousEntries[2], same(firstVisible));
+    expect(sequence.lastVisibleEntry, same(nextVisible));
+  });
+
+  test('timestamp grouping counts a replacement widget as visible', () {
+    final entry = ServerChatEntry(
+      const ToolResultMessage(toolUseId: 'image-tool', content: 'hidden'),
+      timestamp: timestamp,
+    );
+
+    final sequence = deriveVisibleChatSequence(
+      [entry],
+      hiddenToolUseIds: const {'image-tool'},
+      externallyVisibleIndices: const {0},
+    );
+
+    expect(sequence.lastVisibleEntry, same(entry));
+  });
+}

--- a/apps/mobile/test/messages_test.dart
+++ b/apps/mobile/test/messages_test.dart
@@ -105,6 +105,7 @@ void main() {
         'projectPath': '/workspace/app',
         'gitBranch': 'main',
         'firstPrompt': 'Continue this task',
+        'lastResponse': 'The task is complete.',
         'created': '2026-07-24T00:00:00Z',
         'modified': '2026-07-24T01:00:00Z',
         'isSidechain': false,
@@ -115,6 +116,7 @@ void main() {
     expect(message.status, SessionLinkResolutionStatus.recent);
     expect(message.recentSession?.sessionId, 'claude-uuid');
     expect(message.recentSession?.projectPath, '/workspace/app');
+    expect(message.recentSession?.lastResponse, 'The task is complete.');
   });
 
   test('parses a scoped session-not-found error', () {

--- a/apps/mobile/test/result_chip_test.dart
+++ b/apps/mobile/test/result_chip_test.dart
@@ -1,0 +1,41 @@
+import 'package:ccpocket/models/messages.dart';
+import 'package:ccpocket/theme/app_theme.dart';
+import 'package:ccpocket/widgets/bubbles/result_chip.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Widget subject({required bool showSuccessResultText}) {
+    return MaterialApp(
+      theme: AppTheme.darkTheme,
+      home: Scaffold(
+        body: ResultChip(
+          message: const ResultMessage(
+            subtype: 'success',
+            result: 'Recovered final summary',
+          ),
+          showSuccessResultText: showSuccessResultText,
+        ),
+      ),
+    );
+  }
+
+  testWidgets('successful result text stays hidden when assistant is present', (
+    tester,
+  ) async {
+    await tester.pumpWidget(subject(showSuccessResultText: false));
+
+    expect(find.text('Recovered final summary'), findsNothing);
+    expect(find.text('Done'), findsOneWidget);
+  });
+
+  testWidgets(
+    'successful result text is available as a missing-answer fallback',
+    (tester) async {
+      await tester.pumpWidget(subject(showSuccessResultText: true));
+
+      expect(find.text('Recovered final summary'), findsOneWidget);
+      expect(find.text('Done'), findsOneWidget);
+    },
+  );
+}

--- a/apps/mobile/test/services/bridge_service_usage_test.dart
+++ b/apps/mobile/test/services/bridge_service_usage_test.dart
@@ -291,6 +291,113 @@ void main() {
       },
     );
 
+    test(
+      'requestSessionHistory coalesces requests until history arrives',
+      () async {
+        final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+        final socketReady = Completer<WebSocket>();
+
+        server.transform(WebSocketTransformer()).listen((socket) {
+          socketReady.complete(socket);
+        });
+
+        final outgoing = <ClientMessage>[];
+        final bridge = BridgeService()..onOutgoingMessage = outgoing.add;
+        final connected = bridge.connectionStatus.firstWhere(
+          (state) => state == BridgeConnectionState.connected,
+        );
+        bridge.connect('ws://127.0.0.1:${server.port}');
+
+        final socket = await socketReady.future;
+        await connected;
+        bridge.requestSessionHistory('s1');
+        bridge.requestSessionHistory('s1');
+
+        expect(
+          outgoing.where((message) => message.type == 'get_history'),
+          hasLength(1),
+        );
+
+        socket.add(
+          jsonEncode({
+            'type': 'history',
+            'sessionId': 's1',
+            'messages': <Map<String, dynamic>>[],
+          }),
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        bridge.requestSessionHistory('s1');
+        expect(
+          outgoing.where((message) => message.type == 'get_history'),
+          hasLength(2),
+        );
+
+        socket.add(
+          jsonEncode({
+            'type': 'error',
+            'sessionId': 's1',
+            'message': 'history read failed',
+          }),
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        bridge.requestSessionHistory('s1');
+        expect(
+          outgoing.where(
+            (message) =>
+                message.type == 'get_history' ||
+                message.type == 'get_history_delta',
+          ),
+          hasLength(3),
+        );
+
+        bridge.disconnect();
+        await socket.close();
+        await server.close(force: true);
+        bridge.dispose();
+      },
+    );
+
+    test('malformed history does not block the next retry', () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      final socketReady = Completer<WebSocket>();
+
+      server.transform(WebSocketTransformer()).listen((socket) {
+        socketReady.complete(socket);
+      });
+
+      final outgoing = <ClientMessage>[];
+      final bridge = BridgeService()..onOutgoingMessage = outgoing.add;
+      final connected = bridge.connectionStatus.firstWhere(
+        (state) => state == BridgeConnectionState.connected,
+      );
+      bridge.connect('ws://127.0.0.1:${server.port}');
+
+      final socket = await socketReady.future;
+      await connected;
+      bridge.requestSessionHistory('s1');
+      socket.add(
+        jsonEncode({
+          'type': 'history',
+          'sessionId': 's1',
+          'messages': 'malformed',
+        }),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      bridge.requestSessionHistory('s1');
+      expect(
+        outgoing.where((message) => message.type == 'get_history'),
+        hasLength(2),
+      );
+
+      bridge.disconnect();
+      await socket.close();
+      await server.close(force: true);
+      bridge.dispose();
+    });
+
     test('requestSessionHistory uses last complete cached sequence', () async {
       final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
       final socketReady = Completer<WebSocket>();
@@ -1982,6 +2089,82 @@ void main() {
       await server.close(force: true);
       bridge.dispose();
     });
+
+    test('keeps an unacknowledged stop durable across a socket drop', () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      final socketReady = Completer<WebSocket>();
+
+      server.transform(WebSocketTransformer()).listen((socket) {
+        socketReady.complete(socket);
+      });
+
+      final bridge = BridgeService();
+      bridge.connect('ws://127.0.0.1:${server.port}');
+      final socket = await socketReady.future;
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      bridge.stopSession('session-to-stop');
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      var prefs = await SharedPreferences.getInstance();
+      var raw = prefs.getStringList('bridge_offline_pending_messages_v1');
+      expect(raw, hasLength(1));
+      expect(jsonDecode(raw!.single), {
+        'type': 'stop_session',
+        'sessionId': 'session-to-stop',
+      });
+
+      await socket.close();
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      prefs = await SharedPreferences.getInstance();
+      raw = prefs.getStringList('bridge_offline_pending_messages_v1');
+      expect(raw, hasLength(1));
+      expect(jsonDecode(raw!.single), containsPair('type', 'stop_session'));
+
+      bridge.disconnect();
+      await server.close(force: true);
+      bridge.dispose();
+    });
+
+    test(
+      'clears a durable stop only after the Bridge acknowledges it',
+      () async {
+        final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+        final socketReady = Completer<WebSocket>();
+
+        server.transform(WebSocketTransformer()).listen((socket) {
+          socketReady.complete(socket);
+        });
+
+        final bridge = BridgeService();
+        bridge.connect('ws://127.0.0.1:${server.port}');
+        final socket = await socketReady.future;
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        bridge.stopSession('session-to-stop');
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        socket.add(
+          jsonEncode({
+            'type': 'result',
+            'subtype': 'stopped',
+            'sessionId': 'session-to-stop',
+          }),
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        final prefs = await SharedPreferences.getInstance();
+        expect(
+          prefs.getStringList('bridge_offline_pending_messages_v1'),
+          isNull,
+        );
+
+        bridge.disconnect();
+        await socket.close();
+        await server.close(force: true);
+        bridge.dispose();
+      },
+    );
 
     test(
       'cancelOfflinePendingAction removes queued action and persistence',

--- a/apps/mobile/test/services/bridge_service_usage_test.dart
+++ b/apps/mobile/test/services/bridge_service_usage_test.dart
@@ -1781,6 +1781,12 @@ void main() {
       bridge.send(ClientMessage.start('/home/user/app', provider: 'codex'));
       await Future<void>.delayed(const Duration(milliseconds: 50));
 
+      final prefs = await SharedPreferences.getInstance();
+      expect(
+        prefs.getStringList('bridge_offline_pending_messages_v1'),
+        hasLength(1),
+      );
+
       expect(bridge.offlinePendingActions, isEmpty);
       expect(
         received.where((message) => message['type'] == 'start'),
@@ -1808,6 +1814,12 @@ void main() {
       await Future<void>.delayed(const Duration(milliseconds: 50));
 
       expect(bridge.offlinePendingActions, isEmpty);
+      expect(prefs.getStringList('bridge_offline_pending_messages_v1'), isNull);
+
+      final restoredBridge = BridgeService();
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(restoredBridge.offlinePendingActions, isEmpty);
+      restoredBridge.dispose();
 
       bridge.disconnect();
       await socket.close();

--- a/apps/mobile/test/session_card_test.dart
+++ b/apps/mobile/test/session_card_test.dart
@@ -1319,14 +1319,15 @@ void main() {
       );
     });
 
-    testWidgets('uses first, last, and summary fields by display mode', (
-      tester,
-    ) async {
+    testWidgets(
+      'uses first prompt, last response, and summary by display mode',
+      (tester) async {
       final session = RecentSession(
         sessionId: 'recent-display-mode',
         summary: 'summary text',
         firstPrompt: 'first prompt text',
         lastPrompt: 'last prompt text',
+          lastResponse: 'last response text',
         created: DateTime.now().toIso8601String(),
         modified: DateTime.now().toIso8601String(),
         gitBranch: 'main',
@@ -1356,7 +1357,8 @@ void main() {
           ),
         ),
       );
-      expect(find.text('last prompt text'), findsOneWidget);
+        expect(find.text('last response text'), findsOneWidget);
+        expect(find.text('last prompt text'), findsNothing);
       expect(find.text('first prompt text'), findsNothing);
       expect(find.text('summary text'), findsNothing);
 
@@ -1370,6 +1372,30 @@ void main() {
         ),
       );
       expect(find.text('summary text'), findsOneWidget);
+      expect(find.text('first prompt text'), findsNothing);
+      expect(find.text('last prompt text'), findsNothing);
+        expect(find.text('last response text'), findsNothing);
+      },
+    );
+
+    testWidgets('defaults to the last agent response', (tester) async {
+      final session = RecentSession(
+        sessionId: 'recent-default-response',
+        firstPrompt: 'first prompt text',
+        lastPrompt: 'last prompt text',
+        lastResponse: 'last response text',
+        created: DateTime.now().toIso8601String(),
+        modified: DateTime.now().toIso8601String(),
+        gitBranch: 'main',
+        projectPath: '/home/user/my-app',
+        isSidechain: false,
+      );
+
+      await tester.pumpWidget(
+        _wrap(RecentSessionCard(session: session, onTap: () {})),
+      );
+
+      expect(find.text('last response text'), findsOneWidget);
       expect(find.text('first prompt text'), findsNothing);
       expect(find.text('last prompt text'), findsNothing);
     });

--- a/apps/mobile/test/session_composer_activity_indicator_test.dart
+++ b/apps/mobile/test/session_composer_activity_indicator_test.dart
@@ -1,0 +1,115 @@
+import 'dart:async';
+
+import 'package:ccpocket/features/chat_session/state/chat_session_cubit.dart';
+import 'package:ccpocket/features/chat_session/state/streaming_state_cubit.dart';
+import 'package:ccpocket/features/chat_session/widgets/session_composer_activity_indicator.dart';
+import 'package:ccpocket/l10n/app_localizations.dart';
+import 'package:ccpocket/models/messages.dart';
+import 'package:ccpocket/services/bridge_service.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _TestBridgeService extends BridgeService {
+  final _messages = StreamController<(ServerMessage, String?)>.broadcast();
+
+  void emit(ServerMessage message, {required String sessionId}) {
+    _messages.add((message, sessionId));
+  }
+
+  @override
+  Stream<ServerMessage> messagesForSession(String sessionId) => _messages.stream
+      .where((event) => event.$2 == sessionId)
+      .map((event) => event.$1);
+
+  @override
+  void dispose() {
+    _messages.close();
+    super.dispose();
+  }
+}
+
+void main() {
+  testWidgets('rebases elapsed time when history arrives after the screen', (
+    tester,
+  ) async {
+    final now = DateTime.utc(2026, 8, 23, 12, 6, 12);
+    final bridge = _TestBridgeService();
+    final streamingCubit = StreamingStateCubit();
+    final sessionCubit = ChatSessionCubit(
+      sessionId: 'late-history',
+      bridge: bridge,
+      streamingCubit: streamingCubit,
+    );
+    var disposed = false;
+    addTearDown(() async {
+      if (disposed) return;
+      await sessionCubit.close();
+      await streamingCubit.close();
+      bridge.dispose();
+    });
+
+    expect(sessionCubit.state.entries, isEmpty);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        locale: const Locale('en'),
+        home: MultiBlocProvider(
+          providers: [
+            BlocProvider<ChatSessionCubit>.value(value: sessionCubit),
+            BlocProvider<StreamingStateCubit>.value(value: streamingCubit),
+          ],
+          child: Scaffold(
+            body: SessionComposerActivityIndicator(
+              status: ProcessStatus.running,
+              now: () => now,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      find.byKey(const ValueKey('composer_activity_indicator')),
+      findsNothing,
+    );
+
+    bridge.emit(
+      const HistoryMessage(
+        messages: [
+          UserInputMessage(
+            text: 'Continue the work',
+            timestamp: '2026-08-23T12:00:00.000Z',
+          ),
+        ],
+      ),
+      sessionId: 'late-history',
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(
+      find.byKey(const ValueKey('composer_activity_indicator')),
+      findsNothing,
+    );
+
+    bridge.emit(
+      const StatusMessage(status: ProcessStatus.running),
+      sessionId: 'late-history',
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('Working'), findsOneWidget);
+    expect(find.text(' · 6:12'), findsOneWidget);
+    expect(find.text('6m ago'), findsOneWidget);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await sessionCubit.close();
+    await streamingCubit.close();
+    bridge.dispose();
+    disposed = true;
+  });
+}

--- a/packages/bridge/README.md
+++ b/packages/bridge/README.md
@@ -50,6 +50,8 @@ ccpocket-bridge --version
 | `BRIDGE_DISABLE_MDNS` | (none) | Disable mDNS auto-discovery advertisement (macOS disables it automatically) |
 | `BRIDGE_ALLOW_CLAUDE_OAUTH` | (none) | Set exactly to `1` to explicitly enable experimental Claude subscription authentication |
 | `BRIDGE_PROMPT_HISTORY_FILE` | `$HOME/.ccpocket/prompt-history-v2.json` | Custom prompt history store path |
+| `BRIDGE_ACTIVE_SESSIONS_FILE` | `$HOME/.ccpocket/active-sessions.json` | Custom active-session recovery store path |
+| `BRIDGE_DISABLE_ACTIVE_SESSIONS` | (none) | Set exactly to `1` to disable active-session recovery for an ephemeral Bridge |
 | `BRIDGE_RECENT_SESSIONS_PROFILE` | (none) | Log recent-session index timing when set to `1` or `true` |
 | `BRIDGE_FILE_LIST_MAX_ENTRIES` | `5000` | Maximum file and directory entries returned to a client; non-positive or invalid values use the default |
 | `BRIDGE_FILE_LIST_MAX_BYTES` | `524288` | Maximum serialized path bytes returned in a client file list; non-positive or invalid values use the default |
@@ -66,6 +68,9 @@ Lowercase proxy variables (`https_proxy`, `http_proxy`, `all_proxy`) are also
 supported. When `BRIDGE_PROMPT_HISTORY_FILE` is not set and `BRIDGE_PORT` is not
 `8765`, prompt history is stored in
 `$HOME/.ccpocket/prompt-history-v2-<port>.json`.
+Active-session recovery is similarly scoped by port as
+`$HOME/.ccpocket/active-sessions-<port>.json`, preventing a secondary test
+Bridge from restoring or overwriting the production Bridge's sessions.
 
 Push relay uses Firebase Anonymous Auth automatically; no FCM environment
 variables are required.

--- a/packages/bridge/src/active-session-store.test.ts
+++ b/packages/bridge/src/active-session-store.test.ts
@@ -1,0 +1,157 @@
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  ActiveSessionStore,
+  activeSessionStoreFileForPort,
+  type PersistedActiveSession,
+} from "./active-session-store.js";
+
+const temporaryDirectories: string[] = [];
+
+function createStore(): {
+  directory: string;
+  file: string;
+  store: ActiveSessionStore;
+} {
+  const directory = mkdtempSync(join(tmpdir(), "ccpocket-active-sessions-"));
+  temporaryDirectories.push(directory);
+  const file = join(directory, "active-sessions.json");
+  return { directory, file, store: new ActiveSessionStore(file) };
+}
+
+function session(
+  overrides: Partial<PersistedActiveSession> = {},
+): PersistedActiveSession {
+  return {
+    bridgeSessionId: "bridge-1",
+    providerSessionId: "provider-1",
+    provider: "claude",
+    projectPath: "/workspace/project",
+    createdAt: "2026-08-23T10:00:00.000Z",
+    lastActivityAt: "2026-08-23T11:00:00.000Z",
+    lastMessage: "Latest response",
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("ActiveSessionStore", () => {
+  it("scopes the default store by Bridge port", () => {
+    expect(activeSessionStoreFileForPort(8765)).toBe(
+      join(homedir(), ".ccpocket", "active-sessions.json"),
+    );
+    expect(activeSessionStoreFileForPort(8766)).toBe(
+      join(homedir(), ".ccpocket", "active-sessions-8766.json"),
+    );
+    expect(activeSessionStoreFileForPort(8766, "/tmp/custom.json")).toBe(
+      "/tmp/custom.json",
+    );
+  });
+
+  it("persists active session metadata across store instances", () => {
+    const { file, store } = createStore();
+    store.replace([
+      session({
+        permissionMode: "acceptEdits",
+        sandboxEnabled: true,
+        worktreePath: "/workspace/project-worktrees/fix",
+        worktreeBranch: "fix/session-list",
+      }),
+    ]);
+
+    expect(new ActiveSessionStore(file).list()).toEqual([
+      session({
+        permissionMode: "acceptEdits",
+        sandboxEnabled: true,
+        worktreePath: "/workspace/project-worktrees/fix",
+        worktreeBranch: "fix/session-list",
+      }),
+    ]);
+  });
+
+  it("deduplicates a provider session using the latest record", () => {
+    const { file, store } = createStore();
+    store.replace([
+      session({ lastMessage: "Older response" }),
+      session({ bridgeSessionId: "bridge-2", lastMessage: "Latest response" }),
+    ]);
+
+    const parsed = JSON.parse(readFileSync(file, "utf-8")) as {
+      sessions: PersistedActiveSession[];
+    };
+    expect(parsed.sessions).toEqual([
+      session({ bridgeSessionId: "bridge-2", lastMessage: "Latest response" }),
+    ]);
+  });
+
+  it("ignores malformed persisted records", () => {
+    const { file } = createStore();
+    writeFileSync(
+      file,
+      JSON.stringify({
+        version: 1,
+        sessions: [session(), { provider: "claude", projectPath: "/missing-id" }],
+      }),
+      "utf-8",
+    );
+
+    expect(new ActiveSessionStore(file).list()).toEqual([session()]);
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "keeps session metadata private on disk",
+    () => {
+      const { directory, file, store } = createStore();
+      store.replace([session()]);
+
+      expect(statSync(directory).mode & 0o777).toBe(0o700);
+      expect(statSync(file).mode & 0o777).toBe(0o600);
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "preserves permissions on an existing custom parent directory",
+    () => {
+      const directory = mkdtempSync(join(tmpdir(), "ccpocket-active-custom-"));
+      temporaryDirectories.push(directory);
+      chmodSync(directory, 0o750);
+      const file = join(directory, "active-sessions.json");
+
+      new ActiveSessionStore(file).replace([session()]);
+
+      expect(statSync(directory).mode & 0o777).toBe(0o750);
+      expect(statSync(file).mode & 0o777).toBe(0o600);
+    },
+  );
+
+  it("retries the same update after a transient write failure", () => {
+    const directory = mkdtempSync(join(tmpdir(), "ccpocket-active-retry-"));
+    temporaryDirectories.push(directory);
+    const blockedParent = join(directory, "blocked");
+    writeFileSync(blockedParent, "not a directory", "utf-8");
+    const file = join(blockedParent, "active-sessions.json");
+    const store = new ActiveSessionStore(file);
+
+    expect(() => store.replace([session()])).toThrow();
+    rmSync(blockedParent);
+    mkdirSync(blockedParent);
+    expect(() => store.replace([session()])).not.toThrow();
+    expect(new ActiveSessionStore(file).list()).toEqual([session()]);
+  });
+});

--- a/packages/bridge/src/active-session-store.ts
+++ b/packages/bridge/src/active-session-store.ts
@@ -1,0 +1,189 @@
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { randomUUID } from "node:crypto";
+import { dirname, join } from "node:path";
+import { homedir } from "node:os";
+import type { SessionInfo } from "./session.js";
+
+export interface PersistedActiveSession {
+  bridgeSessionId: string;
+  providerSessionId: string;
+  provider: "claude" | "codex";
+  projectPath: string;
+  name?: string;
+  createdAt: string;
+  lastActivityAt: string;
+  lastMessage: string;
+  worktreePath?: string;
+  worktreeBranch?: string;
+  permissionMode?: string;
+  model?: string;
+  sandboxEnabled?: boolean;
+  planMode?: boolean;
+  claudeSettings?: SessionInfo["claudeSettings"];
+  codexSettings?: SessionInfo["codexSettings"];
+  codexQueuedInput?: SessionInfo["codexQueuedInput"];
+}
+
+interface ActiveSessionStoreData {
+  version: 1;
+  sessions: PersistedActiveSession[];
+}
+
+const DEFAULT_STORE_FILE = join(
+  homedir(),
+  ".ccpocket",
+  "active-sessions.json",
+);
+const DEFAULT_BRIDGE_PORT = 8765;
+
+export function activeSessionStoreFileForPort(
+  port: number | string | undefined,
+  explicitFile?: string,
+): string {
+  if (explicitFile?.trim()) return explicitFile.trim();
+  const parsedPort =
+    typeof port === "number" ? port : Number.parseInt(port ?? "", 10);
+  if (!Number.isInteger(parsedPort) || parsedPort === DEFAULT_BRIDGE_PORT) {
+    return DEFAULT_STORE_FILE;
+  }
+  return join(homedir(), ".ccpocket", `active-sessions-${parsedPort}.json`);
+}
+
+/**
+ * Persists the provider sessions that the user still considers active.
+ * Bridge-local process IDs are intentionally omitted because they change
+ * whenever the Bridge restarts.
+ */
+export class ActiveSessionStore {
+  private data: ActiveSessionStoreData;
+
+  constructor(
+    private readonly storeFile: string = activeSessionStoreFileForPort(
+      process.env.BRIDGE_PORT,
+      process.env.BRIDGE_ACTIVE_SESSIONS_FILE,
+    ),
+  ) {
+    this.data = this.load();
+  }
+
+  list(): PersistedActiveSession[] {
+    return this.data.sessions.map(clonePersistedActiveSession);
+  }
+
+  replace(sessions: PersistedActiveSession[]): void {
+    const deduped = new Map<string, PersistedActiveSession>();
+    for (const session of sessions) {
+      deduped.set(
+        `${session.provider}:${session.providerSessionId}`,
+        clonePersistedActiveSession(session),
+      );
+    }
+    const next = { version: 1 as const, sessions: [...deduped.values()] };
+    if (JSON.stringify(next) === JSON.stringify(this.data)) return;
+    // Commit the in-memory state only after the atomic disk write succeeds so
+    // a transient I/O failure remains retryable on the next update.
+    this.save(next);
+    this.data = next;
+  }
+
+  private load(): ActiveSessionStoreData {
+    if (!existsSync(this.storeFile)) return { version: 1, sessions: [] };
+    try {
+      const parsed = JSON.parse(
+        readFileSync(this.storeFile, "utf-8"),
+      ) as Partial<ActiveSessionStoreData>;
+      if (parsed.version !== 1 || !Array.isArray(parsed.sessions)) {
+        return { version: 1, sessions: [] };
+      }
+      return {
+        version: 1,
+        sessions: parsed.sessions.filter(isPersistedActiveSession),
+      };
+    } catch {
+      return { version: 1, sessions: [] };
+    }
+  }
+
+  private save(data: ActiveSessionStoreData): void {
+    const storeDir = dirname(this.storeFile);
+    const createdDir = mkdirSync(storeDir, { recursive: true, mode: 0o700 });
+    // ~/.ccpocket is Bridge-owned and may always be hardened. For an explicit
+    // store path, preserve permissions on an existing shared parent directory.
+    if (createdDir !== undefined || storeDir === dirname(DEFAULT_STORE_FILE)) {
+      chmodSync(storeDir, 0o700);
+    }
+    const temporaryFile = join(
+      storeDir,
+      `active-sessions.${randomUUID()}.tmp`,
+    );
+    writeFileSync(temporaryFile, JSON.stringify(data, null, 2), {
+      encoding: "utf-8",
+      mode: 0o600,
+    });
+    renameSync(temporaryFile, this.storeFile);
+    chmodSync(this.storeFile, 0o600);
+  }
+}
+
+function clonePersistedActiveSession(
+  session: PersistedActiveSession,
+): PersistedActiveSession {
+  return {
+    ...session,
+    claudeSettings: session.claudeSettings
+      ? { ...session.claudeSettings }
+      : undefined,
+    codexSettings: session.codexSettings
+      ? {
+          ...session.codexSettings,
+          additionalWritableRoots:
+            session.codexSettings.additionalWritableRoots == null
+              ? undefined
+              : [...session.codexSettings.additionalWritableRoots],
+        }
+      : undefined,
+    codexQueuedInput: session.codexQueuedInput
+      ? {
+          ...session.codexQueuedInput,
+          images: session.codexQueuedInput.images?.map((image) => ({
+            ...image,
+          })),
+          imageRefs: session.codexQueuedInput.imageRefs?.map((image) => ({
+            ...image,
+          })),
+          skills: session.codexQueuedInput.skills?.map((skill) => ({
+            ...skill,
+          })),
+          mentions: session.codexQueuedInput.mentions?.map((mention) => ({
+            ...mention,
+          })),
+        }
+      : undefined,
+  };
+}
+
+function isPersistedActiveSession(
+  value: unknown,
+): value is PersistedActiveSession {
+  if (!value || typeof value !== "object") return false;
+  const session = value as Partial<PersistedActiveSession>;
+  return (
+    (session.provider === "claude" || session.provider === "codex") &&
+    typeof session.bridgeSessionId === "string" &&
+    session.bridgeSessionId.length > 0 &&
+    typeof session.providerSessionId === "string" &&
+    session.providerSessionId.length > 0 &&
+    typeof session.projectPath === "string" &&
+    session.projectPath.length > 0 &&
+    typeof session.createdAt === "string" &&
+    typeof session.lastActivityAt === "string" &&
+    typeof session.lastMessage === "string"
+  );
+}

--- a/packages/bridge/src/codex-process.ts
+++ b/packages/bridge/src/codex-process.ts
@@ -534,8 +534,12 @@ export class CodexProcess extends EventEmitter<CodexProcessEvents> {
     if (!this._threadId) {
       throw new Error("No thread ID available for rename");
     }
+    await this.renameThreadById(this._threadId, name);
+  }
+
+  async renameThreadById(threadId: string, name: string): Promise<void> {
     await this.request("thread/name/set", {
-      threadId: this._threadId,
+      threadId,
       name,
     });
   }
@@ -545,8 +549,12 @@ export class CodexProcess extends EventEmitter<CodexProcessEvents> {
     if (!this._threadId) {
       throw new Error("No thread ID available for goal lookup");
     }
+    return this.getGoalByThreadId(this._threadId);
+  }
+
+  async getGoalByThreadId(threadId: string): Promise<CodexGoal | null> {
     const response = (await this.request("thread/goal/get", {
-      threadId: this._threadId,
+      threadId,
     })) as Record<string, unknown>;
     return response.goal == null ? null : parseCodexGoal(response.goal);
   }
@@ -559,8 +567,15 @@ export class CodexProcess extends EventEmitter<CodexProcessEvents> {
     if (!this._threadId) {
       throw new Error("No thread ID available for goal update");
     }
+    return this.setGoalByThreadId(this._threadId, update);
+  }
+
+  async setGoalByThreadId(
+    threadId: string,
+    update: { objective?: string; status?: CodexGoalStatus },
+  ): Promise<CodexGoal> {
     const response = (await this.request("thread/goal/set", {
-      threadId: this._threadId,
+      threadId,
       ...(update.objective !== undefined
         ? { objective: update.objective.trim() }
         : {}),
@@ -574,8 +589,12 @@ export class CodexProcess extends EventEmitter<CodexProcessEvents> {
     if (!this._threadId) {
       throw new Error("No thread ID available for goal clear");
     }
+    return this.clearGoalByThreadId(this._threadId);
+  }
+
+  async clearGoalByThreadId(threadId: string): Promise<boolean> {
     const response = (await this.request("thread/goal/clear", {
-      threadId: this._threadId,
+      threadId,
     })) as Record<string, unknown>;
     if (typeof response.cleared !== "boolean") {
       throw new Error("thread/goal/clear returned an invalid response");
@@ -636,16 +655,24 @@ export class CodexProcess extends EventEmitter<CodexProcessEvents> {
     if (!this._threadId) {
       throw new Error("No thread ID available for fork");
     }
+    return this.forkThreadById(this._threadId);
+  }
+
+  async forkThreadById(threadId: string): Promise<{
+    threadId: string;
+    thread: Record<string, unknown>;
+  }> {
     const response = (await this.request("thread/fork", {
-      threadId: this._threadId,
+      threadId,
       persistExtendedHistory: true,
     })) as Record<string, unknown>;
     const thread = response.thread as Record<string, unknown> | undefined;
-    const threadId = typeof thread?.id === "string" ? thread.id : undefined;
-    if (!thread || !threadId) {
+    const forkedThreadId =
+      typeof thread?.id === "string" ? thread.id : undefined;
+    if (!thread || !forkedThreadId) {
       throw new Error("thread/fork returned no thread id");
     }
-    return { threadId, thread };
+    return { threadId: forkedThreadId, thread };
   }
 
   async listThreads(
@@ -943,12 +970,12 @@ export class CodexProcess extends EventEmitter<CodexProcessEvents> {
       skills?: Array<{ name: string; path: string }>;
       mentions?: Array<{ name: string; path: string }>;
     },
-  ): void {
+  ): boolean {
     if (!this.inputResolve) {
       console.error(
         "[codex-process] No pending input resolver for sendInputStructured",
       );
-      return;
+      return false;
     }
     const resolve = this.inputResolve;
     this.inputResolve = null;
@@ -958,6 +985,7 @@ export class CodexProcess extends EventEmitter<CodexProcessEvents> {
       skills: options?.skills,
       mentions: options?.mentions,
     });
+    return true;
   }
 
   async steerInputStructured(

--- a/packages/bridge/src/index.ts
+++ b/packages/bridge/src/index.ts
@@ -19,6 +19,10 @@ import {
   promptHistoryStoreFileForPort,
   PromptHistoryStore,
 } from "./prompt-history-store.js";
+import {
+  activeSessionStoreFileForPort,
+  ActiveSessionStore,
+} from "./active-session-store.js";
 import { parseAllowedDirectories } from "./path-utils.js";
 import { parseBridgePort } from "./bridge-port.js";
 import { listenForStartup } from "./server-listen.js";
@@ -87,6 +91,15 @@ export async function startServer() {
       process.env.BRIDGE_PROMPT_HISTORY_FILE,
     ),
   );
+  const activeSessionStore =
+    process.env.BRIDGE_DISABLE_ACTIVE_SESSIONS === "1"
+      ? null
+      : new ActiveSessionStore(
+          activeSessionStoreFileForPort(
+            PORT,
+            process.env.BRIDGE_ACTIVE_SESSIONS_FILE,
+          ),
+        );
   const mdns = MDNS_ENABLED ? new MdnsAdvertiser() : undefined;
 
   // Initialize stores (async)
@@ -223,6 +236,7 @@ export async function startServer() {
     firebaseAuth,
     promptHistoryBackup,
     promptHistoryStore,
+    activeSessionStore,
   });
 
   function shutdown() {

--- a/packages/bridge/src/sdk-process.test.ts
+++ b/packages/bridge/src/sdk-process.test.ts
@@ -1063,6 +1063,51 @@ describe("SdkProcess Claude authentication", () => {
     expect(exits).toEqual([0]);
   });
 
+  it("suppresses estimated API cost when resumed OAuth auth is resolved separately", async () => {
+    vi.stubEnv("BRIDGE_ALLOW_CLAUDE_OAUTH", "1");
+    const proc = new SdkProcess();
+    const messages: ServerMessage[] = [];
+    const exits: Array<number | null> = [];
+    proc.on("message", (message) => messages.push(message));
+    proc.on("exit", (code) => exits.push(code));
+
+    mockSdkQuery.mockReturnValueOnce({
+      async *[Symbol.asyncIterator]() {
+        yield {
+          type: "system",
+          subtype: "init",
+          session_id: "resumed-oauth-session",
+          model: "claude-opus-4-6",
+          apiKeySource: "api_key",
+        };
+        yield {
+          type: "result",
+          subtype: "success",
+          result: "Done",
+          total_cost_usd: 3.029,
+          duration_ms: 156300,
+          session_id: "resumed-oauth-session",
+        };
+      },
+      close: vi.fn(),
+      supportedCommands: vi.fn().mockResolvedValue([]),
+      initializationResult: vi.fn().mockResolvedValue({
+        account: { apiKeySource: "oauth", subscriptionType: "max" },
+        models: [],
+      }),
+    });
+
+    proc.start(process.cwd(), { sessionId: "resumed-oauth-session" });
+    await vi.waitFor(() => expect(exits).toEqual([0]));
+
+    expect(messages).toContainEqual(
+      expect.objectContaining({ type: "result", subtype: "success" }),
+    );
+    expect(messages).not.toContainEqual(
+      expect.objectContaining({ type: "result", cost: expect.any(Number) }),
+    );
+  });
+
   it("shows explicit Claude assistant errors without dropping partial text", async () => {
     vi.stubEnv("ANTHROPIC_API_KEY", "sk-ant-test");
     const proc = new SdkProcess();

--- a/packages/bridge/src/sdk-process.test.ts
+++ b/packages/bridge/src/sdk-process.test.ts
@@ -432,6 +432,26 @@ describe("sdkMessageToServerMessage", () => {
     });
   });
 
+  describe("Claude status handling", () => {
+    it("surfaces context compaction failures", () => {
+      expect(
+        sdkMessageToServerMessage({
+          type: "system",
+          subtype: "status",
+          status: null,
+          compact_result: "failed",
+          compact_error: "summary request timed out",
+          session_id: "test-session",
+        } as any),
+      ).toEqual({
+        type: "error",
+        message:
+          "Claude context compaction failed: summary request timed out",
+        errorCode: "claude_compaction_failed",
+      });
+    });
+  });
+
   describe("UUID tracking", () => {
     it("removes empty thinking blocks from assistant messages", () => {
       const sdkMsg = {
@@ -858,6 +878,26 @@ describe("SdkProcess input dispatch", () => {
     ).toEqual({ queued: true, shouldInterrupt: true });
     expect(resolve).not.toHaveBeenCalled();
   });
+
+  it("tracks Claude compaction and request status messages", () => {
+    const proc = new SdkProcess();
+    const internal = proc as any;
+    internal._status = "running";
+
+    internal.updateStatusFromMessage({
+      type: "system",
+      subtype: "status",
+      status: "compacting",
+    });
+    expect(proc.status).toBe("compacting");
+
+    internal.updateStatusFromMessage({
+      type: "system",
+      subtype: "status",
+      status: "requesting",
+    });
+    expect(proc.status).toBe("running");
+  });
 });
 
 describe("SdkProcess Claude authentication", () => {
@@ -1021,6 +1061,64 @@ describe("SdkProcess Claude authentication", () => {
       expect.objectContaining({ type: "result", cost: expect.any(Number) }),
     );
     expect(exits).toEqual([0]);
+  });
+
+  it("shows explicit Claude assistant errors without dropping partial text", async () => {
+    vi.stubEnv("ANTHROPIC_API_KEY", "sk-ant-test");
+    const proc = new SdkProcess();
+    const messages: ServerMessage[] = [];
+    const exits: Array<number | null> = [];
+    proc.on("message", (message) => messages.push(message));
+    proc.on("exit", (code) => exits.push(code));
+
+    mockSdkQuery.mockReturnValueOnce({
+      async *[Symbol.asyncIterator]() {
+        yield {
+          type: "system",
+          subtype: "init",
+          session_id: "partial-error-session",
+          model: "claude-sonnet-4-6",
+          apiKeySource: "api_key",
+        };
+        yield {
+          type: "assistant",
+          session_id: "partial-error-session",
+          uuid: "assistant-error",
+          error: "max_output_tokens",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "Partial useful response" }],
+          },
+        };
+        yield {
+          type: "result",
+          subtype: "error_during_execution",
+          errors: [
+            "[ede_diagnostic] result_type=assistant last_content_type=text stop_reason=max_tokens",
+          ],
+          session_id: "partial-error-session",
+        };
+      },
+      close: vi.fn(),
+      supportedCommands: vi.fn().mockResolvedValue([]),
+    });
+
+    proc.start(process.cwd());
+    await vi.waitFor(() => expect(exits).toEqual([0]));
+
+    expect(messages).toContainEqual(
+      expect.objectContaining({
+        type: "assistant",
+        message: expect.objectContaining({
+          content: [{ type: "text", text: "Partial useful response" }],
+        }),
+      }),
+    );
+    expect(messages).toContainEqual({
+      type: "error",
+      message: "Claude reached the maximum response length before finishing.",
+      errorCode: "claude_max_output_tokens",
+    });
   });
 
   it("rejects an unexpected OAuth init when only an API key was configured", async () => {

--- a/packages/bridge/src/sdk-process.test.ts
+++ b/packages/bridge/src/sdk-process.test.ts
@@ -336,6 +336,41 @@ describe("sdkMessageToServerMessage", () => {
       });
     });
 
+    it("suppresses Claude's internal EDE diagnostic result", () => {
+      const sdkMsg = {
+        type: "result" as const,
+        subtype: "error_during_execution",
+        errors: [
+          "[ede_diagnostic] result_type=user last_content_type=n/a stop_reason=tool_use",
+        ],
+        stop_reason: "tool_use",
+        session_id: "test-session",
+      };
+
+      expect(sdkMessageToServerMessage(sdkMsg as any)).toBeNull();
+    });
+
+    it("keeps a real error while removing its internal EDE diagnostic", () => {
+      const sdkMsg = {
+        type: "result" as const,
+        subtype: "error_during_execution",
+        errors: [
+          "[ede_diagnostic] result_type=user last_content_type=n/a stop_reason=tool_use",
+          "MCP server disconnected",
+        ],
+        stop_reason: "tool_use",
+        session_id: "test-session",
+      };
+
+      expect(sdkMessageToServerMessage(sdkMsg as any)).toEqual({
+        type: "result",
+        subtype: "error",
+        error: "MCP server disconnected",
+        sessionId: "test-session",
+        stopReason: "tool_use",
+      });
+    });
+
     it("omits stopReason when not present in SDK message", () => {
       const sdkMsg = {
         type: "result" as const,

--- a/packages/bridge/src/sdk-process.test.ts
+++ b/packages/bridge/src/sdk-process.test.ts
@@ -636,6 +636,30 @@ describe("sdkMessageToServerMessage", () => {
       });
     });
 
+    it("marks internal task notifications as synthetic when the SDK omits the flag", () => {
+      const sdkMsg = {
+        type: "user" as const,
+        message: {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: "<task-notification>\n<status>killed</status>\n</task-notification>",
+            },
+          ],
+        },
+        uuid: "usr-task-111" as `${string}-${string}-${string}-${string}-${string}`,
+        session_id: "test-session",
+      };
+
+      const serverMsg = sdkMessageToServerMessage(sdkMsg as any);
+
+      expect(serverMsg).toMatchObject({
+        type: "user_input",
+        isSynthetic: true,
+      });
+    });
+
     it("omits isSynthetic when not set on user message", () => {
       const sdkMsg = {
         type: "user" as const,
@@ -1164,6 +1188,64 @@ describe("SdkProcess Claude authentication", () => {
       message: "Claude reached the maximum response length before finishing.",
       errorCode: "claude_max_output_tokens",
     });
+  });
+
+  it("does not duplicate an invalid request already explained by Claude", async () => {
+    vi.stubEnv("ANTHROPIC_API_KEY", "sk-ant-test");
+    const proc = new SdkProcess();
+    const messages: ServerMessage[] = [];
+    const exits: Array<number | null> = [];
+    proc.on("message", (message) => messages.push(message));
+    proc.on("exit", (code) => exits.push(code));
+
+    mockSdkQuery.mockReturnValueOnce({
+      async *[Symbol.asyncIterator]() {
+        yield {
+          type: "system",
+          subtype: "init",
+          session_id: "image-error-session",
+          model: "claude-opus-4-1",
+          apiKeySource: "api_key",
+        };
+        yield {
+          type: "assistant",
+          session_id: "image-error-session",
+          uuid: "assistant-image-error",
+          error: "invalid_request",
+          message: {
+            role: "assistant",
+            content: [
+              {
+                type: "text",
+                text: "API Error: an image in the conversation could not be processed and was removed.",
+              },
+            ],
+          },
+        };
+      },
+      close: vi.fn(),
+      supportedCommands: vi.fn().mockResolvedValue([]),
+    });
+
+    proc.start(process.cwd());
+    await vi.waitFor(() => expect(exits).toEqual([0]));
+
+    expect(messages).toContainEqual(
+      expect.objectContaining({
+        type: "assistant",
+        message: expect.objectContaining({
+          content: [
+            expect.objectContaining({
+              type: "text",
+              text: expect.stringContaining("image in the conversation"),
+            }),
+          ],
+        }),
+      }),
+    );
+    expect(messages).not.toContainEqual(
+      expect.objectContaining({ errorCode: "claude_invalid_request" }),
+    );
   });
 
   it("rejects an unexpected OAuth init when only an API key was configured", async () => {

--- a/packages/bridge/src/sdk-process.test.ts
+++ b/packages/bridge/src/sdk-process.test.ts
@@ -433,6 +433,42 @@ describe("sdkMessageToServerMessage", () => {
   });
 
   describe("UUID tracking", () => {
+    it("removes empty thinking blocks from assistant messages", () => {
+      const sdkMsg = {
+        type: "assistant" as const,
+        message: {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: " \n " },
+            { type: "text", text: "Visible response" },
+          ],
+        },
+        session_id: "test-session",
+      };
+
+      const serverMsg = sdkMessageToServerMessage(sdkMsg as any);
+
+      expect(serverMsg).toMatchObject({
+        type: "assistant",
+        message: {
+          content: [{ type: "text", text: "Visible response" }],
+        },
+      });
+    });
+
+    it("drops assistant messages containing only empty thinking", () => {
+      const sdkMsg = {
+        type: "assistant" as const,
+        message: {
+          role: "assistant",
+          content: [{ type: "thinking", thinking: "" }],
+        },
+        session_id: "test-session",
+      };
+
+      expect(sdkMessageToServerMessage(sdkMsg as any)).toBeNull();
+    });
+
     it("includes messageUuid for assistant messages with uuid", () => {
       const sdkMsg = {
         type: "assistant" as const,
@@ -751,6 +787,31 @@ describe("SdkProcess input dispatch", () => {
     expect(proc.hasInputQueue).toBe(true);
   });
 
+  it("delivers the queued follow-up when an interrupted turn completes", () => {
+    const proc = new SdkProcess();
+    const resolve = vi.fn();
+    const internal = proc as any;
+    internal._status = "running";
+    internal.userMessageResolve = resolve;
+
+    proc.dispatchInput("follow up");
+    internal.updateStatusFromMessage({
+      type: "result",
+      subtype: "error_during_execution",
+    });
+
+    expect(resolve).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "user",
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "follow up" }],
+        },
+      }),
+    );
+    expect(proc.hasInputQueue).toBe(false);
+  });
+
   it("queues without interrupting while approval is pending", () => {
     const proc = new SdkProcess();
     const resolve = vi.fn();
@@ -927,6 +988,14 @@ describe("SdkProcess Claude authentication", () => {
     mockSdkQuery.mockReturnValueOnce({
       async *[Symbol.asyncIterator]() {
         yield initMessage;
+        yield {
+          type: "result",
+          subtype: "success",
+          result: "Done",
+          total_cost_usd: 4.7011,
+          duration_ms: 26400,
+          session_id: "oauth-session",
+        };
       },
       close,
       supportedCommands: vi.fn().mockResolvedValue([]),
@@ -945,6 +1014,12 @@ describe("SdkProcess Claude authentication", () => {
     expect(messages).not.toContainEqual(expect.objectContaining({
       type: "error",
     }));
+    expect(messages).toContainEqual(
+      expect.objectContaining({ type: "result", subtype: "success" }),
+    );
+    expect(messages).not.toContainEqual(
+      expect.objectContaining({ type: "result", cost: expect.any(Number) }),
+    );
     expect(exits).toEqual([0]);
   });
 

--- a/packages/bridge/src/sdk-process.ts
+++ b/packages/bridge/src/sdk-process.ts
@@ -402,9 +402,21 @@ export function sdkMessageToServerMessage(msg: SDKMessage): ServerMessage | null
 
     case "assistant": {
       const ast = msg as unknown as { message: Record<string, unknown>; uuid?: string };
+      const rawContent = ast.message.content;
+      const content = Array.isArray(rawContent)
+        ? rawContent.filter((item) => {
+            const block = item as Record<string, unknown>;
+            return block.type !== "thinking" ||
+              (typeof block.thinking === "string" && block.thinking.trim().length > 0);
+          })
+        : rawContent;
+      if (Array.isArray(content) && content.length === 0) return null;
       return {
         type: "assistant",
-        message: ast.message as ServerMessage extends { type: "assistant" } ? ServerMessage["message"] : never,
+        message: {
+          ...ast.message,
+          content,
+        } as ServerMessage extends { type: "assistant" } ? ServerMessage["message"] : never,
         ...(ast.uuid ? { messageUuid: ast.uuid } : {}),
       } as ServerMessage;
     }
@@ -585,6 +597,7 @@ export class SdkProcess extends EventEmitter<SdkProcessEvents> {
   get permissionMode(): PermissionMode | undefined { return this._permissionMode; }
   private _model: string | undefined;
   get model(): string | undefined { return this._model; }
+  private usesSubscriptionAuth = false;
   private sessionAllowRules = new Set<string>();
 
   private initTimeoutId: ReturnType<typeof setTimeout> | null = null;
@@ -633,6 +646,7 @@ export class SdkProcess extends EventEmitter<SdkProcessEvents> {
 
     this.stopped = false;
     this._sessionId = null;
+    this.usesSubscriptionAuth = false;
     this.sessionEndEmitted = false;
     this.pendingPermissions.clear();
     this.permissionModeGeneration += 1;
@@ -801,6 +815,44 @@ export class SdkProcess extends EventEmitter<SdkProcessEvents> {
     return this.pendingInputQueue.length > 0;
   }
 
+  private buildUserMessage(
+    text: string,
+    images?: Array<{ base64: string; mimeType: string }>,
+  ): SDKUserMsg {
+    const content: SDKUserMsg["message"]["content"] = [];
+    for (const image of images ?? []) {
+      content.push({
+        type: "image",
+        source: {
+          type: "base64",
+          media_type: image.mimeType as ImageMediaType,
+          data: image.base64,
+        },
+      });
+    }
+    content.push({ type: "text", text });
+    return {
+      type: "user",
+      session_id: this._sessionId ?? "",
+      message: { role: "user", content },
+      parent_tool_use_id: null,
+    };
+  }
+
+  private deliverQueuedInputIfWaiting(): void {
+    const resolve = this.userMessageResolve;
+    const queued = this.pendingInputQueue.shift();
+    if (!resolve || !queued) {
+      if (queued) this.pendingInputQueue.unshift(queued);
+      return;
+    }
+    this.userMessageResolve = null;
+    console.log(
+      `[sdk-process] Delivering queued input after turn completion (remaining: ${this.pendingInputQueue.length})`,
+    );
+    resolve(this.buildUserMessage(queued.text, queued.images));
+  }
+
   dispatchInput(text: string): { queued: boolean; shouldInterrupt: boolean } {
     const shouldInterrupt =
       this._status === "running" || this._status === "compacting";
@@ -815,15 +867,7 @@ export class SdkProcess extends EventEmitter<SdkProcessEvents> {
     }
     const resolve = this.userMessageResolve;
     this.userMessageResolve = null;
-    resolve({
-      type: "user",
-      session_id: this._sessionId ?? "",
-      message: {
-        role: "user",
-        content: [{ type: "text", text }],
-      },
-      parent_tool_use_id: null,
-    });
+    resolve(this.buildUserMessage(text));
     return { queued: false, shouldInterrupt: false };
   }
 
@@ -851,35 +895,9 @@ export class SdkProcess extends EventEmitter<SdkProcessEvents> {
     const resolve = this.userMessageResolve;
     this.userMessageResolve = null;
 
-    const content: SDKUserMsg["message"]["content"] = [];
-
-    // Add image blocks first (Claude processes images before text)
-    for (const image of images) {
-      content.push({
-        type: "image",
-        source: {
-          type: "base64",
-          media_type: image.mimeType as ImageMediaType,
-          data: image.base64,
-        },
-      });
-    }
-
-    // Add text block
-    content.push({ type: "text", text });
-
     const totalKB = images.reduce((sum, img) => sum + Math.round(img.base64.length / 1024), 0);
     console.log(`[sdk-process] Sending message with ${images.length} image(s) (${totalKB}KB base64 total)`);
-
-    resolve({
-      type: "user",
-      session_id: this._sessionId ?? "",
-      message: {
-        role: "user",
-        content,
-      },
-      parent_tool_use_id: null,
-    });
+    resolve(this.buildUserMessage(text, images));
     return { queued: false, shouldInterrupt: false };
   }
 
@@ -1153,29 +1171,7 @@ export class SdkProcess extends EventEmitter<SdkProcessEvents> {
       if (this.pendingInputQueue.length > 0) {
         const { text, images } = this.pendingInputQueue.shift()!;
         console.log(`[sdk-process] Sending queued input${images ? ` with ${images.length} image(s)` : ""} (remaining: ${this.pendingInputQueue.length})`);
-        const content: SDKUserMsg["message"]["content"] = [];
-        if (images) {
-          for (const image of images) {
-            content.push({
-              type: "image",
-              source: {
-                type: "base64",
-                media_type: image.mimeType as ImageMediaType,
-                data: image.base64,
-              },
-            });
-          }
-        }
-        content.push({ type: "text", text });
-        yield {
-          type: "user",
-          session_id: this._sessionId ?? "",
-          message: {
-            role: "user",
-            content,
-          },
-          parent_tool_use_id: null,
-        };
+        yield this.buildUserMessage(text, images);
         continue;
       }
       const msg = await new Promise<SDKUserMsg>((resolve) => {
@@ -1213,6 +1209,10 @@ export class SdkProcess extends EventEmitter<SdkProcessEvents> {
       // Convert SDK message to ServerMessage
       let serverMsg = sdkMessageToServerMessage(message);
       if (serverMsg?.type === "result") {
+        if (this.usesSubscriptionAuth) {
+          const { cost: _estimatedApiCost, ...withoutCost } = serverMsg;
+          serverMsg = withoutCost as ServerMessage;
+        }
         if (this.toolCallsSinceLastResult > 0 || this.fileEditsSinceLastResult > 0) {
           serverMsg = {
             ...serverMsg,
@@ -1238,6 +1238,8 @@ export class SdkProcess extends EventEmitter<SdkProcessEvents> {
           this.initTimeoutId = null;
         }
         this._sessionId = message.session_id;
+        this.usesSubscriptionAuth =
+          (message as Record<string, unknown>).apiKeySource === "oauth";
         const initModel = (message as Record<string, unknown>).model;
         if (typeof initModel === "string" && initModel) {
           this._model = initModel;
@@ -1362,6 +1364,7 @@ export class SdkProcess extends EventEmitter<SdkProcessEvents> {
       case "result":
         this.pendingPermissions.clear();
         this.setStatus("idle");
+        this.deliverQueuedInputIfWaiting();
         break;
     }
   }

--- a/packages/bridge/src/sdk-process.ts
+++ b/packages/bridge/src/sdk-process.ts
@@ -467,8 +467,24 @@ export function sdkMessageToServerMessage(msg: SDKMessage): ServerMessage | null
           ...tokenUsage,
         };
       }
+      // Claude Code can misclassify a routine interrupt as
+      // error_during_execution and prepend an internal-only EDE diagnostic.
+      // Its own terminal renderer filters these records, so keep the same
+      // boundary here while preserving any accompanying real error.
+      const rawErrors = Array.isArray(res.errors)
+        ? (res.errors as unknown[]).filter(
+            (error): error is string => typeof error === "string",
+          )
+        : [];
+      const visibleErrors = rawErrors.filter(
+        (error) => !error.startsWith("[ede_diagnostic]"),
+      );
+      if (rawErrors.length > 0 && visibleErrors.length === 0) {
+        return null;
+      }
       // All other result subtypes are errors
-      const errorText = Array.isArray(res.errors) ? (res.errors as string[]).join("\n") : "Unknown error";
+      const errorText =
+        visibleErrors.length > 0 ? visibleErrors.join("\n") : "Unknown error";
       // Suppress spurious CLI runtime errors (SDK bug: Bun API referenced on Node.js)
       if (errorText.includes("Bun is not defined")) {
         return null;

--- a/packages/bridge/src/sdk-process.ts
+++ b/packages/bridge/src/sdk-process.ts
@@ -625,6 +625,9 @@ export class SdkProcess extends EventEmitter<SdkProcessEvents> {
       this._permissionMode,
       options?.permissionMode,
     );
+    // Keep the requested model visible before the SDK's init event. This is
+    // also the value the Bridge persists if it restarts while Claude is idle.
+    this._model = options?.model;
     this.sessionAllowRules.clear();
     this.toolCallsSinceLastResult = 0;
     this.fileEditsSinceLastResult = 0;

--- a/packages/bridge/src/sdk-process.ts
+++ b/packages/bridge/src/sdk-process.ts
@@ -376,6 +376,31 @@ export interface RewindFilesResult {
   deletions?: number;
 }
 
+const CLAUDE_ASSISTANT_ERROR_MESSAGES: Record<string, string> = {
+  authentication_failed: "Claude authentication failed. Sign in again on the Bridge machine.",
+  oauth_org_not_allowed: "This Claude subscription organization cannot be used by the Agent SDK.",
+  billing_error: "Claude could not continue because of an account billing error.",
+  rate_limit: "Claude is temporarily rate limited. Try again shortly.",
+  invalid_request: "Claude rejected this request as invalid.",
+  model_not_found: "The selected Claude model is not available for this account.",
+  server_error: "Claude encountered a server error.",
+  unknown: "Claude stopped because of an unknown request error.",
+  max_output_tokens: "Claude reached the maximum response length before finishing.",
+};
+
+function claudeAssistantErrorMessage(error: string): ServerMessage {
+  return {
+    type: "error",
+    message:
+      CLAUDE_ASSISTANT_ERROR_MESSAGES[error] ??
+      `Claude stopped: ${error.replaceAll("_", " ")}.`,
+    errorCode:
+      error === "authentication_failed"
+        ? "auth_token_expired"
+        : `claude_${error}`,
+  };
+}
+
 /**
  * Convert SDK messages to the ServerMessage format used by the WebSocket protocol.
  * Exported for testing.
@@ -396,6 +421,16 @@ export function sdkMessageToServerMessage(msg: SDKMessage): ServerMessage | null
       }
       if (sys.subtype === "compact_boundary") {
         return { type: "status", status: "compacting" as ProcessStatus };
+      }
+      if (sys.subtype === "status" && sys.compact_result === "failed") {
+        return {
+          type: "error",
+          message:
+            typeof sys.compact_error === "string" && sys.compact_error
+              ? `Claude context compaction failed: ${sys.compact_error}`
+              : "Claude context compaction failed.",
+          errorCode: "claude_compaction_failed",
+        };
       }
       return null;
     }
@@ -1230,6 +1265,12 @@ export class SdkProcess extends EventEmitter<SdkProcessEvents> {
       if (serverMsg) {
         this.emitMessage(serverMsg);
       }
+      if (message.type === "assistant") {
+        const assistantError = (message as Record<string, unknown>).error;
+        if (typeof assistantError === "string" && assistantError) {
+          this.emitMessage(claudeAssistantErrorMessage(assistantError));
+        }
+      }
 
       // Extract session ID and model from system/init
       if (message.type === "system" && "subtype" in message && (message as Record<string, unknown>).subtype === "init") {
@@ -1348,9 +1389,19 @@ export class SdkProcess extends EventEmitter<SdkProcessEvents> {
 
   private updateStatusFromMessage(msg: SDKMessage): void {
     switch (msg.type) {
-      case "system":
-        // Already handled in processMessages for init
+      case "system": {
+        const sys = msg as Record<string, unknown>;
+        if (sys.subtype === "status") {
+          if (sys.status === "compacting") {
+            this.setStatus("compacting");
+          } else if (sys.status === "requesting") {
+            this.setStatus("running");
+          } else if (sys.status === null && this._status === "compacting") {
+            this.setStatus("running");
+          }
+        }
         break;
+      }
       case "assistant":
         if (this.pendingPermissions.size === 0) {
           this.setStatus("running");

--- a/packages/bridge/src/sdk-process.ts
+++ b/packages/bridge/src/sdk-process.ts
@@ -633,6 +633,7 @@ export class SdkProcess extends EventEmitter<SdkProcessEvents> {
   private _model: string | undefined;
   get model(): string | undefined { return this._model; }
   private usesSubscriptionAuth = false;
+  private subscriptionAuthResolution: Promise<void> | null = null;
   private sessionAllowRules = new Set<string>();
 
   private initTimeoutId: ReturnType<typeof setTimeout> | null = null;
@@ -682,6 +683,7 @@ export class SdkProcess extends EventEmitter<SdkProcessEvents> {
     this.stopped = false;
     this._sessionId = null;
     this.usesSubscriptionAuth = false;
+    this.subscriptionAuthResolution = null;
     this.sessionEndEmitted = false;
     this.pendingPermissions.clear();
     this.permissionModeGeneration += 1;
@@ -787,6 +789,22 @@ export class SdkProcess extends EventEmitter<SdkProcessEvents> {
         },
       },
     });
+
+    const queryInstance = this.queryInstance;
+    if (queryInstance && typeof queryInstance.initializationResult === "function") {
+      this.subscriptionAuthResolution = queryInstance.initializationResult()
+        .then((initialization) => {
+          if (this.queryInstance === queryInstance) {
+            this.usesSubscriptionAuth ||=
+              initialization.account.apiKeySource === "oauth";
+          }
+        })
+        .catch((error: unknown) => {
+          console.warn(
+            `[sdk-process] Could not resolve Claude auth source: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        });
+    }
 
     // Background message processing
     this.processMessages().catch((err) => {
@@ -1244,6 +1262,7 @@ export class SdkProcess extends EventEmitter<SdkProcessEvents> {
       // Convert SDK message to ServerMessage
       let serverMsg = sdkMessageToServerMessage(message);
       if (serverMsg?.type === "result") {
+        await this.subscriptionAuthResolution;
         if (this.usesSubscriptionAuth) {
           const { cost: _estimatedApiCost, ...withoutCost } = serverMsg;
           serverMsg = withoutCost as ServerMessage;
@@ -1279,7 +1298,7 @@ export class SdkProcess extends EventEmitter<SdkProcessEvents> {
           this.initTimeoutId = null;
         }
         this._sessionId = message.session_id;
-        this.usesSubscriptionAuth =
+        this.usesSubscriptionAuth ||=
           (message as Record<string, unknown>).apiKeySource === "oauth";
         const initModel = (message as Record<string, unknown>).model;
         if (typeof initModel === "string" && initModel) {

--- a/packages/bridge/src/sdk-process.ts
+++ b/packages/bridge/src/sdk-process.ts
@@ -388,6 +388,17 @@ const CLAUDE_ASSISTANT_ERROR_MESSAGES: Record<string, string> = {
   max_output_tokens: "Claude reached the maximum response length before finishing.",
 };
 
+const CLAUDE_SYSTEM_INJECTED_USER_TEXT =
+  /^<(?:local-command-caveat|local-command-std(?:err|out)|task-notification|teammate-message|bash-(?:input|stdout))>/;
+
+function isClaudeSystemInjectedUserText(text: string): boolean {
+  const normalized = text.trimStart();
+  return (
+    CLAUDE_SYSTEM_INJECTED_USER_TEXT.test(normalized) ||
+    normalized.startsWith("Base directory for this skill:")
+  );
+}
+
 function claudeAssistantErrorMessage(error: string): ServerMessage {
   return {
     type: "error",
@@ -399,6 +410,24 @@ function claudeAssistantErrorMessage(error: string): ServerMessage {
         ? "auth_token_expired"
         : `claude_${error}`,
   };
+}
+
+function assistantAlreadyExplainsInvalidRequest(message: SDKMessage): boolean {
+  if (message.type !== "assistant") return false;
+  const rawContent = (
+    message as unknown as { message?: { content?: unknown } }
+  ).message?.content;
+  if (!Array.isArray(rawContent)) return false;
+
+  return rawContent.some((item) => {
+    if (!item || typeof item !== "object") return false;
+    const block = item as Record<string, unknown>;
+    return (
+      block.type === "text" &&
+      typeof block.text === "string" &&
+      /^API Error:/i.test(block.text.trimStart())
+    );
+  });
 }
 
 /**
@@ -487,11 +516,14 @@ export function sdkMessageToServerMessage(msg: SDKMessage): ServerMessage | null
         .filter((c: unknown) => (c as Record<string, unknown>).type === "text")
         .map((c: unknown) => (c as Record<string, unknown>).text as string);
       if (texts.length > 0) {
+        const isSynthetic =
+          usr.isSynthetic === true ||
+          texts.every(isClaudeSystemInjectedUserText);
         return {
           type: "user_input",
           text: texts.join("\n"),
           ...(usr.uuid ? { userMessageUuid: usr.uuid } : {}),
-          ...(usr.isSynthetic ? { isSynthetic: true } : {}),
+          ...(isSynthetic ? { isSynthetic: true } : {}),
           ...(usr.isMeta ? { isMeta: true } : {}),
         } as ServerMessage;
       }
@@ -1286,7 +1318,14 @@ export class SdkProcess extends EventEmitter<SdkProcessEvents> {
       }
       if (message.type === "assistant") {
         const assistantError = (message as Record<string, unknown>).error;
-        if (typeof assistantError === "string" && assistantError) {
+        if (
+          typeof assistantError === "string" &&
+          assistantError &&
+          !(
+            assistantError === "invalid_request" &&
+            assistantAlreadyExplainsInvalidRequest(message)
+          )
+        ) {
           this.emitMessage(claudeAssistantErrorMessage(assistantError));
         }
       }

--- a/packages/bridge/src/session.test.ts
+++ b/packages/bridge/src/session.test.ts
@@ -17,7 +17,7 @@ const { codexInstances, sdkInstances, fakeDirs, fakeFiles } = vi.hoisted(
       emit: (event: string, ...args: unknown[]) => boolean;
     }>,
     sdkInstances: [] as Array<{
-      permissionMode: string;
+      permissionMode: string | undefined;
       start: ReturnType<typeof vi.fn>;
       stop: ReturnType<typeof vi.fn>;
       rewindFiles: ReturnType<typeof vi.fn>;
@@ -78,7 +78,7 @@ vi.mock("./codex-process.js", () => ({
     public isWaitingForInput = false;
     public start = vi.fn((_: string, __?: unknown) => {});
     public stop = vi.fn(() => {});
-    public sendInputStructured = vi.fn();
+    public sendInputStructured = vi.fn(() => true);
     public steerInputStructured = vi.fn(async () => {});
 
     constructor() {
@@ -90,8 +90,10 @@ vi.mock("./codex-process.js", () => ({
 
 vi.mock("./sdk-process.js", () => ({
   SdkProcess: class MockSdkProcess extends EventEmitter {
-    public permissionMode = "default";
-    public start = vi.fn((_: string, __?: unknown) => {});
+    public permissionMode: string | undefined;
+    public start = vi.fn((_: string, options?: { permissionMode?: string }) => {
+      this.permissionMode = options?.permissionMode;
+    });
     public stop = vi.fn(() => {});
     public rewindFiles = vi.fn(async () => ({ canRewind: false }));
 
@@ -152,6 +154,105 @@ describe("SessionManager codex path", () => {
     );
   });
 
+  it("keeps restored sessions dormant and activates only the selected one", () => {
+    const manager = new SessionManager(() => {});
+    const codexSessionId = manager.create(
+      "/tmp/project-codex",
+      undefined,
+      undefined,
+      undefined,
+      "codex",
+      {
+        threadId: "thread-restored",
+        approvalPolicy: "on-request",
+        collaborationMode: "plan",
+      },
+      "bridge-codex-restored",
+      true,
+    );
+    const claudeSessionId = manager.create(
+      "/tmp/project-claude",
+      {
+        sessionId: "claude-restored",
+        permissionMode: "acceptEdits",
+        model: "claude-opus-4-7",
+      },
+      undefined,
+      undefined,
+      "claude",
+      undefined,
+      "bridge-claude-restored",
+      true,
+    );
+
+    expect(codexInstances[0].start).not.toHaveBeenCalled();
+    expect(sdkInstances[0].start).not.toHaveBeenCalled();
+    expect(manager.get(codexSessionId)?.dormant).toBe(true);
+    expect(manager.get(claudeSessionId)?.dormant).toBe(true);
+    expect(manager.list()).toMatchObject([
+      {
+        id: "bridge-codex-restored",
+        status: "idle",
+        permissionMode: "plan",
+        planMode: true,
+      },
+      {
+        id: "bridge-claude-restored",
+        status: "idle",
+        permissionMode: "acceptEdits",
+        model: "claude-opus-4-7",
+      },
+    ]);
+
+    manager.activate(claudeSessionId);
+
+    expect(sdkInstances[0].start).toHaveBeenCalledTimes(1);
+    expect(sdkInstances[0].start).toHaveBeenCalledWith(
+      "/tmp/project-claude",
+      expect.objectContaining({
+        sessionId: "claude-restored",
+        permissionMode: "acceptEdits",
+        model: "claude-opus-4-7",
+      }),
+    );
+    expect(codexInstances[0].start).not.toHaveBeenCalled();
+    expect(manager.get(claudeSessionId)?.dormant).toBe(false);
+
+    manager.activate(codexSessionId);
+
+    expect(codexInstances[0].start).toHaveBeenCalledWith(
+      "/tmp/project-codex",
+      expect.objectContaining({
+        threadId: "thread-restored",
+        approvalPolicy: "on-request",
+        collaborationMode: "plan",
+      }),
+    );
+    expect(manager.get(codexSessionId)?.dormant).toBe(false);
+  });
+
+  it("does not evict dormant restored sessions from the active set", () => {
+    const manager = new SessionManager(() => {});
+
+    for (let index = 0; index < 31; index += 1) {
+      manager.create(
+        `/tmp/project-restored-${index}`,
+        undefined,
+        undefined,
+        undefined,
+        "codex",
+        { threadId: `thread-restored-${index}` },
+        `bridge-restored-${index}`,
+        true,
+      );
+    }
+
+    expect(manager.list()).toHaveLength(31);
+    expect(
+      codexInstances.every((process) => !process.start.mock.calls.length),
+    ).toBe(true);
+  });
+
   it("re-derives permissions after incremental runtime settings", () => {
     const manager = new SessionManager(() => {});
     const sessionId = manager.create(
@@ -174,8 +275,9 @@ describe("SessionManager codex path", () => {
       sandboxMode: "read-only",
     });
 
-    expect(manager.get(sessionId)?.codexSettings?.codexPermissionsMode)
-      .toBeUndefined();
+    expect(
+      manager.get(sessionId)?.codexSettings?.codexPermissionsMode,
+    ).toBeUndefined();
     expect(manager.list()[0].codexSettings?.codexPermissionsMode).toBe(
       "custom",
     );
@@ -252,8 +354,7 @@ describe("SessionManager codex path", () => {
       manager.getCachedCommands("codex", "/tmp/shared-project")?.skills,
     ).toEqual(["codex-skill"]);
     expect(
-      manager.getCachedCommands("claude", "/tmp/shared-project")
-        ?.slashCommands,
+      manager.getCachedCommands("claude", "/tmp/shared-project")?.slashCommands,
     ).toEqual(["claude-command"]);
   });
 
@@ -467,8 +568,9 @@ describe("SessionManager codex path", () => {
 
     const session = manager.get(sessionId);
     expect(session?.history).toHaveLength(100);
-    expect(session?.history.some((message) => message.type === "user_input"))
-      .toBe(false);
+    expect(
+      session?.history.some((message) => message.type === "user_input"),
+    ).toBe(false);
     expect(session?.codexLatestUserInput).toMatchObject({
       type: "user_input",
       text: "delegate this task",
@@ -836,6 +938,83 @@ describe("SessionManager codex path", () => {
     ).toBe(true);
   });
 
+  it("keeps a restored queued input retryable when startup exits", () => {
+    const manager = new SessionManager(() => {});
+    const sessionId = manager.create(
+      "/tmp/project-codex",
+      undefined,
+      undefined,
+      undefined,
+      "codex",
+      {
+        threadId: "thread-restored-queue",
+        collaborationMode: "plan",
+      },
+      "bridge-restored-queue",
+      true,
+    );
+    const session = manager.get(sessionId)!;
+    session.codexQueuedInput = {
+      itemId: "queued-restored",
+      text: "Do not lose this",
+      createdAt: "2026-08-23T10:00:00.000Z",
+    };
+    const process = codexInstances[0];
+
+    manager.activate(sessionId);
+    process.emit("exit", 1);
+
+    expect(session.dormant).toBe(true);
+    expect(session.codexQueuedInput?.text).toBe("Do not lose this");
+    expect(session.codexStartOptions?.collaborationMode).toBe("plan");
+
+    manager.activate(sessionId);
+    process.isWaitingForInput = true;
+    process.emit("input_ready");
+
+    expect(process.start).toHaveBeenCalledTimes(2);
+    expect(process.sendInputStructured).toHaveBeenCalledWith(
+      "Do not lose this",
+      { images: undefined, skills: undefined, mentions: undefined },
+    );
+    expect(session.codexQueuedInput).toBeUndefined();
+  });
+
+  it("restarts Codex when input arrives after an empty process exit", () => {
+    const manager = new SessionManager(() => {});
+    const sessionId = manager.create(
+      "/tmp/project-codex",
+      undefined,
+      undefined,
+      undefined,
+      "codex",
+      { threadId: "thread-exited-empty" },
+    );
+    const session = manager.get(sessionId)!;
+    const process = codexInstances[0];
+
+    process.emit("exit", 1);
+    expect(session.dormant).toBe(true);
+    expect(
+      manager.queueCodexInput(sessionId, {
+        itemId: "queued-after-exit",
+        text: "Retry after exit",
+        createdAt: "2026-08-23T10:00:00.000Z",
+      }),
+    ).toBe(true);
+
+    manager.activate(sessionId);
+    process.isWaitingForInput = true;
+    process.emit("input_ready");
+
+    expect(process.start).toHaveBeenCalledTimes(2);
+    expect(process.sendInputStructured).toHaveBeenCalledWith(
+      "Retry after exit",
+      { images: undefined, skills: undefined, mentions: undefined },
+    );
+    expect(session.codexQueuedInput).toBeUndefined();
+  });
+
   it("steers queued codex input and broadcasts the promoted user message", async () => {
     const forwarded: Array<{ sessionId: string; msg: ServerMessage }> = [];
     const manager = new SessionManager((sessionId, msg) => {
@@ -961,8 +1140,7 @@ describe("SessionManager codex path", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     const forwardedMsg = forwarded.at(-1)?.msg as
-      | Record<string, unknown>
-      | undefined;
+      Record<string, unknown> | undefined;
     expect(forwardedMsg).toBeDefined();
     expect(forwardedMsg?.type).toBe("tool_result");
     expect(forwardedMsg?.images).toEqual([
@@ -975,8 +1153,7 @@ describe("SessionManager codex path", () => {
     expect(forwardedMsg).not.toHaveProperty("rawContentBlocks");
 
     const historyMsg = manager.get(sessionId)?.history.at(-1) as
-      | Record<string, unknown>
-      | undefined;
+      Record<string, unknown> | undefined;
     expect(historyMsg).toBeDefined();
     expect(historyMsg?.images).toEqual([
       {
@@ -1126,7 +1303,9 @@ describe("SessionManager claude UUID backfill", () => {
       userMessageUuid: "uuid-text",
     } as ServerMessage);
 
-    const userInputs = session.history.filter((msg) => msg.type === "user_input");
+    const userInputs = session.history.filter(
+      (msg) => msg.type === "user_input",
+    );
     expect(userInputs).toHaveLength(1);
     const merged = userInputs[0] as Record<string, unknown> | undefined;
     expect(merged).toBeDefined();
@@ -1164,9 +1343,7 @@ describe("SessionManager claude UUID backfill", () => {
       userMessageUuid: "item-real-1",
     } as ServerMessage);
 
-    let userInputs = session.history.filter(
-      (msg) => msg.type === "user_input",
-    );
+    let userInputs = session.history.filter((msg) => msg.type === "user_input");
     expect(userInputs).toHaveLength(1);
     expect(userInputs[0]).toMatchObject({
       type: "user_input",
@@ -1245,9 +1422,7 @@ describe("SessionManager claude UUID backfill", () => {
         text: "repeat",
       },
     });
-    expect(
-      "userMessageUuid" in (broadcasts.at(-1)?.msg ?? {}),
-    ).toBe(false);
+    expect("userMessageUuid" in (broadcasts.at(-1)?.msg ?? {})).toBe(false);
   });
 
   it("counts resumed Codex past messages when assigning remote user turn UUIDs", () => {
@@ -1293,9 +1468,7 @@ describe("SessionManager claude UUID backfill", () => {
         text: "remote after resume",
       },
     });
-    expect(
-      "userMessageUuid" in (broadcasts.at(-1)?.msg ?? {}),
-    ).toBe(false);
+    expect("userMessageUuid" in (broadcasts.at(-1)?.msg ?? {})).toBe(false);
   });
 
   it("suppresses Codex raw user echo already restored from canonical history", () => {

--- a/packages/bridge/src/session.test.ts
+++ b/packages/bridge/src/session.test.ts
@@ -781,6 +781,30 @@ describe("SessionManager codex path", () => {
     });
   });
 
+  it("restarts and resumes Claude after its SDK process exits", () => {
+    const manager = new SessionManager(() => {});
+    const sessionId = manager.create(
+      "/tmp/project-claude",
+      { sessionId: "claude-thread-exited" },
+      undefined,
+      undefined,
+      "claude",
+    );
+    const process = sdkInstances[0];
+
+    process.emit("exit", 1);
+    expect(manager.get(sessionId)?.dormant).toBe(true);
+
+    manager.activate(sessionId);
+
+    expect(process.start).toHaveBeenCalledTimes(2);
+    expect(process.start).toHaveBeenLastCalledWith(
+      "/tmp/project-claude",
+      expect.objectContaining({ sessionId: "claude-thread-exited" }),
+    );
+    expect(manager.get(sessionId)?.dormant).toBe(false);
+  });
+
   it("evicts the least recently active idle session above the retention limit", () => {
     const onSessionUpdated = vi.fn();
     const manager = new SessionManager(

--- a/packages/bridge/src/session.ts
+++ b/packages/bridge/src/session.ts
@@ -678,12 +678,10 @@ export class SessionManager {
 
     proc.on("exit", () => {
       session.status = "idle";
-      // Keep an accepted queued prompt until it has actually been handed to
-      // Codex. Any unexpected Codex exit remains restartable, including when
-      // the next prompt is only queued after the process has already exited.
-      if (session.provider === "codex") {
-        session.dormant = true;
-      }
+      // An exited provider process cannot accept another prompt. Keep the
+      // logical session dormant so the next input restarts and resumes it.
+      // Codex also retains any accepted queued prompt until handoff.
+      session.dormant = true;
       // Add status message to history so it stays in sync with session.status
       this.appendHistoryToSession(session, {
         type: "status",
@@ -759,11 +757,11 @@ export class SessionManager {
     }
 
     if (!deferProcessStart) {
-    if (effectiveProvider === "codex") {
-      (proc as CodexProcess).start(effectiveCwd, codexOptions);
-    } else {
-      (proc as SdkProcess).start(effectiveCwd, options);
-    }
+      if (effectiveProvider === "codex") {
+        (proc as CodexProcess).start(effectiveCwd, codexOptions);
+      } else {
+        (proc as SdkProcess).start(effectiveCwd, options);
+      }
     }
 
     // Add session to Map only after proc.start() succeeds.

--- a/packages/bridge/src/session.ts
+++ b/packages/bridge/src/session.ts
@@ -67,6 +67,22 @@ export interface SessionInfo {
   createdAt: Date;
   lastActivityAt: Date;
   gitBranch: string;
+  /** Last assistant preview restored from the active-session registry. */
+  restoredLastMessage?: string;
+  /** Claude launch settings that must survive a Bridge restart. */
+  claudeSettings?: {
+    model?: string;
+    effort?: StartOptions["effort"];
+    maxTurns?: number;
+    maxBudgetUsd?: number;
+    fallbackModel?: string;
+    persistSession?: boolean;
+  };
+  /** Restored sessions stay process-free until the user interacts with them. */
+  dormant?: boolean;
+  /** Internal launch options retained only while a restored session is dormant. */
+  claudeStartOptions?: StartOptions;
+  codexStartOptions?: CodexStartOptions;
   /** If this session uses a worktree, the path to it. */
   worktreePath?: string;
   /** Branch name of the worktree. */
@@ -158,6 +174,7 @@ export interface SessionSummary {
   executionMode?: string;
   planMode?: boolean;
   model?: string;
+  claudeSettings?: SessionInfo["claudeSettings"];
   codexSettings?: {
     profile?: string;
     approvalPolicy?: string;
@@ -218,9 +235,7 @@ function mergeCodexSettings(
     ...(msg.modelReasoningEffort !== undefined
       ? { modelReasoningEffort: msg.modelReasoningEffort }
       : {}),
-    ...(msg.serviceTier !== undefined
-      ? { serviceTier: msg.serviceTier }
-      : {}),
+    ...(msg.serviceTier !== undefined ? { serviceTier: msg.serviceTier } : {}),
     ...(msg.networkAccessEnabled !== undefined
       ? { networkAccessEnabled: msg.networkAccessEnabled }
       : {}),
@@ -244,7 +259,9 @@ function sanitizeCodexModel(model: unknown): string | undefined {
   return normalized;
 }
 
-function publicQueuedInput(item?: QueuedCodexInput): QueuedInputItem | undefined {
+function publicQueuedInput(
+  item?: QueuedCodexInput,
+): QueuedInputItem | undefined {
   if (!item) return undefined;
   return {
     itemId: item.itemId,
@@ -303,8 +320,13 @@ export class SessionManager {
     worktreeOpts?: WorktreeOptions,
     provider?: Provider,
     codexOptions?: CodexStartOptions,
+    restoredBridgeSessionId?: string,
+    deferProcessStart = false,
   ): string {
-    const id = randomUUID().slice(0, 8);
+    const id =
+      restoredBridgeSessionId && !this.sessions.has(restoredBridgeSessionId)
+        ? restoredBridgeSessionId
+        : randomUUID().slice(0, 8);
     const effectiveProvider = provider ?? "claude";
     const proc =
       effectiveProvider === "codex" ? new CodexProcess() : new SdkProcess();
@@ -356,7 +378,7 @@ export class SessionManager {
       pastMessages:
         pastMessages && pastMessages.length > 0 ? pastMessages : undefined,
       projectPath,
-      status: "starting",
+      status: deferProcessStart ? "idle" : "starting",
       createdAt: new Date(),
       lastActivityAt: new Date(),
       gitBranch,
@@ -370,7 +392,32 @@ export class SessionManager {
       // Pre-populate claudeSessionId for resumed sessions so that get_history
       // can return it immediately (before the SDK sends a system/result event).
       claudeSessionId: options?.sessionId,
+      dormant: deferProcessStart,
+      claudeStartOptions:
+        deferProcessStart && effectiveProvider === "claude"
+          ? { ...options }
+          : undefined,
+      codexStartOptions:
+        deferProcessStart && effectiveProvider === "codex"
+          ? {
+              ...codexOptions,
+              additionalWritableRoots:
+                codexOptions?.additionalWritableRoots == null
+                  ? undefined
+                  : [...codexOptions.additionalWritableRoots],
+            }
+          : undefined,
     };
+    if (effectiveProvider === "claude" && options) {
+      session.claudeSettings = {
+        model: options.model,
+        effort: options.effort,
+        maxTurns: options.maxTurns,
+        maxBudgetUsd: options.maxBudgetUsd,
+        fallbackModel: options.fallbackModel,
+        persistSession: options.persistSession,
+      };
+    }
     if (effectiveProvider === "codex") {
       this.seedCodexPastUserTurnUuidMap(session);
     }
@@ -411,20 +458,16 @@ export class SessionManager {
             skills: msg.skills ?? previousCommands?.skills ?? [],
             skillMetadata:
               (msg.skillMetadata as
-                | Array<Record<string, unknown>>
-                | undefined) ??
+                Array<Record<string, unknown>> | undefined) ??
               previousCommands?.skillMetadata,
             apps: msg.apps ?? previousCommands?.apps ?? [],
             appMetadata:
-              (msg.appMetadata as
-                | Array<Record<string, unknown>>
-                | undefined) ??
+              (msg.appMetadata as Array<Record<string, unknown>> | undefined) ??
               previousCommands?.appMetadata,
             plugins: msg.plugins ?? previousCommands?.plugins ?? [],
             pluginMetadata:
               (msg.pluginMetadata as
-                | Array<Record<string, unknown>>
-                | undefined) ??
+                Array<Record<string, unknown>> | undefined) ??
               previousCommands?.pluginMetadata,
           });
         }
@@ -635,7 +678,12 @@ export class SessionManager {
 
     proc.on("exit", () => {
       session.status = "idle";
-      session.codexQueuedInput = undefined;
+      // Keep an accepted queued prompt until it has actually been handed to
+      // Codex. Any unexpected Codex exit remains restartable, including when
+      // the next prompt is only queued after the process has already exited.
+      if (session.provider === "codex") {
+        session.dormant = true;
+      }
       // Add status message to history so it stays in sync with session.status
       this.appendHistoryToSession(session, {
         type: "status",
@@ -696,7 +744,10 @@ export class SessionManager {
         session.claudeSessionId = codexOptions.threadId;
         this.saveWorktreeMapping(session);
         if (codexOptions.profile) {
-          void saveCodexSessionProfile(codexOptions.threadId, codexOptions.profile);
+          void saveCodexSessionProfile(
+            codexOptions.threadId,
+            codexOptions.profile,
+          );
         }
         if (codexOptions.additionalWritableRoots) {
           void saveCodexSessionAdditionalWritableRoots(
@@ -707,10 +758,12 @@ export class SessionManager {
       }
     }
 
+    if (!deferProcessStart) {
     if (effectiveProvider === "codex") {
       (proc as CodexProcess).start(effectiveCwd, codexOptions);
     } else {
       (proc as SdkProcess).start(effectiveCwd, options);
+    }
     }
 
     // Add session to Map only after proc.start() succeeds.
@@ -728,7 +781,50 @@ export class SessionManager {
     return this.sessions.get(id);
   }
 
-  appendHistory(sessionId: string, msg: ServerMessage): HistoryEntry | undefined {
+  activate(id: string): SessionInfo | undefined {
+    const session = this.sessions.get(id);
+    if (!session || !session.dormant) return session;
+    const effectiveCwd = session.worktreePath ?? session.projectPath;
+    session.status = "starting";
+    session.dormant = false;
+    try {
+      if (session.provider === "codex") {
+        const process = session.process as CodexProcess;
+        process.start(effectiveCwd, {
+          ...(session.codexStartOptions ?? {}),
+          ...(session.codexSettings ?? {}),
+          threadId: session.claudeSessionId,
+          collaborationMode:
+            session.codexStartOptions?.collaborationMode ??
+            process.collaborationMode,
+        } as CodexStartOptions);
+      } else {
+        const process = session.process as SdkProcess;
+        process.start(effectiveCwd, {
+          ...(session.claudeStartOptions ?? {}),
+          sessionId: session.claudeSessionId,
+          permissionMode:
+            process.permissionMode ??
+            session.claudeStartOptions?.permissionMode,
+          sandboxEnabled: session.sandboxEnabled,
+        });
+      }
+      session.claudeStartOptions = undefined;
+      if (!session.codexQueuedInput) {
+        session.codexStartOptions = undefined;
+      }
+      return session;
+    } catch (err) {
+      session.dormant = true;
+      session.status = "idle";
+      throw err;
+    }
+  }
+
+  appendHistory(
+    sessionId: string,
+    msg: ServerMessage,
+  ): HistoryEntry | undefined {
     const session = this.sessions.get(sessionId);
     if (!session) return undefined;
     const entry = this.appendHistoryToSession(session, msg);
@@ -776,7 +872,8 @@ export class SessionManager {
 
   list(): SessionSummary[] {
     return Array.from(this.sessions.values()).map((s) => {
-      const codexSettings = s.process instanceof CodexProcess
+      const codexSettings =
+        s.process instanceof CodexProcess
         ? withDerivedCodexPermissionsMode(
             s.codexSettings ??
               (s.process.codexPermissionsMode
@@ -797,11 +894,18 @@ export class SessionManager {
         s.status === "waiting_approval"
           ? processWithPending.getPendingPermission?.()
           : undefined;
+      const codexCollaborationMode =
+        s.process instanceof CodexProcess
+          ? (s.codexStartOptions?.collaborationMode ??
+            s.process.collaborationMode)
+          : undefined;
       const executionMode =
         s.process instanceof SdkProcess
-          ? s.process.permissionMode === "bypassPermissions"
+          ? (s.process.permissionMode ??
+              s.claudeStartOptions?.permissionMode) === "bypassPermissions"
             ? "fullAccess"
-            : s.process.permissionMode === "acceptEdits"
+            : (s.process.permissionMode ??
+                  s.claudeStartOptions?.permissionMode) === "acceptEdits"
               ? "acceptEdits"
               : "default"
           : s.process instanceof CodexProcess
@@ -812,9 +916,10 @@ export class SessionManager {
             : undefined;
       const planMode =
         s.process instanceof SdkProcess
-          ? s.process.permissionMode === "plan"
+          ? (s.process.permissionMode ??
+              s.claudeStartOptions?.permissionMode) === "plan"
           : s.process instanceof CodexProcess
-            ? s.process.collaborationMode === "plan"
+            ? codexCollaborationMode === "plan"
             : undefined;
       return {
         id: s.id,
@@ -831,9 +936,9 @@ export class SessionManager {
         worktreeBranch: s.worktreeBranch,
         permissionMode:
           s.process instanceof SdkProcess
-            ? s.process.permissionMode
+            ? (s.process.permissionMode ?? s.claudeStartOptions?.permissionMode)
             : s.process instanceof CodexProcess
-              ? s.process.collaborationMode === "plan"
+              ? codexCollaborationMode === "plan"
                 ? "plan"
                 : (codexSettings?.approvalPolicy ??
                     s.process.approvalPolicy) === "never"
@@ -842,7 +947,11 @@ export class SessionManager {
               : undefined,
         executionMode,
         planMode,
-        model: s.process instanceof SdkProcess ? s.process.model : undefined,
+        model:
+          s.process instanceof SdkProcess
+            ? (s.process.model ?? s.claudeSettings?.model)
+            : undefined,
+        claudeSettings: s.claudeSettings,
         codexSettings,
         agentNickname:
           s.process instanceof CodexProcess
@@ -971,10 +1080,7 @@ export class SessionManager {
     }
   }
 
-  private hasPastCodexUserMessage(
-    session: SessionInfo,
-    uuid: string,
-  ): boolean {
+  private hasPastCodexUserMessage(session: SessionInfo, uuid: string): boolean {
     return (session.pastMessages ?? []).some((message) => {
       if (!message || typeof message !== "object") return false;
       const item = message as {
@@ -1036,7 +1142,10 @@ export class SessionManager {
       const incomingImages = incoming.imageCount ?? 0;
       if (existingImages !== incomingImages) return false;
     }
-    if (isCodexUserTurnUuid(existingUuid) || isCodexUserTurnUuid(incomingUuid)) {
+    if (
+      isCodexUserTurnUuid(existingUuid) ||
+      isCodexUserTurnUuid(incomingUuid)
+    ) {
       return (
         this.isPendingCodexUserEcho(session, existingUuid) ||
         this.isPendingCodexUserEcho(session, incomingUuid)
@@ -1265,8 +1374,7 @@ export class SessionManager {
             return msg.content.replace(/\s+/g, " ").trim().slice(0, 100);
           }
           const content = msg.content as
-            | Array<Record<string, unknown>>
-            | undefined;
+            Array<Record<string, unknown>> | undefined;
           const textBlock = content?.find((c) => c.type === "text");
           if (textBlock?.text)
             return (textBlock.text as string)
@@ -1276,7 +1384,7 @@ export class SessionManager {
         }
       }
     }
-    return "";
+    return s.restoredLastMessage ?? "";
   }
 
   queueCodexInput(id: string, input: QueuedCodexInput): boolean {
@@ -1317,7 +1425,10 @@ export class SessionManager {
   cancelCodexQueuedInput(id: string, itemId: string): boolean {
     const session = this.sessions.get(id);
     if (!session || session.provider !== "codex") return false;
-    if (!session.codexQueuedInput || session.codexQueuedInput.itemId !== itemId) {
+    if (
+      !session.codexQueuedInput ||
+      session.codexQueuedInput.itemId !== itemId
+    ) {
       return false;
     }
     session.codexQueuedInput = undefined;
@@ -1382,26 +1493,30 @@ export class SessionManager {
     if (!queued || !(session.process instanceof CodexProcess)) return;
     if (!session.process.isWaitingForInput) return;
 
+    const handedOff = session.process.sendInputStructured(queued.text, {
+      images: queued.images,
+      skills: queued.skills,
+      mentions: queued.mentions,
+    });
+    if (!handedOff) return;
+
     session.codexQueuedInput = undefined;
+    session.codexStartOptions = undefined;
     this.broadcastCodexQueue(session);
 
     const userMsg = this.buildQueuedUserInputMessage(queued);
     this.appendHistoryToSession(session, userMsg);
     this.markPendingCodexUserEcho(session, userMsg);
     this.onMessage(session.id, userMsg);
-
-    session.process.sendInputStructured(queued.text, {
-      images: queued.images,
-      skills: queued.skills,
-      mentions: queued.mentions,
-    });
   }
 
   private buildQueuedUserInputMessage(queued: QueuedCodexInput): ServerMessage {
     return {
       type: "user_input",
       text: queued.text,
-      ...(queued.userMessageUuid ? { userMessageUuid: queued.userMessageUuid } : {}),
+      ...(queued.userMessageUuid
+        ? { userMessageUuid: queued.userMessageUuid }
+        : {}),
       timestamp: new Date().toISOString(),
       ...(queued.imageCount ? { imageCount: queued.imageCount } : {}),
       ...(queued.imageRefs ? { images: queued.imageRefs } : {}),
@@ -1710,7 +1825,7 @@ export class SessionManager {
 
   private evictStaleIdleSessions(): void {
     const staleIdleSessions = Array.from(this.sessions.values())
-      .filter((session) => session.status === "idle")
+      .filter((session) => session.status === "idle" && !session.dormant)
       .sort(
         (left, right) =>
           left.lastActivityAt.getTime() - right.lastActivityAt.getTime(),
@@ -1731,7 +1846,7 @@ export class SessionManager {
   private idleSessionCount(): number {
     let count = 0;
     for (const session of this.sessions.values()) {
-      if (session.status === "idle") count += 1;
+      if (session.status === "idle" && !session.dormant) count += 1;
     }
     return count;
   }

--- a/packages/bridge/src/sessions-index.test.ts
+++ b/packages/bridge/src/sessions-index.test.ts
@@ -17,6 +17,8 @@ import {
   getAllRecentSessions,
   getCodexSessionIndexMetadata,
   getCodexSessionHistory,
+  CODEX_HISTORY_MAX_BYTES,
+  CODEX_HISTORY_MAX_MESSAGES,
   extractMessageImages,
   codexThreadToSessionHistory,
 } from "./sessions-index.js";
@@ -223,10 +225,7 @@ describe("isWorktreeSlug", () => {
   it("does not match partial prefix collisions", () => {
     // "-vibetunnel-extra" is not the same as "-vibetunnel-worktrees-"
     expect(
-      isWorktreeSlug(
-        "-Users-x-Workspace-vibetunnel-extra",
-        projectSlug,
-      ),
+      isWorktreeSlug("-Users-x-Workspace-vibetunnel-extra", projectSlug),
     ).toBe(false);
   });
 });
@@ -240,14 +239,16 @@ describe("normalizeWorktreePath", () => {
 
   it("handles branch names with hyphens", () => {
     expect(
-      normalizeWorktreePath("/Users/x/Workspace/gtri-worktrees/test-session-verify"),
+      normalizeWorktreePath(
+        "/Users/x/Workspace/gtri-worktrees/test-session-verify",
+      ),
     ).toBe("/Users/x/Workspace/gtri");
   });
 
   it("returns the original path when not a worktree path", () => {
-    expect(
-      normalizeWorktreePath("/Users/x/Workspace/ccpocket"),
-    ).toBe("/Users/x/Workspace/ccpocket");
+    expect(normalizeWorktreePath("/Users/x/Workspace/ccpocket")).toBe(
+      "/Users/x/Workspace/ccpocket",
+    );
   });
 
   it("returns the original path for empty string", () => {
@@ -255,9 +256,9 @@ describe("normalizeWorktreePath", () => {
   });
 
   it("does not match paths ending with -worktrees (no branch segment)", () => {
-    expect(
-      normalizeWorktreePath("/Users/x/Workspace/ccpocket-worktrees"),
-    ).toBe("/Users/x/Workspace/ccpocket-worktrees");
+    expect(normalizeWorktreePath("/Users/x/Workspace/ccpocket-worktrees")).toBe(
+      "/Users/x/Workspace/ccpocket-worktrees",
+    );
   });
 
   it("does not match nested worktree-like paths", () => {
@@ -313,10 +314,7 @@ describe("scanJsonlDir", () => {
         timestamp: "2026-01-01T00:00:01.000Z",
       }),
     ];
-    writeFileSync(
-      join(testDir, "test-session-1.jsonl"),
-      lines.join("\n"),
-    );
+    writeFileSync(join(testDir, "test-session-1.jsonl"), lines.join("\n"));
 
     const result = await scanJsonlDir(testDir);
     expect(result).toHaveLength(1);
@@ -325,6 +323,7 @@ describe("scanJsonlDir", () => {
     expect(entry.sessionId).toBe("test-session-1");
     expect(entry.provider).toBe("claude");
     expect(entry.firstPrompt).toBe("hello world");
+    expect(entry.lastResponse).toBe("Hi there!");
     expect(entry.created).toBe("2026-01-01T00:00:00.000Z");
     expect(entry.modified).toBe("2026-01-01T00:00:01.000Z");
     expect(entry.gitBranch).toBe("main");
@@ -356,10 +355,7 @@ describe("scanJsonlDir", () => {
         sessionId: "test-session-title",
       }),
     ];
-    writeFileSync(
-      join(testDir, "test-session-title.jsonl"),
-      lines.join("\n"),
-    );
+    writeFileSync(join(testDir, "test-session-title.jsonl"), lines.join("\n"));
 
     const result = await scanJsonlDir(testDir);
     expect(result).toHaveLength(1);
@@ -395,10 +391,7 @@ describe("scanJsonlDir", () => {
         timestamp: "2026-01-01T00:00:01.000Z",
       }),
     ];
-    writeFileSync(
-      join(testDir, "auto-rename-helper.jsonl"),
-      lines.join("\n"),
-    );
+    writeFileSync(join(testDir, "auto-rename-helper.jsonl"), lines.join("\n"));
 
     const result = await scanJsonlDir(testDir);
     expect(result).toEqual([]);
@@ -435,10 +428,7 @@ describe("scanJsonlDir", () => {
     const lines = [
       JSON.stringify({ type: "queue-operation", operation: "dequeue" }),
     ];
-    writeFileSync(
-      join(testDir, "empty-session.jsonl"),
-      lines.join("\n"),
-    );
+    writeFileSync(join(testDir, "empty-session.jsonl"), lines.join("\n"));
 
     const result = await scanJsonlDir(testDir);
     expect(result).toEqual([]);
@@ -479,10 +469,7 @@ describe("scanJsonlDir", () => {
         timestamp: "2026-01-01T00:00:00.000Z",
       }),
     ];
-    writeFileSync(
-      join(testDir, "mixed.jsonl"),
-      lines.join("\n"),
-    );
+    writeFileSync(join(testDir, "mixed.jsonl"), lines.join("\n"));
 
     const result = await scanJsonlDir(testDir);
     expect(result).toHaveLength(1);
@@ -501,10 +488,7 @@ describe("scanJsonlDir", () => {
         timestamp: "2026-01-01T00:00:00.000Z",
       }),
     ];
-    writeFileSync(
-      join(testDir, "string-content.jsonl"),
-      lines.join("\n"),
-    );
+    writeFileSync(join(testDir, "string-content.jsonl"), lines.join("\n"));
 
     const result = await scanJsonlDir(testDir);
     expect(result).toHaveLength(1);
@@ -524,10 +508,7 @@ describe("scanJsonlDir", () => {
         timestamp: "2026-01-01T00:00:00.000Z",
       }),
     ];
-    writeFileSync(
-      join(testDir, "wt-session.jsonl"),
-      lines.join("\n"),
-    );
+    writeFileSync(join(testDir, "wt-session.jsonl"), lines.join("\n"));
 
     const result = await scanJsonlDir(testDir);
     expect(result).toHaveLength(1);
@@ -547,10 +528,7 @@ describe("scanJsonlDir", () => {
         timestamp: "2026-01-01T00:00:00.000Z",
       }),
     ];
-    writeFileSync(
-      join(testDir, "sidechain.jsonl"),
-      lines.join("\n"),
-    );
+    writeFileSync(join(testDir, "sidechain.jsonl"), lines.join("\n"));
 
     const result = await scanJsonlDir(testDir);
     expect(result).toHaveLength(1);
@@ -589,10 +567,7 @@ describe("scanJsonlDir", () => {
         timestamp: "2026-03-01T00:00:01.000Z",
       }),
     ];
-    writeFileSync(
-      join(testDir, "large-msg-session.jsonl"),
-      lines.join("\n"),
-    );
+    writeFileSync(join(testDir, "large-msg-session.jsonl"), lines.join("\n"));
 
     const result = await scanJsonlDir(testDir);
     expect(result).toHaveLength(1);
@@ -635,10 +610,7 @@ describe("scanJsonlDir", () => {
         timestamp: "2026-03-01T00:00:01.000Z",
       }),
     ];
-    writeFileSync(
-      join(testDir, "cwd-drift-session.jsonl"),
-      lines.join("\n"),
-    );
+    writeFileSync(join(testDir, "cwd-drift-session.jsonl"), lines.join("\n"));
 
     const result = await scanJsonlDir(testDir);
     expect(result).toHaveLength(1);
@@ -701,7 +673,11 @@ describe("codex sessions integration", () => {
       JSON.stringify({
         timestamp: "2026-02-13T11:26:43.995Z",
         type: "session_meta",
-        payload: { id: threadId, cwd: "/tmp/project-a", git: { branch: "main" } },
+        payload: {
+          id: threadId,
+          cwd: "/tmp/project-a",
+          git: { branch: "main" },
+        },
       }),
       JSON.stringify({
         timestamp: "2026-02-13T11:26:44.100Z",
@@ -905,12 +881,19 @@ describe("codex sessions integration", () => {
       JSON.stringify({
         timestamp: "2026-02-13T12:00:00.000Z",
         type: "session_meta",
-        payload: { id: threadId, cwd: worktreePath, git: { branch: "feature/x" } },
+        payload: {
+          id: threadId,
+          cwd: worktreePath,
+          git: { branch: "feature/x" },
+        },
       }),
       JSON.stringify({
         timestamp: "2026-02-13T12:00:01.000Z",
         type: "event_msg",
-        payload: { type: "user_message", message: "resume this worktree session" },
+        payload: {
+          type: "user_message",
+          message: "resume this worktree session",
+        },
       }),
       JSON.stringify({
         timestamp: "2026-02-13T12:00:02.000Z",
@@ -933,18 +916,23 @@ describe("codex sessions integration", () => {
     expect(entry?.provider).toBe("codex");
     expect(entry?.projectPath).toBe(mainProjectPath);
     expect(entry?.resumeCwd).toBe(worktreePath);
+    expect(entry?.lastResponse).toBe("worktree response");
 
     const mainFilter = await getAllRecentSessions({
       projectPath: mainProjectPath,
       limit: 200,
     });
-    expect(mainFilter.sessions.some((s) => s.sessionId === threadId)).toBe(true);
+    expect(mainFilter.sessions.some((s) => s.sessionId === threadId)).toBe(
+      true,
+    );
 
     const worktreeFilter = await getAllRecentSessions({
       projectPath: worktreePath,
       limit: 200,
     });
-    expect(worktreeFilter.sessions.some((s) => s.sessionId === threadId)).toBe(true);
+    expect(worktreeFilter.sessions.some((s) => s.sessionId === threadId)).toBe(
+      true,
+    );
   });
 
   it("returns only codex sessions when provider=codex", async () => {
@@ -1243,6 +1231,9 @@ describe("codex sessions integration", () => {
       "thanks, now add a test",
     );
     expect(metadata.get(wantedThreadId)?.summary).toBe("done: fixed the bug");
+    expect(metadata.get(wantedThreadId)?.lastResponse).toBe(
+      "done: fixed the bug",
+    );
   });
 
   it("reads codex history from jsonl", async () => {
@@ -1280,6 +1271,118 @@ describe("codex sessions integration", () => {
     expect(history[0].content[0].text).toBe("show me the diff");
     expect(history[1].role).toBe("assistant");
     expect(history[1].content[0].text).toBe("Here is the diff summary.");
+  });
+
+  it("bounds a large Codex rollout while preserving its newest messages", async () => {
+    const threadId = "019c56c0-d4d8-7b22-9e3c-200664d68011";
+    const codexDir = join(tempHome, ".codex", "sessions", "2026", "02", "13");
+    mkdirSync(codexDir, { recursive: true });
+    const payload = "x".repeat(12 * 1024);
+    const lines = [
+      JSON.stringify({
+        type: "session_meta",
+        payload: { id: threadId, cwd: "/tmp/project-a" },
+      }),
+      ...Array.from({ length: 2200 }, (_, index) =>
+        JSON.stringify({
+          type: "response_item",
+          payload: {
+            type: "message",
+            role: "assistant",
+            content: [
+              { type: "output_text", text: `response-${index}:${payload}` },
+            ],
+          },
+        }),
+      ),
+    ];
+    writeFileSync(
+      join(codexDir, `rollout-2026-02-13T11-26-43-${threadId}.jsonl`),
+      lines.join("\n"),
+    );
+
+    const history = await getCodexSessionHistory(threadId);
+    expect(history.length).toBeLessThanOrEqual(CODEX_HISTORY_MAX_MESSAGES);
+    expect(
+      Buffer.byteLength(JSON.stringify(history), "utf-8"),
+    ).toBeLessThanOrEqual(CODEX_HISTORY_MAX_BYTES + 1024);
+    expect(JSON.stringify(history.at(-1))).toContain("response-2199");
+    expect(JSON.stringify(history[0])).not.toContain("response-0:");
+  });
+
+  it("finds a filename-matched thread without loading a large unrelated rollout", async () => {
+    const threadId = "019c56c0-d4d8-7b22-9e3c-200664d68018";
+    const codexDir = join(tempHome, ".codex", "sessions", "2026", "02", "13");
+    mkdirSync(codexDir, { recursive: true });
+    writeFileSync(
+      join(codexDir, "rollout-2026-02-13T00-00-00-unrelated.jsonl"),
+      Buffer.alloc(8 * 1024 * 1024, 0x78),
+    );
+    writeFileSync(
+      join(codexDir, `rollout-2026-02-13T23-59-59-${threadId}.jsonl`),
+      [
+        JSON.stringify({
+          type: "session_meta",
+          payload: { id: threadId, cwd: "/tmp/project-a" },
+        }),
+        JSON.stringify({
+          type: "event_msg",
+          payload: {
+            type: "user_message",
+            message: "target history",
+            images: ["data:image/png;base64,dGFyZ2V0LWltYWdl"],
+          },
+        }),
+      ].join("\n"),
+    );
+
+    const history = await getCodexSessionHistory(threadId);
+    expect(history).toMatchObject([
+      {
+        role: "user",
+        uuid: "codex:user-turn:1",
+        imageCount: 1,
+      },
+    ]);
+    await expect(
+      extractMessageImages(threadId, "codex:user-turn:1"),
+    ).resolves.toEqual([{ base64: "dGFyZ2V0LWltYWdl", mimeType: "image/png" }]);
+  });
+
+  it("compacts each oversized Codex history message below the per-message cap", async () => {
+    const threadId = "019c56c0-d4d8-7b22-9e3c-200664d68019";
+    const codexDir = join(tempHome, ".codex", "sessions", "2026", "02", "13");
+    mkdirSync(codexDir, { recursive: true });
+    const oversizedInput = Object.fromEntries(
+      Array.from({ length: 24 }, (_, index) => [
+        `field-${index}`,
+        "x".repeat(256 * 1024),
+      ]),
+    );
+    writeFileSync(
+      join(codexDir, `rollout-2026-02-13T23-59-59-${threadId}.jsonl`),
+      [
+        JSON.stringify({
+          type: "session_meta",
+          payload: { id: threadId, cwd: "/tmp/project-a" },
+        }),
+        JSON.stringify({
+          type: "response_item",
+          payload: {
+            type: "function_call",
+            call_id: "oversized-tool",
+            name: "exec_command",
+            arguments: JSON.stringify(oversizedInput),
+          },
+        }),
+      ].join("\n"),
+    );
+
+    const history = await getCodexSessionHistory(threadId);
+    expect(history).toHaveLength(1);
+    expect(
+      Buffer.byteLength(JSON.stringify(history[0]), "utf-8"),
+    ).toBeLessThanOrEqual(2 * 1024 * 1024);
   });
 
   it("trims codex history after thread_rolled_back events", async () => {
@@ -1367,7 +1470,7 @@ describe("codex sessions integration", () => {
           type: "function_call",
           name: "mcp__dart-mcp__list_running_apps",
           call_id: "call-1",
-          arguments: "{\"root\":\"/tmp/project-a\"}",
+          arguments: '{"root":"/tmp/project-a"}',
         },
       }),
       JSON.stringify({
@@ -1466,7 +1569,7 @@ describe("codex sessions integration", () => {
           type: "function_call",
           name: "mcp__computer-use__get_app_state",
           call_id: "call-1",
-          arguments: "{\"app\":\"Google Chrome\"}",
+          arguments: '{"app":"Google Chrome"}',
         },
       }),
       JSON.stringify({
@@ -2091,9 +2194,9 @@ describe("codex sessions integration", () => {
       ].join("\n"),
     );
 
-    await expect(extractMessageImages(sessionId, "uuid-image")).resolves.toEqual([
-      { base64: "aW1hZ2U=", mimeType: "image/png" },
-    ]);
+    await expect(
+      extractMessageImages(sessionId, "uuid-image"),
+    ).resolves.toEqual([{ base64: "aW1hZ2U=", mimeType: "image/png" }]);
     await expect(extractMessageImages(sessionId, "uuid-text")).resolves.toEqual(
       [],
     );
@@ -2125,22 +2228,22 @@ describe("codex sessions integration", () => {
     writeFileSync(jsonlPath, entry("AAAA"));
     utimesSync(jsonlPath, fixedTime, fixedTime);
 
-    await expect(extractMessageImages(sessionId, "uuid-image")).resolves.toEqual([
-      { base64: "AAAA", mimeType: "image/png" },
-    ]);
+    await expect(
+      extractMessageImages(sessionId, "uuid-image"),
+    ).resolves.toEqual([{ base64: "AAAA", mimeType: "image/png" }]);
 
     const originalStat = statSync(jsonlPath);
     writeFileSync(jsonlPath, entry("BBBB"));
     utimesSync(jsonlPath, fixedTime, fixedTime);
     expect(statSync(jsonlPath).mtimeMs).toBe(originalStat.mtimeMs);
-    await expect(extractMessageImages(sessionId, "uuid-image")).resolves.toEqual([
-      { base64: "AAAA", mimeType: "image/png" },
-    ]);
+    await expect(
+      extractMessageImages(sessionId, "uuid-image"),
+    ).resolves.toEqual([{ base64: "AAAA", mimeType: "image/png" }]);
 
     writeFileSync(jsonlPath, entry("CCCCCC"));
-    await expect(extractMessageImages(sessionId, "uuid-image")).resolves.toEqual([
-      { base64: "CCCCCC", mimeType: "image/png" },
-    ]);
+    await expect(
+      extractMessageImages(sessionId, "uuid-image"),
+    ).resolves.toEqual([{ base64: "CCCCCC", mimeType: "image/png" }]);
   });
 });
 
@@ -2203,6 +2306,130 @@ describe("claude namedOnly optimization", () => {
     expect(result.sessions).toHaveLength(1);
     expect(result.sessions[0].sessionId).toBe("named-s1");
     expect(result.sessions[0].name).toBe("My named session");
+  });
+
+  it("supplements indexed Claude sessions with the last agent response", async () => {
+    const projectDir = join(tempHome, ".claude", "projects", "-tmp-project-a");
+    mkdirSync(projectDir, { recursive: true });
+    const sessionId = "indexed-last-response";
+    const jsonlPath = join(projectDir, `${sessionId}.jsonl`);
+    writeFileSync(
+      join(projectDir, "sessions-index.json"),
+      JSON.stringify({
+        version: 1,
+        entries: [
+          {
+            sessionId,
+            fullPath: jsonlPath,
+            fileMtime: Date.now(),
+            firstPrompt: "initial request",
+            messageCount: 4,
+            created: "2026-02-13T10:00:00.000Z",
+            modified: "2026-02-13T11:00:00.000Z",
+            gitBranch: "main",
+            projectPath: "/tmp/project-a",
+            isSidechain: false,
+          },
+        ],
+      }),
+    );
+    writeFileSync(
+      jsonlPath,
+      [
+        JSON.stringify({
+          type: "user",
+          message: { role: "user", content: "initial request" },
+          timestamp: "2026-02-13T10:00:00.000Z",
+        }),
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "initial response" }],
+          },
+          timestamp: "2026-02-13T10:01:00.000Z",
+        }),
+        JSON.stringify({
+          type: "user",
+          message: { role: "user", content: "follow-up request" },
+          timestamp: "2026-02-13T10:02:00.000Z",
+        }),
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "final agent response" }],
+          },
+          timestamp: "2026-02-13T10:03:00.000Z",
+        }),
+      ].join("\n"),
+    );
+
+    const result = await getAllRecentSessions({
+      provider: "claude",
+      limit: 20,
+    });
+
+    expect(result.sessions).toHaveLength(1);
+    expect(result.sessions[0].lastPrompt).toBe("follow-up request");
+    expect(result.sessions[0].lastResponse).toBe("final agent response");
+  });
+
+  it("finds indexed Claude sessions by the response shown on their card", async () => {
+    const projectDir = join(tempHome, ".claude", "projects", "-tmp-project-a");
+    mkdirSync(projectDir, { recursive: true });
+    const sessionId = "indexed-searchable-response";
+    const jsonlPath = join(projectDir, `${sessionId}.jsonl`);
+    writeFileSync(
+      join(projectDir, "sessions-index.json"),
+      JSON.stringify({
+        version: 1,
+        entries: [
+          {
+            sessionId,
+            fullPath: jsonlPath,
+            fileMtime: Date.now(),
+            firstPrompt: "initial request",
+            messageCount: 2,
+            created: "2026-02-13T10:00:00.000Z",
+            modified: "2026-02-13T11:00:00.000Z",
+            gitBranch: "main",
+            projectPath: "/tmp/project-a",
+            isSidechain: false,
+          },
+        ],
+      }),
+    );
+    writeFileSync(
+      jsonlPath,
+      [
+        JSON.stringify({
+          type: "user",
+          message: { role: "user", content: "initial request" },
+          timestamp: "2026-02-13T10:00:00.000Z",
+        }),
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "distinct searchable response" }],
+          },
+          timestamp: "2026-02-13T10:01:00.000Z",
+        }),
+      ].join("\n"),
+    );
+
+    const result = await getAllRecentSessions({
+      provider: "claude",
+      searchQuery: "searchable response",
+      limit: 20,
+    });
+
+    expect(result.sessions).toHaveLength(1);
+    expect(result.sessions[0]).toMatchObject({
+      sessionId,
+      lastResponse: "distinct searchable response",
+    });
   });
 
   it("finds an exact Claude session outside the first recent page", async () => {
@@ -2384,9 +2611,13 @@ describe("claude namedOnly optimization", () => {
 
     expect(result.sessions).toHaveLength(1);
     expect(result.sessions[0].sessionId).toBe(sessionId);
-    expect(result.sessions[0].projectPath).toBe("/Users/test/big-image-project");
+    expect(result.sessions[0].projectPath).toBe(
+      "/Users/test/big-image-project",
+    );
     expect(result.sessions[0].gitBranch).toBe("main");
-    expect(result.sessions[0].firstPrompt).toBe("Please inspect this screenshot.");
+    expect(result.sessions[0].firstPrompt).toBe(
+      "Please inspect this screenshot.",
+    );
   });
 
   it("hydrates indexed Claude session names from JSONL custom-title entries", async () => {

--- a/packages/bridge/src/sessions-index.test.ts
+++ b/packages/bridge/src/sessions-index.test.ts
@@ -17,6 +17,7 @@ import {
   getAllRecentSessions,
   getCodexSessionIndexMetadata,
   getCodexSessionHistory,
+  getSessionHistory,
   CODEX_HISTORY_MAX_BYTES,
   CODEX_HISTORY_MAX_MESSAGES,
   extractMessageImages,
@@ -2203,6 +2204,98 @@ describe("codex sessions integration", () => {
     await expect(
       extractMessageImages(sessionId, "uuid-malformed-image"),
     ).resolves.toEqual([]);
+  });
+
+  it("restores non-empty Claude thinking and tool results", async () => {
+    const sessionId = "claude-complete-history";
+    const claudeDir = join(tempHome, ".claude", "projects", "-tmp-project-a");
+    mkdirSync(claudeDir, { recursive: true });
+    writeFileSync(
+      join(claudeDir, `${sessionId}.jsonl`),
+      [
+        JSON.stringify({
+          type: "assistant",
+          uuid: "assistant-tool",
+          timestamp: "2026-08-24T08:00:00.000Z",
+          message: {
+            role: "assistant",
+            content: [
+              { type: "thinking", thinking: "Check the project state." },
+              { type: "thinking", thinking: "  \n " },
+              {
+                type: "tool_use",
+                id: "tool-1",
+                name: "Bash",
+                input: { command: "git status" },
+              },
+            ],
+          },
+        }),
+        JSON.stringify({
+          type: "user",
+          uuid: "tool-result-message",
+          timestamp: "2026-08-24T08:00:01.000Z",
+          message: {
+            role: "user",
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "tool-1",
+                content: [{ type: "text", text: "working tree clean" }],
+              },
+            ],
+          },
+        }),
+      ].join("\n"),
+    );
+
+    await expect(getSessionHistory(sessionId)).resolves.toEqual([
+      {
+        role: "assistant",
+        uuid: "assistant-tool",
+        timestamp: "2026-08-24T08:00:00.000Z",
+        content: [
+          { type: "thinking", thinking: "Check the project state." },
+          {
+            type: "tool_use",
+            id: "tool-1",
+            name: "Bash",
+            input: { command: "git status" },
+          },
+        ],
+      },
+      {
+        role: "tool_result",
+        toolUseId: "tool-1",
+        toolName: "Bash",
+        timestamp: "2026-08-24T08:00:01.000Z",
+        content: "working tree clean",
+      },
+    ]);
+  });
+
+  it("bounds restored Claude history before sending it to clients", async () => {
+    const sessionId = "claude-bounded-history";
+    const claudeDir = join(tempHome, ".claude", "projects", "-tmp-project-a");
+    mkdirSync(claudeDir, { recursive: true });
+    writeFileSync(
+      join(claudeDir, `${sessionId}.jsonl`),
+      Array.from({ length: CODEX_HISTORY_MAX_MESSAGES + 5 }, (_, index) =>
+        JSON.stringify({
+          type: "user",
+          uuid: `user-${index}`,
+          message: { role: "user", content: `message ${index}` },
+        }),
+      ).join("\n"),
+    );
+
+    const history = await getSessionHistory(sessionId);
+
+    expect(history).toHaveLength(CODEX_HISTORY_MAX_MESSAGES);
+    expect(history[0].uuid).toBe("user-5");
+    expect(history.at(-1)?.uuid).toBe(
+      `user-${CODEX_HISTORY_MAX_MESSAGES + 4}`,
+    );
   });
 
   it("reuses a fresh Claude image index and invalidates it on file changes", async () => {

--- a/packages/bridge/src/sessions-index.ts
+++ b/packages/bridge/src/sessions-index.ts
@@ -3128,6 +3128,7 @@ export async function getSessionHistory(
   }
 
   const messages: SessionHistoryMessage[] = [];
+  const toolNamesById = new Map<string, string>();
   const lines = raw.split("\n");
 
   for (const line of lines) {
@@ -3178,8 +3179,12 @@ export async function getSessionHistory(
 
     if (!Array.isArray(message.content)) continue;
 
-    // Filter content to only text and tool_use (skip tool_result for cleaner display)
     const content: SessionHistoryContentItem[] = [];
+    const toolResults: Array<{
+      id: string;
+      content: string;
+      timestamp?: string;
+    }> = [];
     let imageCount = 0;
     for (const c of message.content) {
       if (typeof c !== "object" || c === null) continue;
@@ -3188,12 +3193,33 @@ export async function getSessionHistory(
 
       if (contentType === "text" && item.text) {
         content.push({ type: "text", text: item.text as string });
+      } else if (
+        contentType === "thinking" &&
+        typeof item.thinking === "string" &&
+        item.thinking.trim().length > 0
+      ) {
+        content.push({ type: "thinking", thinking: item.thinking });
       } else if (contentType === "tool_use") {
+        const id = typeof item.id === "string" ? item.id : "";
+        const name = typeof item.name === "string" ? item.name : "";
+        if (!id || !name) continue;
+        toolNamesById.set(id, name);
         content.push({
           type: "tool_use",
-          id: item.id as string,
-          name: item.name as string,
+          id,
+          name,
           input: (item.input as Record<string, unknown>) ?? {},
+        });
+      } else if (contentType === "tool_result") {
+        const id =
+          typeof item.tool_use_id === "string" ? item.tool_use_id : "";
+        if (!id) continue;
+        toolResults.push({
+          id,
+          content: historyToolResultContent(item.content),
+          ...(typeof entry.timestamp === "string"
+            ? { timestamp: entry.timestamp }
+            : {}),
         });
       } else if (contentType === "image") {
         imageCount++;
@@ -3219,9 +3245,38 @@ export async function getSessionHistory(
         ...(imageCount > 0 ? { imageCount } : {}),
       });
     }
+
+    for (const result of toolResults) {
+      appendToolResultMessage(
+        messages,
+        result.id,
+        toolNamesById.get(result.id),
+        result.content,
+        result.timestamp ? { timestamp: result.timestamp } : undefined,
+      );
+    }
   }
 
-  return messages;
+  // Claude transcripts can become very large. Use the same tested tail and
+  // per-message safety budget as Codex before serializing history to mobile.
+  return boundCodexSessionHistory(messages);
+}
+
+function historyToolResultContent(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (!Array.isArray(value)) return value == null ? "" : String(value);
+
+  return value
+    .map((entry) => {
+      const item = asObject(entry);
+      if (!item) return "";
+      if (item.type === "text" && typeof item.text === "string") {
+        return item.text;
+      }
+      return "";
+    })
+    .filter(Boolean)
+    .join("\n");
 }
 
 // ---- Extract full image data from JSONL for a specific message ----

--- a/packages/bridge/src/sessions-index.ts
+++ b/packages/bridge/src/sessions-index.ts
@@ -1,4 +1,11 @@
-import { readdir, readFile, writeFile, appendFile, stat, open } from "node:fs/promises";
+import {
+  readdir,
+  readFile,
+  writeFile,
+  appendFile,
+  stat,
+  open,
+} from "node:fs/promises";
 import { createReadStream, type Dirent } from "node:fs";
 import { createInterface } from "node:readline";
 import { basename, extname, join } from "node:path";
@@ -16,6 +23,8 @@ export interface SessionIndexEntry {
   summary?: string;
   firstPrompt: string;
   lastPrompt?: string;
+  /** Last assistant response text shown by recent-session cards. */
+  lastResponse?: string;
   created: string;
   modified: string;
   gitBranch: string;
@@ -71,7 +80,7 @@ export interface GetRecentSessionsOptions {
   provider?: "claude" | "codex";
   /** Show only sessions with a non-empty name. */
   namedOnly?: boolean;
-  /** Free-text search across name, firstPrompt, lastPrompt and summary. */
+  /** Free-text search across name and recent-session preview fields. */
   searchQuery?: string;
 }
 
@@ -272,7 +281,10 @@ const RE_SYSTEM_INJECTED =
   /^<(?:local-command-caveat|local-command-std(?:err|out)|task-notification|teammate-message|bash-(?:input|stdout))>/;
 
 function isSystemInjectedText(text: string): boolean {
-  return RE_SYSTEM_INJECTED.test(text) || text.startsWith("Base directory for this skill:");
+  return (
+    RE_SYSTEM_INJECTED.test(text) ||
+    text.startsWith("Base directory for this skill:")
+  );
 }
 
 function isCodexAutoRenameSession(firstPrompt: string): boolean {
@@ -335,6 +347,20 @@ function extractUserPromptText(entry: Record<string, unknown>): string {
   return "";
 }
 
+/** Extract all text blocks from a Claude assistant entry. */
+function extractAssistantResponseText(entry: Record<string, unknown>): string {
+  const message = entry.message as { content?: unknown } | undefined;
+  if (typeof message?.content === "string") return message.content.trim();
+  if (!Array.isArray(message?.content)) return "";
+  return (message.content as Array<{ type?: unknown; text?: unknown }>)
+    .filter(
+      (content) => content.type === "text" && typeof content.text === "string",
+    )
+    .map((content) => content.text as string)
+    .join("\n")
+    .trim();
+}
+
 /**
  * Parse head and optional tail text chunks to build a SessionIndexEntry.
  * Uses regex for most fields, JSON.parse only for first/last user lines.
@@ -353,6 +379,7 @@ function parseFromChunks(
 ): ParsedClaudeChunks {
   let firstPrompt = "";
   let lastPrompt = "";
+  let lastResponse = "";
   let created = "";
   let modified = "";
   let gitBranch = "";
@@ -416,21 +443,35 @@ function parseFromChunks(
       if (pmMatch) permissionMode = pmMatch[1];
     }
 
-    if (isUser && !firstPrompt) {
-      // JSON.parse only user lines to extract prompt text, skipping
-      // system-injected messages (e.g. <local-command-caveat>)
+    if (isUser) {
+      // Extract prompt text while skipping system-injected messages (e.g.
+      // <local-command-caveat>). For small files this also captures the last
+      // prompt without a separate tail read.
       try {
         const entry = JSON.parse(line) as Record<string, unknown>;
         const text = extractUserPromptText(entry);
         if (text && !isSystemInjectedText(text)) {
-          if (isAutoRenamePromptText(text)) {
+          if (!firstPrompt && isAutoRenamePromptText(text)) {
             isInternalAutoRename = true;
             break;
           }
+          if (!firstPrompt) {
           firstPrompt = text;
           headFoundFirstPrompt = true;
         }
-      } catch { /* skip */ }
+          lastPrompt = text;
+        }
+      } catch {
+        /* skip */
+      }
+    } else if (isAssistant) {
+      try {
+        const entry = JSON.parse(line) as Record<string, unknown>;
+        const text = extractAssistantResponseText(entry);
+        if (text) lastResponse = text;
+      } catch {
+        /* skip */
+      }
     }
   }
 
@@ -447,9 +488,11 @@ function parseFromChunks(
   if (tail) {
     const tailLines = tail.split("\n");
 
-    // Find last timestamp and last user prompt from tail (scan in reverse)
+    // Find last timestamp, user prompt, and assistant response from the tail.
     let lastUserLine: string | null = null;
+    let lastAssistantLine: string | null = null;
     let tailCustomTitle = "";
+    let foundTailTimestamp = false;
     for (let i = tailLines.length - 1; i >= 0; i--) {
       const line = tailLines[i];
       if (!line.trim()) continue;
@@ -468,29 +511,18 @@ function parseFromChunks(
       if (!isUser && !isAssistant) continue;
       hasAnyMessage = true;
 
-      // Get the last modified timestamp
-      if (!modified || true) {
-        // Always update modified from tail (tail is later in file)
+      if (!lastUserLine && isUser) lastUserLine = line;
+      if (!lastAssistantLine && isAssistant) lastAssistantLine = line;
+
+      // The first message found in reverse order is the last modified one.
+      if (!foundTailTimestamp) {
         const tsMatch = line.match(RE_TIMESTAMP);
         if (tsMatch) {
           modified = tsMatch[1];
-          // We found the last message — we're done with timestamps
-          if (isUser && !lastUserLine) lastUserLine = line;
-          break;
+          foundTailTimestamp = true;
         }
       }
-    }
-
-    // Also find last user line if not found in reverse timestamp scan
-    if (!lastUserLine) {
-      for (let i = tailLines.length - 1; i >= 0; i--) {
-        const line = tailLines[i];
-        if (!line.trim()) continue;
-        if (RE_TYPE_USER.test(line)) {
-          lastUserLine = line;
-          break;
-        }
-      }
+      if (lastUserLine && lastAssistantLine) break;
     }
 
     // JSON.parse only the last user line for lastPrompt
@@ -499,7 +531,18 @@ function parseFromChunks(
         const entry = JSON.parse(lastUserLine) as Record<string, unknown>;
         const text = extractUserPromptText(entry);
         if (text && !isSystemInjectedText(text)) lastPrompt = text;
-      } catch { /* skip */ }
+      } catch {
+        /* skip */
+      }
+    }
+    if (lastAssistantLine) {
+      try {
+        const entry = JSON.parse(lastAssistantLine) as Record<string, unknown>;
+        const text = extractAssistantResponseText(entry);
+        if (text) lastResponse = text;
+      } catch {
+        /* skip */
+      }
     }
 
     // Fill in metadata from tail if head didn't have it
@@ -547,6 +590,7 @@ function parseFromChunks(
       provider: "claude",
       firstPrompt,
       ...(lastPrompt && lastPrompt !== firstPrompt ? { lastPrompt } : {}),
+      ...(lastResponse ? { lastResponse } : {}),
       ...(customTitle ? { name: customTitle } : {}),
       created,
       modified,
@@ -615,12 +659,10 @@ async function parseClaudeJsonlFileFast(
   // from the start whenever head parsing missed these fields so resume uses
   // the original session cwd rather than a later in-session directory.
   if (
-    result
-    && (
-      !result.firstPrompt
-      || !parsedChunks.headFoundProjectPath
-      || !parsedChunks.headFoundGitBranch
-    )
+    result &&
+    (!result.firstPrompt ||
+      !parsedChunks.headFoundProjectPath ||
+      !parsedChunks.headFoundGitBranch)
   ) {
     const missing = await extractMissingFieldsStreaming(
       filePath,
@@ -668,7 +710,9 @@ async function hydrateClaudeIndexedEntry(
     modified: entry.modified ?? "",
     gitBranch: entry.gitBranch ?? "",
     projectPath: normalizedPath,
-    ...(rawProjectPath && rawProjectPath !== normalizedPath ? { resumeCwd: rawProjectPath } : {}),
+    ...(rawProjectPath && rawProjectPath !== normalizedPath
+      ? { resumeCwd: rawProjectPath }
+      : {}),
     isSidechain: entry.isSidechain ?? false,
   };
 
@@ -682,7 +726,8 @@ async function hydrateClaudeIndexedEntry(
 
   if (!needsJsonlRepair) return base;
 
-  const fallbackPath = entry.fullPath || join(dirPath, `${entry.sessionId}.jsonl`);
+  const fallbackPath =
+    entry.fullPath || join(dirPath, `${entry.sessionId}.jsonl`);
   const parsed = await parseClaudeJsonlFileFast(entry.sessionId, fallbackPath);
   if (!parsed) return base;
   if (isAutoRenamePromptText(parsed.firstPrompt)) return null;
@@ -690,14 +735,25 @@ async function hydrateClaudeIndexedEntry(
   return {
     ...base,
     firstPrompt: base.firstPrompt || parsed.firstPrompt,
-    ...(parsed.name ? { name: parsed.name } : base.name ? { name: base.name } : {}),
+    ...(parsed.name
+      ? { name: parsed.name }
+      : base.name
+        ? { name: base.name }
+        : {}),
     created: base.created || parsed.created,
     modified: base.modified || parsed.modified,
     gitBranch: base.gitBranch || parsed.gitBranch,
     projectPath: base.projectPath || parsed.projectPath,
     isSidechain: base.isSidechain || parsed.isSidechain,
-    ...(base.lastPrompt || !parsed.lastPrompt ? {} : { lastPrompt: parsed.lastPrompt }),
-    ...(base.permissionMode || !parsed.permissionMode ? {} : { permissionMode: parsed.permissionMode }),
+    ...(base.lastPrompt || !parsed.lastPrompt
+      ? {}
+      : { lastPrompt: parsed.lastPrompt }),
+    ...(base.lastResponse || !parsed.lastResponse
+      ? {}
+      : { lastResponse: parsed.lastResponse }),
+    ...(base.permissionMode || !parsed.permissionMode
+      ? {}
+      : { permissionMode: parsed.permissionMode }),
   };
 }
 
@@ -713,7 +769,12 @@ async function extractMissingFieldsStreaming(
   needFirstPrompt: boolean,
   needProjectPath: boolean,
   needGitBranch: boolean,
-): Promise<{ firstPrompt: string; projectPath: string; rawCwd: string; gitBranch: string }> {
+): Promise<{
+  firstPrompt: string;
+  projectPath: string;
+  rawCwd: string;
+  gitBranch: string;
+}> {
   return new Promise((resolve) => {
     const stream = createReadStream(filePath, { encoding: "utf-8" });
     const rl = createInterface({ input: stream, crlfDelay: Infinity });
@@ -781,36 +842,36 @@ async function extractMissingFieldsStreaming(
 }
 
 /**
- * Maximum bytes to read from file tail when searching for lastPrompt.
+ * Maximum bytes to read from a file tail when searching for recent text.
  * Claude sessions often have large tool-result lines (diffs, etc.) near the
  * end, so 8KB is rarely enough.  We grow the read window in steps up to this
  * cap to balance speed and coverage.
  */
-const LAST_PROMPT_MAX_TAIL = 131072; // 128KB
+const RECENT_TEXT_MAX_TAIL = 131072; // 128KB
 
 /**
- * Fast tail-read to extract the last user prompt from a JSONL file.
- * Starts at TAIL_BYTES and doubles up to LAST_PROMPT_MAX_TAIL until a real
- * user text prompt is found.  No full-file scan is ever performed.
- * Used to supplement sessions-index.json entries that lack lastPrompt.
+ * Fast tail-read to extract the last user prompt and assistant response from
+ * a JSONL file. The read window grows until both are found or the cap is hit.
  */
-async function extractLastPromptFromTail(
+async function extractRecentTextFromTail(
   filePath: string,
-): Promise<string> {
+): Promise<{ lastPrompt: string; lastResponse: string }> {
   let fh;
   try {
     fh = await open(filePath, "r");
   } catch {
-    return "";
+    return { lastPrompt: "", lastResponse: "" };
   }
   try {
     const fileSize = (await fh.stat()).size;
-    if (fileSize === 0) return "";
+    if (fileSize === 0) return { lastPrompt: "", lastResponse: "" };
+    let lastPrompt = "";
+    let lastResponse = "";
 
     // Grow tail window: 8KB → 16KB → 32KB → 64KB → 128KB
     for (
       let tailSize = TAIL_BYTES;
-      tailSize <= LAST_PROMPT_MAX_TAIL;
+      tailSize <= RECENT_TEXT_MAX_TAIL;
       tailSize *= 2
     ) {
       const readSize = Math.min(fileSize, tailSize);
@@ -825,28 +886,69 @@ async function extractLastPromptFromTail(
         if (nl >= 0) raw = raw.slice(nl + 1);
       }
 
-      // Scan in reverse to find the last user line with real text
+      // Scan in reverse to find the latest real user and assistant texts.
       const lines = raw.split("\n");
       for (let i = lines.length - 1; i >= 0; i--) {
         const line = lines[i];
         if (!line.trim()) continue;
-        if (!RE_TYPE_USER.test(line)) continue;
+        if (!lastPrompt && RE_TYPE_USER.test(line)) {
         try {
           const entry = JSON.parse(line) as Record<string, unknown>;
           const text = extractUserPromptText(entry);
-          if (text && !isSystemInjectedText(text)) return text;
+            if (text && !isSystemInjectedText(text)) lastPrompt = text;
+          } catch {
+            // Truncated line — retry with a larger window.
+          }
+        } else if (!lastResponse && RE_TYPE_ASSISTANT.test(line)) {
+          try {
+            const entry = JSON.parse(line) as Record<string, unknown>;
+            const text = extractAssistantResponseText(entry);
+            if (text) lastResponse = text;
         } catch {
-          // Truncated line — skip
+            // Truncated line — retry with a larger window.
+          }
+        }
+        if (lastPrompt && lastResponse) {
+          return { lastPrompt, lastResponse };
         }
       }
 
       // If we already read the entire file, stop
       if (readSize >= fileSize) break;
     }
-    return "";
+    return { lastPrompt, lastResponse };
   } finally {
     await fh.close();
   }
+}
+
+async function supplementClaudeRecentText(
+  entries: SessionIndexEntry[],
+): Promise<void> {
+  const targets = entries.filter(
+    (entry) =>
+      entry.provider === "claude" &&
+      (!entry.lastPrompt || !entry.lastResponse) &&
+      entry.projectPath,
+  );
+  if (targets.length === 0) return;
+
+  const projectsDir = join(homedir(), ".claude", "projects");
+  await parallelMap(targets, PARALLEL_FILE_READ_LIMIT, async (entry) => {
+    const slug = pathToSlug(entry.projectPath);
+    const jsonlPath = join(projectsDir, slug, `${entry.sessionId}.jsonl`);
+    const recentText = await extractRecentTextFromTail(jsonlPath);
+    if (
+      !entry.lastPrompt &&
+      recentText.lastPrompt &&
+      recentText.lastPrompt !== entry.firstPrompt
+    ) {
+      entry.lastPrompt = recentText.lastPrompt;
+    }
+    if (!entry.lastResponse && recentText.lastResponse) {
+      entry.lastResponse = recentText.lastResponse;
+    }
+  });
 }
 
 /**
@@ -928,9 +1030,7 @@ export async function getAllRecentSessions(
   markDuration(durations, "loadClaudeProjectDirs", loadProjectDirsStartedAt);
 
   // Compute worktree slug prefix for projectPath filtering
-  const projectSlug = filterProjectPath
-    ? pathToSlug(filterProjectPath)
-    : null;
+  const projectSlug = filterProjectPath ? pathToSlug(filterProjectPath) : null;
 
   // --- Load Claude and Codex sessions in parallel ---
 
@@ -976,7 +1076,12 @@ export async function getAllRecentSessions(
           indexDirs: 0,
           indexEntries: 0,
           jsonlOnlyDirs: 0,
-          jsonlStats: { filesTotal: 0, filesExcluded: 0, filesRead: 0, entriesReturned: 0 },
+          jsonlStats: {
+            filesTotal: 0,
+            filesExcluded: 0,
+            filesRead: 0,
+            entriesReturned: 0,
+          },
         };
 
         if (raw !== null) {
@@ -1023,7 +1128,9 @@ export async function getAllRecentSessions(
           }
 
           result.jsonlOnlyDirs = 1;
-          const scanned = await scanJsonlDir(dirPath, { stats: result.jsonlStats });
+          const scanned = await scanJsonlDir(dirPath, {
+            stats: result.jsonlStats,
+          });
           result.entries.push(...scanned);
         }
 
@@ -1091,7 +1198,8 @@ export async function getAllRecentSessions(
         (e.modified ? 1 : 0) +
         (e.name ? 1 : 0) +
         (e.summary ? 1 : 0) +
-        (e.lastPrompt ? 1 : 0);
+        (e.lastPrompt ? 1 : 0) +
+        (e.lastResponse ? 1 : 0);
       if (score(entry) > score(existing)) {
         seen.set(entry.sessionId, entry);
       }
@@ -1125,7 +1233,20 @@ export async function getAllRecentSessions(
   }
   perfStats.counts.afterNamedOnly = filtered.length;
 
-  // Filter by search query (name, firstPrompt, lastPrompt, summary)
+  // Claude's index does not include recent prompt/response text. Hydrate all
+  // remaining Claude candidates before server-side search so a phrase visible
+  // on a recent-session card is searchable too.
+  if (options.searchQuery) {
+    const supplementSearchStartedAt = process.hrtime.bigint();
+    await supplementClaudeRecentText(filtered);
+    markDuration(
+      durations,
+      "supplementSearchRecentText",
+      supplementSearchStartedAt,
+    );
+  }
+
+  // Filter by search query across every visible preview field.
   if (options.searchQuery) {
     const q = options.searchQuery.toLowerCase();
     filtered = filtered.filter(
@@ -1133,6 +1254,7 @@ export async function getAllRecentSessions(
         e.name?.toLowerCase().includes(q) ||
         e.firstPrompt?.toLowerCase().includes(q) ||
         e.lastPrompt?.toLowerCase().includes(q) ||
+        e.lastResponse?.toLowerCase().includes(q) ||
         e.summary?.toLowerCase().includes(q),
     );
   }
@@ -1153,25 +1275,11 @@ export async function getAllRecentSessions(
   perfStats.counts.returned = sliced.length;
   markDuration(durations, "paginate", paginateStartedAt);
 
-  // Supplement missing lastPrompt for Claude sessions (sessions-index.json
-  // doesn't include lastPrompt).  Only the paginated page is processed so at
-  // most `limit` tail reads are needed — lightweight enough to keep inline.
+  // Supplement recent text for Claude sessions. sessions-index.json doesn't
+  // include the last prompt or response, so only the paginated page is read.
   const supplementStartedAt = process.hrtime.bigint();
-  const needLastPrompt = sliced.filter(
-    (e) => e.provider === "claude" && !e.lastPrompt && e.projectPath,
-  );
-  if (needLastPrompt.length > 0) {
-    const projectsDir = join(homedir(), ".claude", "projects");
-    await parallelMap(needLastPrompt, PARALLEL_FILE_READ_LIMIT, async (entry) => {
-      const slug = pathToSlug(entry.projectPath);
-      const jsonlPath = join(projectsDir, slug, `${entry.sessionId}.jsonl`);
-      const lp = await extractLastPromptFromTail(jsonlPath);
-      if (lp && lp !== entry.firstPrompt) {
-        entry.lastPrompt = lp;
-      }
-    });
-  }
-  markDuration(durations, "supplementLastPrompt", supplementStartedAt);
+  await supplementClaudeRecentText(sliced);
+  markDuration(durations, "supplementRecentText", supplementStartedAt);
 
   markDuration(durations, "total", totalStartedAt);
   logRecentSessionsPerf(options, durations, perfStats);
@@ -1201,6 +1309,8 @@ export interface CodexSessionIndexMetadata {
   lastPrompt?: string;
   /** Last assistant message text — the closest thing to a session summary. */
   summary?: string;
+  /** Last assistant response text for the recent-session card. */
+  lastResponse?: string;
 }
 
 interface CodexSessionParseResult {
@@ -1234,7 +1344,10 @@ async function listCodexSessionFiles(): Promise<string[]> {
   return files;
 }
 
-function parseCodexSessionJsonl(raw: string, fallbackSessionId: string): CodexSessionParseResult | null {
+function parseCodexSessionJsonl(
+  raw: string,
+  fallbackSessionId: string,
+): CodexSessionParseResult | null {
   const lines = raw.split("\n");
   let threadId = fallbackSessionId;
   let projectPath = "";
@@ -1305,10 +1418,16 @@ function parseCodexSessionJsonl(raw: string, fallbackSessionId: string): CodexSe
         if (git && typeof git.branch === "string") {
           gitBranch = git.branch;
         }
-        if (typeof payload.agent_nickname === "string" && payload.agent_nickname.length > 0) {
+        if (
+          typeof payload.agent_nickname === "string" &&
+          payload.agent_nickname.length > 0
+        ) {
           agentNickname = payload.agent_nickname;
         }
-        if (typeof payload.agent_role === "string" && payload.agent_role.length > 0) {
+        if (
+          typeof payload.agent_role === "string" &&
+          payload.agent_role.length > 0
+        ) {
           agentRole = payload.agent_role;
         }
       }
@@ -1327,15 +1446,18 @@ function parseCodexSessionJsonl(raw: string, fallbackSessionId: string): CodexSe
         if (typeof payload.approvals_reviewer === "string") {
           approvalsReviewer = payload.approvals_reviewer;
         }
-        const sp = payload.sandbox_policy as Record<string, unknown> | undefined;
+        const sp = payload.sandbox_policy as
+          Record<string, unknown> | undefined;
         if (sp && typeof sp.type === "string") {
           sandboxMode = sp.type;
         }
         if (typeof payload.model === "string") {
           model = payload.model;
         }
-        const collaborationMode = payload.collaboration_mode as Record<string, unknown> | undefined;
-        const collaborationSettings = collaborationMode?.settings as Record<string, unknown> | undefined;
+        const collaborationMode = payload.collaboration_mode as
+          Record<string, unknown> | undefined;
+        const collaborationSettings = collaborationMode?.settings as
+          Record<string, unknown> | undefined;
         if (typeof collaborationSettings?.reasoning_effort === "string") {
           modelReasoningEffort = collaborationSettings.reasoning_effort;
         }
@@ -1360,14 +1482,17 @@ function parseCodexSessionJsonl(raw: string, fallbackSessionId: string): CodexSe
 
     if (entry.type === "event_msg") {
       const payload = entry.payload as Record<string, unknown> | undefined;
-      if (payload?.type === "user_message" && typeof payload.message === "string") {
+      if (
+        payload?.type === "user_message" &&
+        typeof payload.message === "string"
+      ) {
         hasMessages = true;
         if (!firstPrompt) firstPrompt = payload.message;
         lastPrompt = payload.message;
       } else if (
-        payload?.type === "agent_message"
-        && typeof payload.message === "string"
-        && payload.message.trim().length > 0
+        payload?.type === "agent_message" &&
+        typeof payload.message === "string" &&
+        payload.message.trim().length > 0
       ) {
         hasMessages = true;
         lastAssistantText = payload.message;
@@ -1377,13 +1502,20 @@ function parseCodexSessionJsonl(raw: string, fallbackSessionId: string): CodexSe
 
     if (entry.type === "response_item") {
       const payload = entry.payload as Record<string, unknown> | undefined;
-      if (!payload || payload.type !== "message" || payload.role !== "assistant") {
+      if (
+        !payload ||
+        payload.type !== "message" ||
+        payload.role !== "assistant"
+      ) {
         continue;
       }
       const content = payload.content;
       if (!Array.isArray(content)) continue;
       const text = (content as Array<Record<string, unknown>>)
-        .filter((item) => item.type === "output_text" && typeof item.text === "string")
+        .filter(
+          (item) =>
+            item.type === "output_text" && typeof item.text === "string",
+        )
         .map((item) => item.text as string)
         .join("\n")
         .trim();
@@ -1399,16 +1531,15 @@ function parseCodexSessionJsonl(raw: string, fallbackSessionId: string): CodexSe
   if (!projectPath || !hasMessages) return null;
   summary = lastAssistantText || summary;
 
-  const codexSettings = (
-    approvalPolicy
-    || approvalsReviewer
-    || sandboxMode
-    || model
-    || modelReasoningEffort
-    || serviceTier
-    || networkAccessEnabled !== undefined
-    || webSearchMode
-  )
+  const codexSettings =
+    approvalPolicy ||
+    approvalsReviewer ||
+    sandboxMode ||
+    model ||
+    modelReasoningEffort ||
+    serviceTier ||
+    networkAccessEnabled !== undefined ||
+    webSearchMode
     ? {
         approvalPolicy,
         approvalsReviewer,
@@ -1429,6 +1560,7 @@ function parseCodexSessionJsonl(raw: string, fallbackSessionId: string): CodexSe
       ...(agentNickname ? { agentNickname } : {}),
       ...(agentRole ? { agentRole } : {}),
       summary: summary || undefined,
+      lastResponse: lastAssistantText || undefined,
       firstPrompt,
       ...(lastPrompt && lastPrompt !== firstPrompt ? { lastPrompt } : {}),
       created,
@@ -1500,7 +1632,9 @@ function extractClaudeCustomTitleFromText(text: string): string | undefined {
   return customTitle || undefined;
 }
 
-async function getClaudeJsonlCustomTitle(filePath: string): Promise<string | undefined> {
+async function getClaudeJsonlCustomTitle(
+  filePath: string,
+): Promise<string | undefined> {
   let fh;
   try {
     fh = await open(filePath, "r");
@@ -1520,7 +1654,9 @@ async function getClaudeJsonlCustomTitle(filePath: string): Promise<string | und
 
     const headBuf = Buffer.alloc(HEAD_BYTES);
     await fh.read(headBuf, 0, HEAD_BYTES, 0);
-    const headTitle = extractClaudeCustomTitleFromText(headBuf.toString("utf-8"));
+    const headTitle = extractClaudeCustomTitleFromText(
+      headBuf.toString("utf-8"),
+    );
 
     const tailBuf = Buffer.alloc(TAIL_BYTES);
     await fh.read(tailBuf, 0, TAIL_BYTES, fileSize - TAIL_BYTES);
@@ -1565,8 +1701,12 @@ export async function getClaudeSessionName(
 
   const entry = index.entries.find((e) => e.sessionId === claudeSessionId);
   return (
-    await getClaudeJsonlCustomTitle(entry?.fullPath || join(dirPath, `${claudeSessionId}.jsonl`))
-  ) ?? entry?.customTitle ?? undefined;
+    (await getClaudeJsonlCustomTitle(
+      entry?.fullPath || join(dirPath, `${claudeSessionId}.jsonl`),
+    )) ??
+    entry?.customTitle ??
+    undefined
+  );
 }
 
 /**
@@ -1611,7 +1751,13 @@ export async function renameClaudeSession(
   }
 
   const slug = pathToSlug(projectPath);
-  const indexPath = join(homedir(), ".claude", "projects", slug, "sessions-index.json");
+  const indexPath = join(
+    homedir(),
+    ".claude",
+    "projects",
+    slug,
+    "sessions-index.json",
+  );
 
   let index: RawSessionIndexFile | null = null;
   try {
@@ -1801,7 +1947,9 @@ export async function renameCodexSession(
   }
 }
 
-async function getAllRecentCodexSessions(options: CodexRecentOptions = {}): Promise<SessionIndexEntry[]> {
+async function getAllRecentCodexSessions(
+  options: CodexRecentOptions = {},
+): Promise<SessionIndexEntry[]> {
   const files = await listCodexSessionFiles();
   const entries: SessionIndexEntry[] = [];
   options.perfStats && (options.perfStats.filesTotal = files.length);
@@ -1827,7 +1975,10 @@ async function getAllRecentCodexSessions(options: CodexRecentOptions = {}): Prom
   for (const parsed of parsedResults) {
     options.perfStats && (options.perfStats.filesRead += 1);
     if (!parsed) continue;
-    if (normalizedProjectPath && parsed.entry.projectPath !== normalizedProjectPath) {
+    if (
+      normalizedProjectPath &&
+      parsed.entry.projectPath !== normalizedProjectPath
+    ) {
       continue;
     }
     // Attach thread name if available
@@ -1881,7 +2032,10 @@ export async function getCodexSessionIndexMetadata(
   const targets: string[] = [];
   const matchedThreadIds = new Set<string>();
   for (const filePath of files) {
-    const threadId = matchingCodexThreadIdFromFilePath(filePath, wantedThreadIds);
+    const threadId = matchingCodexThreadIdFromFilePath(
+      filePath,
+      wantedThreadIds,
+    );
     if (!threadId || matchedThreadIds.has(threadId)) continue;
     targets.push(filePath);
     matchedThreadIds.add(threadId);
@@ -1904,9 +2058,16 @@ export async function getCodexSessionIndexMetadata(
         ? { codexSettings: parsed.entry.codexSettings }
         : {}),
       ...(parsed.entry.resumeCwd ? { resumeCwd: parsed.entry.resumeCwd } : {}),
-      ...(parsed.entry.firstPrompt ? { firstPrompt: parsed.entry.firstPrompt } : {}),
-      ...(parsed.entry.lastPrompt ? { lastPrompt: parsed.entry.lastPrompt } : {}),
+      ...(parsed.entry.firstPrompt
+        ? { firstPrompt: parsed.entry.firstPrompt }
+        : {}),
+      ...(parsed.entry.lastPrompt
+        ? { lastPrompt: parsed.entry.lastPrompt }
+        : {}),
       ...(parsed.entry.summary ? { summary: parsed.entry.summary } : {}),
+      ...(parsed.entry.lastResponse
+        ? { lastResponse: parsed.entry.lastResponse }
+        : {}),
     });
   }
 
@@ -1939,6 +2100,189 @@ export interface SessionHistoryMessage {
   imagePaths?: string[];
   imageBase64?: Array<{ data: string; mimeType: string }>;
   content: string | SessionHistoryContentItem[];
+}
+
+export const CODEX_HISTORY_MAX_MESSAGES = 2000;
+export const CODEX_HISTORY_MAX_BYTES = 16 * 1024 * 1024;
+const CODEX_HISTORY_MAX_MESSAGE_BYTES = 2 * 1024 * 1024;
+const CODEX_HISTORY_MAX_TEXT_CHARS = 512 * 1024;
+
+function truncateHistoryText(value: string, maxChars: number): string {
+  if (value.length <= maxChars) return value;
+  const marker = "\n…[older output truncated while restoring this session]…\n";
+  const headChars = Math.max(0, Math.floor((maxChars - marker.length) * 0.75));
+  const tailChars = Math.max(0, maxChars - marker.length - headChars);
+  return `${value.slice(0, headChars)}${marker}${value.slice(-tailChars)}`;
+}
+
+function serializedByteLength(value: unknown): number {
+  try {
+    return Buffer.byteLength(JSON.stringify(value), "utf-8");
+  } catch {
+    return CODEX_HISTORY_MAX_MESSAGE_BYTES;
+  }
+}
+
+function compactCodexHistoryMessage(
+  message: SessionHistoryMessage,
+): SessionHistoryMessage {
+  const content =
+    typeof message.content === "string"
+      ? truncateHistoryText(message.content, CODEX_HISTORY_MAX_TEXT_CHARS)
+      : message.content.map((item) => {
+          const next = { ...item };
+          if (typeof next.text === "string") {
+            next.text = truncateHistoryText(
+              next.text,
+              CODEX_HISTORY_MAX_TEXT_CHARS,
+            );
+          }
+          if (typeof next.thinking === "string") {
+            next.thinking = truncateHistoryText(
+              next.thinking,
+              CODEX_HISTORY_MAX_TEXT_CHARS,
+            );
+          }
+          if (
+            next.input &&
+            serializedByteLength(next.input) > CODEX_HISTORY_MAX_TEXT_CHARS
+          ) {
+            next.input = {
+              truncated: true,
+              preview: truncateHistoryText(
+                JSON.stringify(next.input),
+                CODEX_HISTORY_MAX_TEXT_CHARS,
+              ),
+            };
+          }
+          return next;
+        });
+  let imageBytes = 0;
+  const imageBase64 = message.imageBase64?.filter((image) => {
+    imageBytes += Buffer.byteLength(image.data, "utf-8");
+    return imageBytes <= CODEX_HISTORY_MAX_MESSAGE_BYTES;
+  });
+  let compacted: SessionHistoryMessage = {
+    ...message,
+    content,
+    ...(imageBase64 && imageBase64.length > 0
+      ? { imageBase64 }
+      : { imageBase64: undefined }),
+  };
+  if (serializedByteLength(compacted) <= CODEX_HISTORY_MAX_MESSAGE_BYTES) {
+    return compacted;
+  }
+
+  compacted = {
+    ...compacted,
+    imageBase64: undefined,
+    content:
+      typeof compacted.content === "string"
+        ? truncateHistoryText(compacted.content, 128 * 1024)
+        : compacted.content.map((item) => ({
+            ...item,
+            ...(typeof item.text === "string"
+              ? { text: truncateHistoryText(item.text, 128 * 1024) }
+              : {}),
+            ...(typeof item.thinking === "string"
+              ? {
+                  thinking: truncateHistoryText(item.thinking, 128 * 1024),
+                }
+              : {}),
+            ...(item.input ? { input: { truncated: true } } : {}),
+          })),
+  };
+  if (serializedByteLength(compacted) <= CODEX_HISTORY_MAX_MESSAGE_BYTES) {
+    return compacted;
+  }
+
+  const base: SessionHistoryMessage = {
+    role: compacted.role,
+    content: typeof compacted.content === "string" ? compacted.content : [],
+    ...(compacted.uuid ? { uuid: compacted.uuid } : {}),
+    ...(compacted.rawItemId ? { rawItemId: compacted.rawItemId } : {}),
+    ...(compacted.timestamp ? { timestamp: compacted.timestamp } : {}),
+    ...(compacted.isMeta ? { isMeta: true } : {}),
+    ...(compacted.imageCount ? { imageCount: compacted.imageCount } : {}),
+    ...(compacted.toolUseId ? { toolUseId: compacted.toolUseId } : {}),
+    ...(compacted.toolName ? { toolName: compacted.toolName } : {}),
+  };
+  if (!Array.isArray(compacted.content)) return base;
+
+  const boundedContent: SessionHistoryContentItem[] = [];
+  let totalBytes = serializedByteLength(base);
+  for (const item of compacted.content) {
+    const itemBytes = serializedByteLength(item) + 1;
+    if (totalBytes + itemBytes > CODEX_HISTORY_MAX_MESSAGE_BYTES) break;
+    boundedContent.push(item);
+    totalBytes += itemBytes;
+  }
+  return {
+    ...base,
+    content:
+      boundedContent.length > 0
+        ? boundedContent
+        : [{ type: "text", text: "[older content omitted while restoring]" }],
+  };
+}
+
+export function boundCodexSessionHistory(
+  history: SessionHistoryMessage[],
+): SessionHistoryMessage[] {
+  const tail: SessionHistoryMessage[] = [];
+  let totalBytes = 0;
+  for (let index = history.length - 1; index >= 0; index--) {
+    const message = compactCodexHistoryMessage(history[index]);
+    const messageBytes = serializedByteLength(message);
+    if (
+      tail.length >= CODEX_HISTORY_MAX_MESSAGES ||
+      (tail.length > 0 && totalBytes + messageBytes > CODEX_HISTORY_MAX_BYTES)
+    ) {
+      break;
+    }
+    tail.push(message);
+    totalBytes += messageBytes;
+  }
+  return tail.reverse();
+}
+
+interface IncrementalCodexHistoryBudget {
+  bytesByMessage: number[];
+  totalBytes: number;
+}
+
+function compactAndBoundCodexHistoryInPlace(
+  messages: SessionHistoryMessage[],
+  budget: IncrementalCodexHistoryBudget,
+): void {
+  while (budget.bytesByMessage.length > messages.length) {
+    budget.totalBytes -= budget.bytesByMessage.pop() ?? 0;
+  }
+  for (
+    let index = budget.bytesByMessage.length;
+    index < messages.length;
+    index++
+  ) {
+    const compacted = compactCodexHistoryMessage(messages[index]);
+    messages[index] = compacted;
+    const messageBytes = serializedByteLength(compacted);
+    budget.bytesByMessage.push(messageBytes);
+    budget.totalBytes += messageBytes;
+  }
+
+  let dropCount = 0;
+  while (
+    messages.length - dropCount > CODEX_HISTORY_MAX_MESSAGES ||
+    (messages.length - dropCount > 1 &&
+      budget.totalBytes > CODEX_HISTORY_MAX_BYTES)
+  ) {
+    budget.totalBytes -= budget.bytesByMessage[dropCount] ?? 0;
+    dropCount += 1;
+  }
+  if (dropCount > 0) {
+    messages.splice(0, dropCount);
+    budget.bytesByMessage.splice(0, dropCount);
+  }
 }
 
 export function codexUserTurnUuid(ordinal: number): string {
@@ -2135,10 +2479,12 @@ export function codexThreadToSessionHistory(
         }
 
         case "reasoning": {
-          const summary = arrayValue(item.summary)
-            .filter((value): value is string => typeof value === "string");
-          const content = arrayValue(item.content)
-            .filter((value): value is string => typeof value === "string");
+          const summary = arrayValue(item.summary).filter(
+            (value): value is string => typeof value === "string",
+          );
+          const content = arrayValue(item.content).filter(
+            (value): value is string => typeof value === "string",
+          );
           appendCodexThinkingMessage(
             messages,
             [...summary, ...content].join("\n"),
@@ -2195,7 +2541,9 @@ export function codexThreadToSessionHistory(
             ...(typeof item.status === "string" ? { status: item.status } : {}),
           });
           if (item.result != null || item.error != null) {
-            const normalized = normalizeCodexMcpResult(item.result ?? item.error);
+            const normalized = normalizeCodexMcpResult(
+              item.result ?? item.error,
+            );
             appendToolResultMessage(
               messages,
               itemId,
@@ -2328,14 +2676,14 @@ function appendTextMessage(
 
   const last = messages.at(-1);
   if (
-    last
-    && last.role === role
-    && Array.isArray(last.content)
-    && last.content.length === 1
-    && last.content[0].type === "text"
-    && typeof last.content[0].text === "string"
-    && last.content[0].text.trim() === normalized
-    && (!uuid || last.uuid === uuid)
+    last &&
+    last.role === role &&
+    Array.isArray(last.content) &&
+    last.content.length === 1 &&
+    last.content[0].type === "text" &&
+    typeof last.content[0].text === "string" &&
+    last.content[0].text.trim() === normalized &&
+    (!uuid || last.uuid === uuid)
   ) {
     return false;
   }
@@ -2350,8 +2698,9 @@ function appendTextMessage(
 }
 
 function countCodexUserTurns(messages: SessionHistoryMessage[]): number {
-  return messages.filter((message) => message.role === "user" && !message.isMeta)
-    .length;
+  return messages.filter(
+    (message) => message.role === "user" && !message.isMeta,
+  ).length;
 }
 
 function applyCodexThreadRollback(
@@ -2392,7 +2741,8 @@ function appendImageGenerationResult(
     return;
   }
 
-  const status = typeof payload.status === "string" ? payload.status : undefined;
+  const status =
+    typeof payload.status === "string" ? payload.status : undefined;
   const revisedPrompt =
     typeof payload.revised_prompt === "string"
       ? payload.revised_prompt
@@ -2405,7 +2755,8 @@ function appendImageGenerationResult(
       : typeof payload.savedPath === "string"
         ? payload.savedPath
         : undefined;
-  const result = typeof payload.result === "string" ? payload.result : undefined;
+  const result =
+    typeof payload.result === "string" ? payload.result : undefined;
   const base64Image =
     !savedPath && result
       ? { data: stripImageDataUrlPrefix(result), mimeType: "image/png" }
@@ -2470,13 +2821,13 @@ function appendToolUseMessage(
 
   const last = messages.at(-1);
   if (
-    last
-    && last.role === "assistant"
-    && Array.isArray(last.content)
-    && last.content.length === 1
-    && last.content[0].type === "tool_use"
-    && last.content[0].id === id
-    && last.content[0].name === normalizedName
+    last &&
+    last.role === "assistant" &&
+    Array.isArray(last.content) &&
+    last.content.length === 1 &&
+    last.content[0].type === "tool_use" &&
+    last.content[0].id === id &&
+    last.content[0].name === normalizedName
   ) {
     return;
   }
@@ -2601,18 +2952,20 @@ function normalizeCodexMcpResult(result: unknown): {
 function isCodexInjectedUserContext(text: string): boolean {
   const normalized = text.trimStart();
   return (
-    normalized.startsWith("# AGENTS.md instructions for ")
-    || normalized.startsWith("<environment_context>")
-    || normalized.startsWith("<permissions instructions>")
-    || normalized.startsWith("<collaboration_mode>")
-    || normalized.startsWith("<personality_spec>")
-    || normalized.startsWith("<skills_instructions>")
-    || normalized.startsWith("<plugins_instructions>")
-    || normalized.startsWith("<skill>")
+    normalized.startsWith("# AGENTS.md instructions for ") ||
+    normalized.startsWith("<environment_context>") ||
+    normalized.startsWith("<permissions instructions>") ||
+    normalized.startsWith("<collaboration_mode>") ||
+    normalized.startsWith("<personality_spec>") ||
+    normalized.startsWith("<skills_instructions>") ||
+    normalized.startsWith("<plugins_instructions>") ||
+    normalized.startsWith("<skill>")
   );
 }
 
-function getCodexSearchInput(payload: Record<string, unknown>): Record<string, unknown> {
+function getCodexSearchInput(
+  payload: Record<string, unknown>,
+): Record<string, unknown> {
   const action = asObject(payload.action);
   const input: Record<string, unknown> = {};
   if (typeof action?.query === "string") {
@@ -2688,26 +3041,71 @@ async function findSessionJsonlPath(sessionId: string): Promise<string | null> {
   return null;
 }
 
-async function findCodexSessionJsonlPath(threadId: string): Promise<string | null> {
+async function findCodexSessionJsonlPath(
+  threadId: string,
+): Promise<string | null> {
   const files = await listCodexSessionFiles();
-  for (const filePath of files) {
-    const fallbackSessionId = basename(filePath, ".jsonl");
-    if (
-      fallbackSessionId === threadId ||
-      fallbackSessionId.endsWith(`-${threadId}`)
-    ) {
+  const exactFilenameMatch = files.find(
+    (filePath) => basename(filePath, ".jsonl") === threadId,
+  );
+  if (exactFilenameMatch) return exactFilenameMatch;
+
+  const rolloutFilenameMatches = files.filter((filePath) =>
+    basename(filePath, ".jsonl").endsWith(`-${threadId}`),
+  );
+  let filenameMatchWithoutMetadata: string | null = null;
+  for (const filePath of rolloutFilenameMatches) {
+    const metadataThreadId = await readCodexSessionMetaThreadId(filePath);
+    if (metadataThreadId === threadId) {
       return filePath;
     }
-    let raw: string;
+    if (metadataThreadId === null && filenameMatchWithoutMetadata === null) {
+      filenameMatchWithoutMetadata = filePath;
+    }
+  }
+  if (filenameMatchWithoutMetadata) return filenameMatchWithoutMetadata;
+
+  const filenameMatches = new Set(rolloutFilenameMatches);
+  for (const filePath of files) {
+    if (filenameMatches.has(filePath)) continue;
+    if ((await readCodexSessionMetaThreadId(filePath)) === threadId) {
+      return filePath;
+    }
+  }
+  return null;
+}
+
+const CODEX_SESSION_META_SCAN_MAX_BYTES = 64 * 1024;
+
+async function readCodexSessionMetaThreadId(
+  filePath: string,
+): Promise<string | null> {
+  let handle;
+  try {
+    handle = await open(filePath, "r");
+    const buffer = Buffer.alloc(CODEX_SESSION_META_SCAN_MAX_BYTES);
+    const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
+    let head = buffer.toString("utf-8", 0, bytesRead);
+    if (bytesRead === buffer.length && !head.endsWith("\n")) {
+      const finalNewline = head.lastIndexOf("\n");
+      head = finalNewline >= 0 ? head.slice(0, finalNewline) : "";
+    }
+    for (const line of head.split("\n")) {
+      if (!line.trim()) continue;
+      let entry: Record<string, unknown>;
     try {
-      raw = await readFile(filePath, "utf-8");
+        entry = JSON.parse(line) as Record<string, unknown>;
     } catch {
       continue;
     }
-    const parsed = parseCodexSessionJsonl(raw, fallbackSessionId);
-    if (parsed?.threadId === threadId) {
-      return filePath;
+      if (entry.type !== "session_meta") continue;
+      const payload = asObject(entry.payload);
+      return typeof payload?.id === "string" ? payload.id : null;
     }
+  } catch {
+    return null;
+  } finally {
+    await handle?.close().catch(() => {});
   }
   return null;
 }
@@ -2747,14 +3145,16 @@ export async function getSessionHistory(
 
     // Skip context compaction and transcript-only messages (not real user input)
     if (type === "user") {
-      if (entry.isCompactSummary === true || entry.isVisibleInTranscriptOnly === true) {
+      if (
+        entry.isCompactSummary === true ||
+        entry.isVisibleInTranscriptOnly === true
+      ) {
         continue;
       }
     }
 
     const message = entry.message as
-      | { role: string; content: unknown[] | string }
-      | undefined;
+      { role: string; content: unknown[] | string } | undefined;
     if (!message?.content) continue;
 
     const role = message.role as "user" | "assistant";
@@ -2831,17 +3231,17 @@ export interface ExtractedImage {
   mimeType: string;
 }
 
-interface CodexMessageImageIndex {
+interface CodexMessageImagesCacheEntry {
   jsonlPath: string;
   size: number;
   mtimeMs: number;
-  imagesByUuid: Map<string, ExtractedImage[]>;
+  images: ExtractedImage[];
 }
 
-const CODEX_IMAGE_INDEX_CACHE_LIMIT = 8;
-const codexMessageImageIndexCache = new Map<
+const CODEX_MESSAGE_IMAGE_CACHE_LIMIT = 64;
+const codexMessageImageCache = new Map<
   string,
-  Promise<CodexMessageImageIndex | null>
+  Promise<CodexMessageImagesCacheEntry | null>
 >();
 
 interface ClaudeMessageImageIndex {
@@ -2984,7 +3384,8 @@ async function buildClaudeMessageImageIndex(
     if (entry.type !== "user") continue;
     if (typeof entry.uuid !== "string") continue;
 
-    const message = entry.message as { content: unknown[] | string } | undefined;
+    const message = entry.message as
+      { content: unknown[] | string } | undefined;
     if (!message?.content || !Array.isArray(message.content)) continue;
 
     const images: ExtractedImage[] = [];
@@ -3023,11 +3424,25 @@ async function buildClaudeMessageImageIndex(
 }
 
 async function extractCodexMessageImages(
-  sessionId: string,
+  threadId: string,
   messageUuid: string,
 ): Promise<ExtractedImage[]> {
-  const index = await getCodexMessageImageIndex(sessionId);
-  return index?.imagesByUuid.get(messageUuid) ?? [];
+  const cacheKey = `${threadId}\u0000${messageUuid}`;
+  const cached = codexMessageImageCache.get(cacheKey);
+  if (cached) {
+    const entry = await cached;
+    if (entry && (await isFreshCodexMessageImagesEntry(entry))) {
+      codexMessageImageCache.delete(cacheKey);
+      codexMessageImageCache.set(cacheKey, cached);
+      return entry.images;
+    }
+    codexMessageImageCache.delete(cacheKey);
+  }
+
+  const promise = buildCodexMessageImagesEntry(threadId, messageUuid);
+  codexMessageImageCache.set(cacheKey, promise);
+  trimCodexMessageImageCache();
+  return (await promise)?.images ?? [];
 }
 
 function isCodexMessageImageUuid(messageUuid: string): boolean {
@@ -3037,103 +3452,120 @@ function isCodexMessageImageUuid(messageUuid: string): boolean {
   );
 }
 
-async function getCodexMessageImageIndex(
-  threadId: string,
-): Promise<CodexMessageImageIndex | null> {
-  const cached = codexMessageImageIndexCache.get(threadId);
-  if (cached) {
-    const index = await cached;
-    if (index && (await isFreshCodexMessageImageIndex(index))) {
-      return index;
-    }
-    codexMessageImageIndexCache.delete(threadId);
-  }
-
-  const promise = buildCodexMessageImageIndex(threadId);
-  codexMessageImageIndexCache.set(threadId, promise);
-  trimCodexMessageImageIndexCache();
-  return promise;
-}
-
-async function isFreshCodexMessageImageIndex(
-  index: CodexMessageImageIndex,
+async function isFreshCodexMessageImagesEntry(
+  entry: CodexMessageImagesCacheEntry,
 ): Promise<boolean> {
   try {
-    const current = await stat(index.jsonlPath);
-    return current.size === index.size && current.mtimeMs === index.mtimeMs;
+    const current = await stat(entry.jsonlPath);
+    return current.size === entry.size && current.mtimeMs === entry.mtimeMs;
   } catch {
     return false;
   }
 }
 
-function trimCodexMessageImageIndexCache() {
-  while (codexMessageImageIndexCache.size > CODEX_IMAGE_INDEX_CACHE_LIMIT) {
-    const oldest = codexMessageImageIndexCache.keys().next().value;
+function trimCodexMessageImageCache(): void {
+  while (codexMessageImageCache.size > CODEX_MESSAGE_IMAGE_CACHE_LIMIT) {
+    const oldest = codexMessageImageCache.keys().next().value;
     if (!oldest) return;
-    codexMessageImageIndexCache.delete(oldest);
+    codexMessageImageCache.delete(oldest);
   }
 }
 
-async function buildCodexMessageImageIndex(
+async function buildCodexMessageImagesEntry(
   threadId: string,
-): Promise<CodexMessageImageIndex | null> {
+  messageUuid: string,
+): Promise<CodexMessageImagesCacheEntry | null> {
   const jsonlPath = await findCodexSessionJsonlPath(threadId);
   if (!jsonlPath) return null;
 
-  let fileStat;
-  let raw: string;
   try {
-    fileStat = await stat(jsonlPath);
-    raw = await readFile(jsonlPath, "utf-8");
-  } catch {
-    return null;
-  }
-
-  const imagesByUuid = await collectCodexMessageImages(raw.split("\n"));
+    const fileStat = await stat(jsonlPath);
+    const images = await scanCodexMessageImages(jsonlPath, messageUuid);
   return {
     jsonlPath,
     size: fileStat.size,
     mtimeMs: fileStat.mtimeMs,
-    imagesByUuid,
+      images,
   };
+  } catch {
+    return null;
+  }
 }
 
-async function collectCodexMessageImages(
-  lines: string[],
-): Promise<Map<string, ExtractedImage[]>> {
-  const imagesByUuid = new Map<string, ExtractedImage[]>();
-  const responseItemImagesByOrdinal =
-    collectCodexUserResponseItemImagesByOrdinal(lines);
-  let ordinal = 0;
+async function scanCodexMessageImages(
+  jsonlPath: string,
+  messageUuid: string,
+): Promise<ExtractedImage[]> {
+  const lineMatch = /^codex-line-(\d+)$/.exec(messageUuid);
+  const ordinalMatch = /^codex:user-turn:(\d+)$/.exec(messageUuid);
+  const targetLineIndex = lineMatch ? Number(lineMatch[1]) : undefined;
+  const targetOrdinal = ordinalMatch ? Number(ordinalMatch[1]) : undefined;
+  if (
+    (targetLineIndex === undefined || !Number.isSafeInteger(targetLineIndex)) &&
+    (targetOrdinal === undefined ||
+      !Number.isSafeInteger(targetOrdinal) ||
+      targetOrdinal < 1)
+  ) {
+    return [];
+  }
 
-  for (const [lineIndex, line] of lines.entries()) {
-    if (!line.trim()) continue;
+  let lineIndex = 0;
+  let eventOrdinal = 0;
+  let responseOrdinal = 0;
+  let eventTargetSeen = false;
+  let responseFallback: ExtractedImage[] | undefined;
+  const lines = createInterface({
+    input: createReadStream(jsonlPath, { encoding: "utf-8" }),
+    crlfDelay: Infinity,
+  });
 
+  try {
+    for await (const line of lines) {
+      const currentLineIndex = lineIndex++;
+      if (!line.trim()) continue;
     let entry: Record<string, unknown>;
     try {
       entry = JSON.parse(line) as Record<string, unknown>;
     } catch {
       continue;
     }
-
-    if (entry.type !== "event_msg") continue;
     const payload = asObject(entry.payload);
-    if (!payload || payload.type !== "user_message") continue;
+      if (!payload) continue;
 
-    const lineImages = await extractCodexUserMessagePayloadImages(payload);
-    imagesByUuid.set(`codex-line-${lineIndex}`, lineImages);
+      if (
+        entry.type === "response_item" &&
+        payload.type === "message" &&
+        payload.role === "user" &&
+        codexUserResponseItemHasDisplayContent(payload)
+      ) {
+        responseOrdinal += 1;
+        if (responseOrdinal === targetOrdinal) {
+          const images = extractCodexUserResponseItemImages(payload);
+          if (images.length > 0) responseFallback = images;
+          if (eventTargetSeen) return responseFallback ?? [];
+        }
+        continue;
+      }
 
+      if (entry.type !== "event_msg" || payload.type !== "user_message") {
+        continue;
+      }
+      if (currentLineIndex === targetLineIndex) {
+        return extractCodexUserMessagePayloadImages(payload);
+      }
     if (!codexUserMessagePayloadHasDisplayContent(payload)) continue;
-    ordinal += 1;
-    imagesByUuid.set(
-      `codex:user-turn:${ordinal}`,
-      lineImages.length > 0
-        ? lineImages
-        : (responseItemImagesByOrdinal.get(ordinal) ?? []),
-    );
+      eventOrdinal += 1;
+      if (eventOrdinal !== targetOrdinal) continue;
+      eventTargetSeen = true;
+      const images = await extractCodexUserMessagePayloadImages(payload);
+      if (images.length > 0) return images;
+      if (responseFallback) return responseFallback;
+    }
+  } finally {
+    lines.close();
   }
 
-  return imagesByUuid;
+  return responseFallback ?? [];
 }
 
 async function extractCodexUserMessagePayloadImages(
@@ -3178,40 +3610,6 @@ async function extractCodexUserMessagePayloadImages(
     }
   }
   return images;
-}
-
-function collectCodexUserResponseItemImagesByOrdinal(
-  lines: string[],
-): Map<number, ExtractedImage[]> {
-  const imagesByOrdinal = new Map<number, ExtractedImage[]>();
-  let ordinal = 0;
-
-  for (const line of lines) {
-    if (!line.trim()) continue;
-    let entry: Record<string, unknown>;
-    try {
-      entry = JSON.parse(line) as Record<string, unknown>;
-    } catch {
-      continue;
-    }
-    if (entry.type !== "response_item") continue;
-    const payload = asObject(entry.payload);
-    if (
-      !payload ||
-      payload.type !== "message" ||
-      payload.role !== "user" ||
-      !codexUserResponseItemHasDisplayContent(payload)
-    ) {
-      continue;
-    }
-    ordinal += 1;
-    const images = extractCodexUserResponseItemImages(payload);
-    if (images.length > 0) {
-      imagesByOrdinal.set(ordinal, images);
-    }
-  }
-
-  return imagesByOrdinal;
 }
 
 function codexUserResponseItemHasDisplayContent(
@@ -3313,18 +3711,22 @@ export async function getCodexSessionHistory(
   const jsonlPath = await findCodexSessionJsonlPath(threadId);
   if (!jsonlPath) return [];
 
-  let raw: string;
-  try {
-    raw = await readFile(jsonlPath, "utf-8");
-  } catch {
-    return [];
-  }
-
   const messages: SessionHistoryMessage[] = [];
-  const lines = raw.split("\n");
+  const historyBudget: IncrementalCodexHistoryBudget = {
+    bytesByMessage: [],
+    totalBytes: 0,
+  };
   let userTurnOrdinal = 0;
+  let index = 0;
+  const lines = createInterface({
+    input: createReadStream(jsonlPath, { encoding: "utf-8" }),
+    crlfDelay: Infinity,
+  });
 
-  for (const [index, line] of lines.entries()) {
+  try {
+    for await (const line of lines) {
+      try {
+        const entryIndex = index++;
     if (!line.trim()) continue;
     let entry: Record<string, unknown>;
     try {
@@ -3342,21 +3744,29 @@ export async function getCodexSessionHistory(
       if (payload.type === "thread_rolled_back") {
         const rawNumTurns = payload.num_turns ?? payload.numTurns;
         const numTurns =
-          typeof rawNumTurns === "number" ? rawNumTurns : Number(rawNumTurns);
+              typeof rawNumTurns === "number"
+                ? rawNumTurns
+                : Number(rawNumTurns);
         applyCodexThreadRollback(messages, numTurns);
-        userTurnOrdinal = countCodexUserTurns(messages);
+            if (Number.isFinite(numTurns) && numTurns > 0) {
+              userTurnOrdinal = Math.max(0, userTurnOrdinal - numTurns);
+            }
         continue;
       }
 
       if (payload.type === "user_message") {
-        const rawMessage = typeof payload.message === "string" ? payload.message : "";
-        const images = Array.isArray(payload.images) ? payload.images.length : 0;
+            const rawMessage =
+              typeof payload.message === "string" ? payload.message : "";
+            const images = Array.isArray(payload.images)
+              ? payload.images.length
+              : 0;
         const localImages = Array.isArray(payload.local_images)
           ? payload.local_images.length
           : 0;
         const imageCount = images + localImages;
 
-        const text = rawMessage.trim().length > 0
+            const text =
+              rawMessage.trim().length > 0
           ? rawMessage
           : imageCount > 0
             ? `[Image attached${imageCount > 1 ? ` x${imageCount}` : ""}]`
@@ -3374,28 +3784,38 @@ export async function getCodexSessionHistory(
             });
           }
         } else {
-          if (appendTextMessage(
+              if (
+                appendTextMessage(
             messages,
             "user",
             text,
             entryTimestamp,
             codexUserTurnUuid(userTurnOrdinal + 1),
-          )) {
+                )
+              ) {
             userTurnOrdinal += 1;
           }
         }
         continue;
       }
 
-      if (payload.type === "agent_message" && typeof payload.message === "string") {
-        appendTextMessage(messages, "assistant", payload.message, entryTimestamp);
+          if (
+            payload.type === "agent_message" &&
+            typeof payload.message === "string"
+          ) {
+            appendTextMessage(
+              messages,
+              "assistant",
+              payload.message,
+              entryTimestamp,
+            );
       }
 
       if (payload.type === "image_generation_end") {
         appendImageGenerationResult(
           messages,
           payload,
-          `image-generation-${index}`,
+              `image-generation-${entryIndex}`,
           entryTimestamp,
         );
       }
@@ -3405,9 +3825,11 @@ export async function getCodexSessionHistory(
         const id =
           typeof payload.call_id === "string"
             ? payload.call_id
-            : `mcp-result-${index}`;
+                : `mcp-result-${entryIndex}`;
         const server =
-          typeof invocation?.server === "string" ? invocation.server : "mcp";
+              typeof invocation?.server === "string"
+                ? invocation.server
+                : "mcp";
         const tool =
           typeof invocation?.tool === "string" ? invocation.tool : "tool";
         const normalized = normalizeCodexMcpResult(payload.result);
@@ -3436,7 +3858,11 @@ export async function getCodexSessionHistory(
 
         if (payload.role === "assistant") {
           const text = content
-            .filter((item) => item.type === "output_text" && typeof item.text === "string")
+                .filter(
+                  (item) =>
+                    item.type === "output_text" &&
+                    typeof item.text === "string",
+                )
             .map((item) => item.text as string)
             .join("\n");
           appendTextMessage(messages, "assistant", text, entryTimestamp);
@@ -3448,17 +3874,22 @@ export async function getCodexSessionHistory(
             continue;
           }
           const text = content
-            .filter((item) => item.type === "input_text" && typeof item.text === "string")
+                .filter(
+                  (item) =>
+                    item.type === "input_text" && typeof item.text === "string",
+                )
             .map((item) => item.text as string)
             .join("\n");
           if (!isCodexInjectedUserContext(text)) {
-            if (appendTextMessage(
+                if (
+                  appendTextMessage(
               messages,
               "user",
               text,
               entryTimestamp,
               codexUserTurnUuid(userTurnOrdinal + 1),
-            )) {
+                  )
+                ) {
               userTurnOrdinal += 1;
             }
           }
@@ -3467,8 +3898,12 @@ export async function getCodexSessionHistory(
       }
 
       if (payload.type === "function_call") {
-        const id = typeof payload.call_id === "string" ? payload.call_id : `tool-${index}`;
-        const rawName = typeof payload.name === "string" ? payload.name : "tool";
+            const id =
+              typeof payload.call_id === "string"
+                ? payload.call_id
+                : `tool-${entryIndex}`;
+            const rawName =
+              typeof payload.name === "string" ? payload.name : "tool";
         appendToolUseMessage(
           messages,
           id,
@@ -3479,8 +3914,12 @@ export async function getCodexSessionHistory(
       }
 
       if (payload.type === "custom_tool_call") {
-        const id = typeof payload.call_id === "string" ? payload.call_id : `tool-${index}`;
-        const rawName = typeof payload.name === "string" ? payload.name : "custom_tool";
+            const id =
+              typeof payload.call_id === "string"
+                ? payload.call_id
+                : `tool-${entryIndex}`;
+            const rawName =
+              typeof payload.name === "string" ? payload.name : "custom_tool";
         appendToolUseMessage(
           messages,
           id,
@@ -3493,7 +3932,9 @@ export async function getCodexSessionHistory(
       if (payload.type === "web_search_call") {
         appendToolUseMessage(
           messages,
-          typeof payload.call_id === "string" ? payload.call_id : `web-search-${index}`,
+              typeof payload.call_id === "string"
+                ? payload.call_id
+                : `web-search-${entryIndex}`,
           "WebSearch",
           getCodexSearchInput(payload),
         );
@@ -3504,7 +3945,7 @@ export async function getCodexSessionHistory(
         appendImageGenerationResult(
           messages,
           payload,
-          `image-generation-${index}`,
+              `image-generation-${entryIndex}`,
           entryTimestamp,
         );
         continue;
@@ -3512,12 +3953,14 @@ export async function getCodexSessionHistory(
 
       // Backward/forward compatibility with older/newer Codex JSONL schemas.
       if (payload.type === "command_execution") {
-        const id = typeof payload.id === "string"
+            const id =
+              typeof payload.id === "string"
           ? payload.id
           : typeof payload.call_id === "string"
             ? payload.call_id
-            : `cmd-${index}`;
-        const input = typeof payload.command === "string"
+                  : `cmd-${entryIndex}`;
+            const input =
+              typeof payload.command === "string"
           ? { command: payload.command }
           : parseObjectLike(payload);
         appendToolUseMessage(messages, id, "Bash", input);
@@ -3525,13 +3968,16 @@ export async function getCodexSessionHistory(
       }
 
       if (payload.type === "mcp_tool_call") {
-        const id = typeof payload.id === "string"
+            const id =
+              typeof payload.id === "string"
           ? payload.id
           : typeof payload.call_id === "string"
             ? payload.call_id
-            : `mcp-${index}`;
-        const server = typeof payload.server === "string" ? payload.server : "unknown";
-        const tool = typeof payload.tool === "string" ? payload.tool : "tool";
+                  : `mcp-${entryIndex}`;
+            const server =
+              typeof payload.server === "string" ? payload.server : "unknown";
+            const tool =
+              typeof payload.tool === "string" ? payload.tool : "tool";
         appendToolUseMessage(
           messages,
           id,
@@ -3542,11 +3988,12 @@ export async function getCodexSessionHistory(
       }
 
       if (payload.type === "file_change") {
-        const id = typeof payload.id === "string"
+            const id =
+              typeof payload.id === "string"
           ? payload.id
           : typeof payload.call_id === "string"
             ? payload.call_id
-            : `file-change-${index}`;
+                  : `file-change-${entryIndex}`;
         const input = Array.isArray(payload.changes)
           ? { changes: payload.changes as unknown[] }
           : parseObjectLike(payload.changes);
@@ -3555,17 +4002,26 @@ export async function getCodexSessionHistory(
       }
 
       if (payload.type === "web_search") {
-        const id = typeof payload.id === "string"
+            const id =
+              typeof payload.id === "string"
           ? payload.id
           : typeof payload.call_id === "string"
             ? payload.call_id
-            : `web-search-${index}`;
-        const input = typeof payload.query === "string"
+                  : `web-search-${entryIndex}`;
+            const input =
+              typeof payload.query === "string"
           ? { query: payload.query }
           : getCodexSearchInput(payload);
         appendToolUseMessage(messages, id, "WebSearch", input);
       }
     }
+      } finally {
+        compactAndBoundCodexHistoryInPlace(messages, historyBudget);
+      }
+    }
+  } catch {
+    // A partially written rollout can disappear or be replaced during a
+    // restart. Return the bounded history parsed so far.
   }
 
   return messages;
@@ -3578,10 +4034,24 @@ export async function getCodexSessionHistory(
  */
 export async function findSessionsByClaudeIds(
   ids: Set<string>,
-): Promise<Map<string, Pick<SessionIndexEntry, "summary" | "firstPrompt" | "lastPrompt" | "projectPath">>> {
+): Promise<
+  Map<
+    string,
+    Pick<
+      SessionIndexEntry,
+      "summary" | "firstPrompt" | "lastPrompt" | "lastResponse" | "projectPath"
+    >
+  >
+> {
   if (ids.size === 0) return new Map();
 
-  const result = new Map<string, Pick<SessionIndexEntry, "summary" | "firstPrompt" | "lastPrompt" | "projectPath">>();
+  const result = new Map<
+    string,
+    Pick<
+      SessionIndexEntry,
+      "summary" | "firstPrompt" | "lastPrompt" | "lastResponse" | "projectPath"
+    >
+  >();
   const remaining = new Set(ids);
 
   const projectsDir = join(homedir(), ".claude", "projects");
@@ -3621,6 +4091,7 @@ export async function findSessionsByClaudeIds(
         summary: entry.summary as string | undefined,
         firstPrompt: (entry.firstPrompt as string) ?? "",
         lastPrompt: entry.lastPrompt as string | undefined,
+        lastResponse: entry.lastResponse as string | undefined,
         projectPath: normalizeWorktreePath((entry.projectPath as string) ?? ""),
       });
       remaining.delete(sid);

--- a/packages/bridge/src/websocket.test.ts
+++ b/packages/bridge/src/websocket.test.ts
@@ -9,7 +9,7 @@ import {
 } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
-import { resolve } from "node:path";
+import { join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolvePlatformPath } from "./path-utils.js";
 
@@ -21,6 +21,7 @@ const {
   getAllRecentSessionsMock,
   getCodexSessionIndexMetadataMock,
   saveCodexSessionProfileMock,
+  renameCodexSessionMock,
   generateCommitMessageMock,
   gitCommitMock,
 } = vi.hoisted(() => ({
@@ -31,6 +32,7 @@ const {
   getAllRecentSessionsMock: vi.fn(),
   getCodexSessionIndexMetadataMock: vi.fn(),
   saveCodexSessionProfileMock: vi.fn(),
+  renameCodexSessionMock: vi.fn(),
   generateCommitMessageMock: vi.fn(),
   gitCommitMock: vi.fn(),
 }));
@@ -38,6 +40,7 @@ const {
 vi.mock("./sessions-index.js", () => ({
   getSessionHistory: getSessionHistoryMock,
   getCodexSessionHistory: getCodexSessionHistoryMock,
+  boundCodexSessionHistory: (history: unknown[]) => history,
   codexThreadToSessionHistory: codexThreadToSessionHistoryMock,
   extractMessageImages: extractMessageImagesMock,
   codexUserTurnUuid: (ordinal: number) => `codex:user-turn:${ordinal}`,
@@ -45,7 +48,7 @@ vi.mock("./sessions-index.js", () => ({
   getCodexSessionIndexMetadata: getCodexSessionIndexMetadataMock,
   saveCodexSessionProfile: saveCodexSessionProfileMock,
   renameClaudeSession: vi.fn().mockResolvedValue(true),
-  renameCodexSession: vi.fn().mockResolvedValue(true),
+  renameCodexSession: renameCodexSessionMock,
 }));
 
 vi.mock("./debug-trace-store.js", () => ({
@@ -104,24 +107,46 @@ vi.mock("./session.js", () => ({
         continueMode?: boolean;
         permissionMode?: string;
         initialInput?: string;
+        model?: string;
+        effort?: string;
+        maxTurns?: number;
+        maxBudgetUsd?: number;
+        fallbackModel?: string;
+        persistSession?: boolean;
+        sandboxEnabled?: boolean;
       },
       pastMessages?: unknown[],
       _worktreeOptions?: unknown,
       provider: "claude" | "codex" = "claude",
       codexOptions?: unknown,
+      restoredBridgeSessionId?: string,
+      deferProcessStart = false,
     ): string {
-      const id = `s-${++this.seq}`;
+      const id = restoredBridgeSessionId ?? `s-${++this.seq}`;
       const process = {
-        status: "idle",
-        isRunning: true,
-        sessionId: codexOptions && typeof codexOptions === "object" && "threadId" in codexOptions
+        status: deferProcessStart ? "starting" : "idle",
+        isRunning: !deferProcessStart,
+        permissionMode: options?.permissionMode,
+        model: options?.model,
+        sessionId:
+          codexOptions &&
+          typeof codexOptions === "object" &&
+          "threadId" in codexOptions
           ? (codexOptions as { threadId?: string }).threadId
           : options?.sessionId,
-        isWaitingForInput: true,
-        setPermissionMode: vi.fn(async () => {}),
+        isWaitingForInput: !deferProcessStart,
+        setPermissionMode: vi.fn(async function (this: any, value: string) {
+          this.permissionMode = value;
+        }),
         approvalPolicy: "never",
         approvalsReviewer: "user",
-        collaborationMode: "default",
+        collaborationMode:
+          codexOptions &&
+          typeof codexOptions === "object" &&
+          "collaborationMode" in codexOptions
+            ? ((codexOptions as { collaborationMode?: string })
+                .collaborationMode ?? "default")
+            : "default",
         setApprovalPolicy: vi.fn(function (this: any, value: string) {
           this.approvalPolicy = value;
         }),
@@ -147,7 +172,10 @@ vi.mock("./session.js", () => ({
         listAvailableModelMetadata: vi.fn(async () => []),
         readProfileConfig: vi.fn(async () => ({ profiles: [] })),
         readThread: vi.fn(async () => ({ id: "thread-read", turns: [] })),
-        rollbackThread: vi.fn(async () => ({ id: "thread-rollback", turns: [] })),
+        rollbackThread: vi.fn(async () => ({
+          id: "thread-rollback",
+          turns: [],
+        })),
         rollbackThreadById: vi.fn(async () => ({
           id: "thread-forked",
           turns: [],
@@ -156,8 +184,13 @@ vi.mock("./session.js", () => ({
           threadId: "thread-forked",
           thread: { id: "thread-forked", turns: [] },
         })),
+        forkThreadById: vi.fn(async () => ({
+          threadId: "thread-forked",
+          thread: { id: "thread-forked", turns: [] },
+        })),
         archiveThread: vi.fn(async () => {}),
         getGoal: vi.fn(async () => null),
+        getGoalByThreadId: vi.fn(async () => null),
         setGoal: vi.fn(async (update: Record<string, unknown>) => ({
           threadId: "thread-goal",
           objective: update.objective ?? "Existing goal",
@@ -168,7 +201,20 @@ vi.mock("./session.js", () => ({
           createdAt: 1,
           updatedAt: 2,
         })),
+        setGoalByThreadId: vi.fn(
+          async (_threadId: string, update: Record<string, unknown>) => ({
+            threadId: "thread-goal",
+            objective: update.objective ?? "Existing goal",
+            status: update.status ?? "active",
+            tokenBudget: null,
+            tokensUsed: 0,
+            timeUsedSeconds: 0,
+            createdAt: 1,
+            updatedAt: 2,
+          }),
+        ),
         clearGoal: vi.fn(async () => true),
+        clearGoalByThreadId: vi.fn(async () => true),
         sendInput: vi.fn(() => false),
         sendInputWithImage: vi.fn(),
         sendInputWithImages: vi.fn(() => false),
@@ -201,8 +247,31 @@ vi.mock("./session.js", () => ({
         historyLowWatermark: 1,
         status: "idle",
         provider,
+        name: undefined,
         createdAt: new Date(),
         lastActivityAt: new Date(),
+        restoredLastMessage: undefined,
+        dormant: deferProcessStart,
+        claudeStartOptions:
+          deferProcessStart && provider === "claude"
+            ? { ...options }
+            : undefined,
+        codexStartOptions:
+          deferProcessStart && provider === "codex" && codexOptions
+            ? { ...(codexOptions as Record<string, unknown>) }
+            : undefined,
+        claudeSettings:
+          provider === "claude"
+            ? {
+                model: options?.model,
+                effort: options?.effort,
+                maxTurns: options?.maxTurns,
+                maxBudgetUsd: options?.maxBudgetUsd,
+                fallbackModel: options?.fallbackModel,
+                persistSession: options?.persistSession,
+              }
+            : undefined,
+        sandboxEnabled: options?.sandboxEnabled,
         process,
       });
       return id;
@@ -212,9 +281,30 @@ vi.mock("./session.js", () => ({
       return this.sessions.get(id);
     }
 
+    renameSession(id: string, name: string | null) {
+      const session = this.sessions.get(id);
+      if (!session) return false;
+      session.name = name ?? undefined;
+      return true;
+    }
+
+    activate(id: string) {
+      const session = this.sessions.get(id);
+      if (!session || !session.dormant) return session;
+      session.dormant = false;
+      session.status = "starting";
+      session.process.isRunning = true;
+      session.process.isWaitingForInput = true;
+      return session;
+    }
+
     queueCodexInput(id: string, input: any) {
       const session = this.sessions.get(id);
-      if (!session || session.provider !== "codex" || session.codexQueuedInput) {
+      if (
+        !session ||
+        session.provider !== "codex" ||
+        session.codexQueuedInput
+      ) {
         return false;
       }
       session.codexQueuedInput = input;
@@ -228,7 +318,10 @@ vi.mock("./session.js", () => ({
       options?: { skills?: unknown[]; mentions?: unknown[] },
     ) {
       const session = this.sessions.get(id);
-      if (!session?.codexQueuedInput || session.codexQueuedInput.itemId !== itemId) {
+      if (
+        !session?.codexQueuedInput ||
+        session.codexQueuedInput.itemId !== itemId
+      ) {
         return false;
       }
       session.codexQueuedInput = {
@@ -242,7 +335,10 @@ vi.mock("./session.js", () => ({
 
     cancelCodexQueuedInput(id: string, itemId: string) {
       const session = this.sessions.get(id);
-      if (!session?.codexQueuedInput || session.codexQueuedInput.itemId !== itemId) {
+      if (
+        !session?.codexQueuedInput ||
+        session.codexQueuedInput.itemId !== itemId
+      ) {
         return false;
       }
       session.codexQueuedInput = undefined;
@@ -341,19 +437,33 @@ vi.mock("./session.js", () => ({
     }
 
     list() {
-      return Array.from(this.sessions.values()).map((s) => ({
+      return Array.from(this.sessions.values()).map((s) => {
+        const collaborationMode =
+          s.codexStartOptions?.collaborationMode ?? s.process.collaborationMode;
+        return {
         id: s.id,
         provider: s.provider,
         projectPath: s.projectPath,
         claudeSessionId: s.claudeSessionId,
+          name: s.name,
         status: s.status,
-        createdAt: "",
-        lastActivityAt: "",
+          createdAt: s.createdAt.toISOString(),
+          lastActivityAt: s.lastActivityAt.toISOString(),
         gitBranch: "",
-        lastMessage: "",
+          lastMessage: s.restoredLastMessage ?? "",
+          permissionMode:
+            s.provider === "codex" && collaborationMode === "plan"
+              ? "plan"
+              : s.process.permissionMode,
+          model: s.process.model ?? s.claudeSettings?.model,
+          claudeSettings: s.claudeSettings,
+          sandboxEnabled: s.sandboxEnabled,
+          planMode:
+            s.provider === "codex" ? collaborationMode === "plan" : undefined,
         codexSettings: s.codexSettings,
         queuedInput: s.codexQueuedInput,
-      }));
+        };
+      });
     }
 
     getCachedCommands() {
@@ -367,7 +477,12 @@ vi.mock("./session.js", () => ({
     destroyAll() {}
 
     async rewindFiles(_id: string, _targetUuid: string, _dryRun?: boolean) {
-      return { canRewind: true, filesChanged: ["test.ts"], insertions: 1, deletions: 0 };
+      return {
+        canRewind: true,
+        filesChanged: ["test.ts"],
+        insertions: 1,
+        deletions: 0,
+      };
     }
 
     rewindConversation(
@@ -428,6 +543,7 @@ vi.mock("./session.js", () => ({
 }));
 
 import { BridgeWebSocketServer } from "./websocket.js";
+import { ActiveSessionStore } from "./active-session-store.js";
 import { CodexProcess, CodexRpcError } from "./codex-process.js";
 
 describe("BridgeWebSocketServer resume/get_history flow", () => {
@@ -439,20 +555,26 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     originalFetch = globalThis.fetch;
     httpServer = createServer();
     getSessionHistoryMock.mockReset();
+    getSessionHistoryMock.mockResolvedValue([]);
     getCodexSessionHistoryMock.mockReset();
     codexThreadToSessionHistoryMock.mockReset();
     extractMessageImagesMock.mockReset();
     getAllRecentSessionsMock.mockReset();
     getCodexSessionIndexMetadataMock.mockReset();
     saveCodexSessionProfileMock.mockReset();
+    renameCodexSessionMock.mockReset();
     generateCommitMessageMock.mockReset();
     gitCommitMock.mockReset();
-    getAllRecentSessionsMock.mockResolvedValue({ sessions: [], hasMore: false });
+    getAllRecentSessionsMock.mockResolvedValue({
+      sessions: [],
+      hasMore: false,
+    });
     getCodexSessionIndexMetadataMock.mockResolvedValue(new Map());
     getCodexSessionHistoryMock.mockResolvedValue([]);
     codexThreadToSessionHistoryMock.mockReturnValue([]);
     extractMessageImagesMock.mockResolvedValue([]);
     saveCodexSessionProfileMock.mockResolvedValue(undefined);
+    renameCodexSessionMock.mockResolvedValue(true);
   });
 
   afterEach(() => {
@@ -460,6 +582,742 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     vi.unstubAllEnvs();
     vi.useRealTimers();
     httpServer.close();
+  });
+
+  it("restores active sessions after restart until the user stops them", async () => {
+    getSessionHistoryMock.mockResolvedValue([
+      {
+        role: "user",
+        content: [{ type: "text", text: "Earlier question" }],
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Earlier answer" }],
+      },
+    ]);
+    const directory = mkdtempSync(join(tmpdir(), "ccpocket-active-restore-"));
+    const projectPath = join(directory, "project");
+    mkdirSync(projectPath, { recursive: true });
+    const storeFile = join(directory, "active-sessions.json");
+    const store = new ActiveSessionStore(storeFile);
+    store.replace([
+      {
+        bridgeSessionId: "bridge-kept",
+        providerSessionId: "claude-kept",
+        provider: "claude",
+        projectPath,
+        name: "Kept conversation",
+        createdAt: "2026-08-23T10:00:00.000Z",
+        lastActivityAt: "2026-08-23T11:00:00.000Z",
+        lastMessage: "Latest agent response",
+        permissionMode: "acceptEdits",
+        model: "claude-opus-4-7",
+        claudeSettings: {
+          model: "claude-opus-4-7",
+          effort: "max",
+          maxTurns: 12,
+          maxBudgetUsd: 20,
+          fallbackModel: "claude-sonnet-4-6",
+          persistSession: true,
+        },
+      },
+    ]);
+
+    try {
+      const bridge = new BridgeWebSocketServer({
+        server: httpServer,
+        allowedDirs: [directory],
+        activeSessionStore: store,
+      });
+      expect((bridge as any).sessionManager.list()).toMatchObject([
+        {
+          id: "bridge-kept",
+          claudeSessionId: "claude-kept",
+          name: "Kept conversation",
+          lastMessage: "Latest agent response",
+        },
+      ]);
+
+      const restored = (bridge as any).sessionManager.get("bridge-kept");
+      expect(restored.startOptions).toMatchObject({
+        sessionId: "claude-kept",
+        permissionMode: "acceptEdits",
+        model: "claude-opus-4-7",
+        effort: "max",
+        maxTurns: 12,
+        maxBudgetUsd: 20,
+        fallbackModel: "claude-sonnet-4-6",
+        persistSession: true,
+      });
+      expect(restored.startOptions.continueMode).toBeUndefined();
+      expect(getSessionHistoryMock).not.toHaveBeenCalled();
+
+      const ws = { readyState: OPEN_STATE, send: vi.fn() } as any;
+      await (bridge as any).handleClientMessage(
+        { type: "get_history", sessionId: "bridge-kept" },
+        ws,
+      );
+      expect(getSessionHistoryMock).toHaveBeenCalledWith("claude-kept");
+      expect(restored.pastMessages).toHaveLength(2);
+      expect(
+        ws.send.mock.calls
+          .map((call: unknown[]) => JSON.parse(call[0] as string))
+          .find((message: any) => message.type === "past_history"),
+      ).toMatchObject({
+        sessionId: "bridge-kept",
+        claudeSessionId: "claude-kept",
+        messages: expect.arrayContaining([
+          expect.objectContaining({ role: "assistant" }),
+        ]),
+      });
+      ws.send.mockClear();
+      await (bridge as any).handleClientMessage(
+        { type: "stop_session", sessionId: "bridge-kept" },
+        ws,
+      );
+
+      expect(new ActiveSessionStore(storeFile).list()).toEqual([]);
+      bridge.close();
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps an unavailable active session for a later restart or explicit stop", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "ccpocket-active-deferred-"));
+    const storeFile = join(directory, "active-sessions.json");
+    const record = {
+      bridgeSessionId: "bridge-unavailable",
+      providerSessionId: "claude-unavailable",
+      provider: "claude" as const,
+      projectPath: join(directory, "temporarily-unmounted"),
+      createdAt: "2026-08-23T10:00:00.000Z",
+      lastActivityAt: "2026-08-23T11:00:00.000Z",
+      lastMessage: "Keep me",
+    };
+    const store = new ActiveSessionStore(storeFile);
+    store.replace([record]);
+
+    try {
+      const bridge = new BridgeWebSocketServer({
+        server: httpServer,
+        allowedDirs: [directory],
+        activeSessionStore: store,
+      });
+      expect(new ActiveSessionStore(storeFile).list()).toEqual([record]);
+
+      const ws = { readyState: OPEN_STATE, send: vi.fn() } as any;
+      await (bridge as any).handleClientMessage(
+        { type: "stop_session", sessionId: "bridge-unavailable" },
+        ws,
+      );
+
+      expect(new ActiveSessionStore(storeFile).list()).toEqual([]);
+      expect(
+        JSON.parse(ws.send.mock.calls.at(-1)?.[0] as string),
+      ).toMatchObject({
+        type: "result",
+        subtype: "stopped",
+        sessionId: "bridge-unavailable",
+      });
+      bridge.close();
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("renames a restored dormant Codex session without starting its process", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "ccpocket-active-rename-"));
+    const projectPath = join(directory, "project");
+    mkdirSync(projectPath, { recursive: true });
+    const storeFile = join(directory, "active-sessions.json");
+    new ActiveSessionStore(storeFile).replace([
+      {
+        bridgeSessionId: "bridge-codex-rename",
+        providerSessionId: "codex-thread-rename",
+        provider: "codex",
+        projectPath,
+        createdAt: "2026-08-23T10:00:00.000Z",
+        lastActivityAt: "2026-08-23T11:00:00.000Z",
+        lastMessage: "Rename me",
+      },
+    ]);
+
+    try {
+      const bridge = new BridgeWebSocketServer({
+        server: httpServer,
+        allowedDirs: [directory],
+        activeSessionStore: new ActiveSessionStore(storeFile),
+      });
+      const ws = { readyState: OPEN_STATE, send: vi.fn() } as any;
+      await (bridge as any).handleClientMessage(
+        {
+          type: "rename_session",
+          sessionId: "bridge-codex-rename",
+          name: "Restored name",
+        },
+        ws,
+      );
+
+      expect(renameCodexSessionMock).toHaveBeenCalledWith(
+        "codex-thread-rename",
+        "Restored name",
+      );
+      expect(
+        ws.send.mock.calls
+          .map((call: unknown[]) => JSON.parse(call[0] as string))
+          .find((message: any) => message.type === "rename_result"),
+      ).toMatchObject({ success: true, name: "Restored name" });
+      expect(
+        (bridge as any).sessionManager.get("bridge-codex-rename").dormant,
+      ).toBe(true);
+      bridge.close();
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("rewinds a restored dormant Codex session through a standalone RPC", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "ccpocket-active-rewind-"));
+    const projectPath = join(directory, "project");
+    mkdirSync(projectPath, { recursive: true });
+    const storeFile = join(directory, "active-sessions.json");
+    new ActiveSessionStore(storeFile).replace([
+      {
+        bridgeSessionId: "bridge-codex-rewind",
+        providerSessionId: "codex-thread-rewind",
+        provider: "codex",
+        projectPath,
+        createdAt: "2026-08-23T10:00:00.000Z",
+        lastActivityAt: "2026-08-23T11:00:00.000Z",
+        lastMessage: "Rewind me",
+      },
+    ]);
+
+    try {
+      const bridge = new BridgeWebSocketServer({
+        server: httpServer,
+        allowedDirs: [directory],
+        activeSessionStore: new ActiveSessionStore(storeFile),
+      });
+      const session = (bridge as any).sessionManager.get("bridge-codex-rewind");
+      session.pastMessages = [
+        {
+          role: "user",
+          uuid: "codex:user-turn:1",
+          content: [{ type: "text", text: "First turn" }],
+        },
+      ];
+      const standalone = {
+        rollbackThreadById: vi.fn(async () => ({ turns: [] })),
+        stop: vi.fn(),
+      };
+      vi.spyOn(bridge as any, "createStandaloneCodexProcess").mockResolvedValue(
+        standalone,
+      );
+      const ws = { readyState: OPEN_STATE, send: vi.fn() } as any;
+
+      await (bridge as any).handleClientMessage(
+        {
+          type: "rewind",
+          sessionId: "bridge-codex-rewind",
+          targetUuid: "codex:user-turn:1",
+          mode: "conversation",
+        },
+        ws,
+      );
+
+      expect(standalone.rollbackThreadById).toHaveBeenCalledWith(
+        "codex-thread-rewind",
+        1,
+      );
+      await vi.waitFor(() => {
+        expect(standalone.stop).toHaveBeenCalled();
+        expect(
+          ws.send.mock.calls
+            .map((call: unknown[]) => JSON.parse(call[0] as string))
+            .find((message: any) => message.type === "rewind_result"),
+        ).toMatchObject({ success: true, mode: "conversation" });
+      });
+      expect(new ActiveSessionStore(storeFile).list()).toEqual([
+        expect.objectContaining({
+          bridgeSessionId: "s-1",
+          providerSessionId: "codex-thread-rewind",
+        }),
+      ]);
+      bridge.close();
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("does not restore a persisted Codex writable root outside current policy", () => {
+    const directory = mkdtempSync(join(tmpdir(), "ccpocket-active-roots-"));
+    const projectPath = join(directory, "allowed", "project");
+    const deniedRoot = join(directory, "no-longer-allowed");
+    mkdirSync(projectPath, { recursive: true });
+    mkdirSync(deniedRoot, { recursive: true });
+    const storeFile = join(directory, "active-sessions.json");
+    const store = new ActiveSessionStore(storeFile);
+    store.replace([
+      {
+        bridgeSessionId: "bridge-denied-root",
+        providerSessionId: "codex-denied-root",
+        provider: "codex",
+        projectPath,
+        createdAt: "2026-08-23T10:00:00.000Z",
+        lastActivityAt: "2026-08-23T11:00:00.000Z",
+        lastMessage: "Do not broaden access",
+        codexSettings: { additionalWritableRoots: [deniedRoot] },
+      },
+    ]);
+
+    try {
+      const bridge = new BridgeWebSocketServer({
+        server: httpServer,
+        allowedDirs: [join(directory, "allowed")],
+        activeSessionStore: store,
+      });
+
+      expect((bridge as any).sessionManager.list()).toEqual([]);
+      expect(new ActiveSessionStore(storeFile).list()).toHaveLength(1);
+      bridge.close();
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves Claude model and launch limits across consecutive restarts", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "ccpocket-active-settings-"));
+    const projectPath = join(directory, "project");
+    mkdirSync(projectPath, { recursive: true });
+    const storeFile = join(directory, "active-sessions.json");
+    new ActiveSessionStore(storeFile).replace([
+      {
+        bridgeSessionId: "bridge-settings",
+        providerSessionId: "claude-settings",
+        provider: "claude",
+        projectPath,
+        createdAt: "2026-08-23T10:00:00.000Z",
+        lastActivityAt: "2026-08-23T11:00:00.000Z",
+        lastMessage: "Settings survive",
+        model: "claude-opus-4-7",
+        claudeSettings: {
+          model: "claude-opus-4-7",
+          effort: "xhigh",
+          maxTurns: 9,
+          maxBudgetUsd: 15,
+          fallbackModel: "claude-sonnet-4-6",
+          persistSession: true,
+        },
+      },
+    ]);
+
+    try {
+      const first = new BridgeWebSocketServer({
+        server: httpServer,
+        allowedDirs: [directory],
+        activeSessionStore: new ActiveSessionStore(storeFile),
+      });
+      first.close();
+
+      expect(new ActiveSessionStore(storeFile).list()[0]).toMatchObject({
+        model: "claude-opus-4-7",
+        claudeSettings: {
+          effort: "xhigh",
+          maxTurns: 9,
+          maxBudgetUsd: 15,
+        },
+      });
+
+      const second = new BridgeWebSocketServer({
+        server: httpServer,
+        allowedDirs: [directory],
+        activeSessionStore: new ActiveSessionStore(storeFile),
+      });
+      expect(
+        (second as any).sessionManager.get("bridge-settings").startOptions,
+      ).toMatchObject({
+        sessionId: "claude-settings",
+        model: "claude-opus-4-7",
+        effort: "xhigh",
+        maxTurns: 9,
+        maxBudgetUsd: 15,
+      });
+      second.close();
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves restored Claude settings when sandbox is toggled", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "ccpocket-active-sandbox-"));
+    const projectPath = join(directory, "project");
+    mkdirSync(projectPath, { recursive: true });
+    const storeFile = join(directory, "active-sessions.json");
+    new ActiveSessionStore(storeFile).replace([
+      {
+        bridgeSessionId: "bridge-sandbox",
+        providerSessionId: "claude-sandbox",
+        provider: "claude",
+        projectPath,
+        createdAt: "2026-08-23T10:00:00.000Z",
+        lastActivityAt: "2026-08-23T11:00:00.000Z",
+        lastMessage: "Keep settings",
+        permissionMode: "acceptEdits",
+        sandboxEnabled: false,
+        claudeSettings: {
+          model: "claude-opus-4-7",
+          effort: "xhigh",
+          maxTurns: 9,
+          maxBudgetUsd: 15,
+          fallbackModel: "claude-sonnet-4-6",
+          persistSession: true,
+        },
+      },
+    ]);
+
+    try {
+      const bridge = new BridgeWebSocketServer({
+        server: httpServer,
+        allowedDirs: [directory],
+        activeSessionStore: new ActiveSessionStore(storeFile),
+      });
+      const ws = { readyState: OPEN_STATE, send: vi.fn() } as any;
+
+      await (bridge as any).handleClientMessage(
+        {
+          type: "set_sandbox_mode",
+          sessionId: "bridge-sandbox",
+          sandboxMode: "on",
+        },
+        ws,
+      );
+
+      const replacement = (bridge as any).sessionManager.get("s-1");
+      expect(replacement.startOptions).toMatchObject({
+        sessionId: "claude-sandbox",
+        permissionMode: "acceptEdits",
+        model: "claude-opus-4-7",
+        effort: "xhigh",
+        maxTurns: 9,
+        maxBudgetUsd: 15,
+        fallbackModel: "claude-sonnet-4-6",
+        persistSession: true,
+        sandboxEnabled: true,
+      });
+      bridge.close();
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves delayed restored Claude history across a sandbox toggle", async () => {
+    const directory = mkdtempSync(
+      join(tmpdir(), "ccpocket-active-claude-history-"),
+    );
+    const projectPath = join(directory, "project");
+    mkdirSync(projectPath, { recursive: true });
+    const storeFile = join(directory, "active-sessions.json");
+    new ActiveSessionStore(storeFile).replace([
+      {
+        bridgeSessionId: "bridge-claude-history",
+        providerSessionId: "claude-history",
+        provider: "claude",
+        projectPath,
+        createdAt: "2026-08-23T10:00:00.000Z",
+        lastActivityAt: "2026-08-23T11:00:00.000Z",
+        lastMessage: "Keep restored history",
+        sandboxEnabled: false,
+      },
+    ]);
+    let resolveHistory!: (messages: unknown[]) => void;
+    getSessionHistoryMock.mockReturnValue(
+      new Promise<unknown[]>((resolve) => {
+        resolveHistory = resolve;
+      }),
+    );
+    const bridge = new BridgeWebSocketServer({
+      server: httpServer,
+      allowedDirs: [directory],
+      activeSessionStore: new ActiveSessionStore(storeFile),
+    });
+    const ws = { readyState: OPEN_STATE, send: vi.fn() } as any;
+
+    try {
+      const operation = (bridge as any).handleClientMessage(
+        {
+          type: "set_sandbox_mode",
+          sessionId: "bridge-claude-history",
+          sandboxMode: "on",
+        },
+        ws,
+      );
+      await vi.waitFor(() => expect(getSessionHistoryMock).toHaveBeenCalled());
+      expect(
+        (bridge as any).sessionManager.get("bridge-claude-history"),
+      ).toBeDefined();
+
+      const restoredHistory = [
+        {
+          role: "user",
+          content: [{ type: "text", text: "restored Claude turn" }],
+        },
+      ];
+      resolveHistory(restoredHistory);
+      await operation;
+
+      const replacement = (bridge as any).sessionManager.get("s-1");
+      expect(replacement.pastMessages).toEqual(restoredHistory);
+    } finally {
+      resolveHistory([]);
+      bridge.close();
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("retains Plan toggles made before a restored Codex session starts", async () => {
+    const directory = mkdtempSync(
+      join(tmpdir(), "ccpocket-active-plan-toggle-"),
+    );
+    const projectPath = join(directory, "project");
+    mkdirSync(projectPath, { recursive: true });
+    const storeFile = join(directory, "active-sessions.json");
+    new ActiveSessionStore(storeFile).replace([
+      {
+        bridgeSessionId: "bridge-plan-toggle",
+        providerSessionId: "codex-plan-toggle",
+        provider: "codex",
+        projectPath,
+        createdAt: "2026-08-23T10:00:00.000Z",
+        lastActivityAt: "2026-08-23T11:00:00.000Z",
+        lastMessage: "Toggle plan before starting",
+        planMode: false,
+        codexSettings: {
+          approvalPolicy: "on-request",
+          sandboxMode: "workspace-write",
+        },
+      },
+    ]);
+
+    const bridge = new BridgeWebSocketServer({
+      server: httpServer,
+      allowedDirs: [directory],
+      activeSessionStore: new ActiveSessionStore(storeFile),
+    });
+    const ws = { readyState: OPEN_STATE, send: vi.fn() } as any;
+
+    try {
+      await (bridge as any).handleClientMessage(
+        {
+          type: "set_permission_mode",
+          sessionId: "bridge-plan-toggle",
+          mode: "plan",
+          planMode: true,
+        },
+        ws,
+      );
+      let session = (bridge as any).sessionManager.get("bridge-plan-toggle");
+      expect(session.dormant).toBe(true);
+      expect(session.codexStartOptions.collaborationMode).toBe("plan");
+      expect(session.codexStartOptions.approvalPolicy).toBe("on-request");
+      expect((bridge as any).sessionManager.list()[0].planMode).toBe(true);
+      expect(new ActiveSessionStore(storeFile).list()[0].planMode).toBe(true);
+
+      await (bridge as any).handleClientMessage(
+        {
+          type: "set_permission_mode",
+          sessionId: "bridge-plan-toggle",
+          mode: "default",
+          planMode: false,
+        },
+        ws,
+      );
+      session = (bridge as any).sessionManager.get("bridge-plan-toggle");
+      expect(session.codexStartOptions.collaborationMode).toBe("default");
+      expect(session.codexStartOptions.approvalPolicy).toBe("on-request");
+      expect((bridge as any).sessionManager.list()[0].planMode).toBe(false);
+      expect(new ActiveSessionStore(storeFile).list()[0].planMode).toBe(false);
+    } finally {
+      bridge.close();
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves restored Codex plan mode across sandbox and restarts", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "ccpocket-active-plan-"));
+    const projectPath = join(directory, "project");
+    mkdirSync(projectPath, { recursive: true });
+    const storeFile = join(directory, "active-sessions.json");
+    new ActiveSessionStore(storeFile).replace([
+      {
+        bridgeSessionId: "bridge-plan",
+        providerSessionId: "codex-plan",
+        provider: "codex",
+        projectPath,
+        createdAt: "2026-08-23T10:00:00.000Z",
+        lastActivityAt: "2026-08-23T11:00:00.000Z",
+        lastMessage: "Keep plan mode",
+        planMode: true,
+        codexSettings: {
+          approvalPolicy: "on-request",
+          sandboxMode: "workspace-write",
+        },
+      },
+    ]);
+
+    try {
+      const first = new BridgeWebSocketServer({
+        server: httpServer,
+        allowedDirs: [directory],
+        activeSessionStore: new ActiveSessionStore(storeFile),
+      });
+      expect((first as any).sessionManager.list()[0]).toMatchObject({
+        planMode: true,
+        permissionMode: "plan",
+      });
+      const restored = (first as any).sessionManager.get("bridge-plan");
+      restored.pastMessages = [
+        {
+          role: "user",
+          content: [{ type: "text", text: "Existing plan turn" }],
+        },
+      ];
+      const ws = { readyState: OPEN_STATE, send: vi.fn() } as any;
+      await (first as any).handleClientMessage(
+        {
+          type: "set_sandbox_mode",
+          sessionId: "bridge-plan",
+          sandboxMode: "off",
+        },
+        ws,
+      );
+      await vi.waitFor(() => {
+        const replacement = (first as any).sessionManager.list()[0];
+        expect(
+          (first as any).sessionManager.get(replacement.id).codexOptions,
+        ).toMatchObject({
+          threadId: "codex-plan",
+          collaborationMode: "plan",
+          sandboxMode: "danger-full-access",
+        });
+      });
+      first.close();
+
+      expect(new ActiveSessionStore(storeFile).list()[0].planMode).toBe(true);
+      const second = new BridgeWebSocketServer({
+        server: httpServer,
+        allowedDirs: [directory],
+        activeSessionStore: new ActiveSessionStore(storeFile),
+      });
+      expect((second as any).sessionManager.list()[0].planMode).toBe(true);
+      second.close();
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("persists a safer Claude permission mode before the next restart", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "ccpocket-active-mode-"));
+    const projectPath = join(directory, "project");
+    mkdirSync(projectPath, { recursive: true });
+    const storeFile = join(directory, "active-sessions.json");
+    new ActiveSessionStore(storeFile).replace([
+      {
+        bridgeSessionId: "bridge-mode",
+        providerSessionId: "claude-mode",
+        provider: "claude",
+        projectPath,
+        createdAt: "2026-08-23T10:00:00.000Z",
+        lastActivityAt: "2026-08-23T11:00:00.000Z",
+        lastMessage: "Use safe mode",
+        permissionMode: "bypassPermissions",
+      },
+    ]);
+
+    try {
+      const first = new BridgeWebSocketServer({
+        server: httpServer,
+        allowedDirs: [directory],
+        activeSessionStore: new ActiveSessionStore(storeFile),
+      });
+      const ws = { readyState: OPEN_STATE, send: vi.fn() } as any;
+      await (first as any).handleClientMessage(
+        {
+          type: "set_permission_mode",
+          sessionId: "bridge-mode",
+          mode: "default",
+        },
+        ws,
+      );
+      await vi.waitFor(() => {
+        expect(new ActiveSessionStore(storeFile).list()[0].permissionMode).toBe(
+          "default",
+        );
+      });
+      first.close();
+
+      const second = new BridgeWebSocketServer({
+        server: httpServer,
+        allowedDirs: [directory],
+        activeSessionStore: new ActiveSessionStore(storeFile),
+      });
+      expect((second as any).sessionManager.list()[0].permissionMode).toBe(
+        "default",
+      );
+      second.close();
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("restores an accepted Codex queued prompt, including image payloads", () => {
+    const directory = mkdtempSync(join(tmpdir(), "ccpocket-active-queue-"));
+    const projectPath = join(directory, "project");
+    mkdirSync(projectPath, { recursive: true });
+    const storeFile = join(directory, "active-sessions.json");
+    new ActiveSessionStore(storeFile).replace([
+      {
+        bridgeSessionId: "bridge-codex-queue",
+        providerSessionId: "codex-thread-queue",
+        provider: "codex",
+        projectPath,
+        createdAt: "2026-08-23T10:00:00.000Z",
+        lastActivityAt: "2026-08-23T11:00:00.000Z",
+        lastMessage: "Working on the first turn",
+        codexQueuedInput: {
+          itemId: "queued-1",
+          text: "Please inspect this image next",
+          createdAt: "2026-08-23T11:01:00.000Z",
+          imageCount: 1,
+          images: [{ base64: "aGVsbG8=", mimeType: "image/png" }],
+          skills: [{ name: "skill", path: "/skill" }],
+        },
+      },
+    ]);
+
+    try {
+      const bridge = new BridgeWebSocketServer({
+        server: httpServer,
+        allowedDirs: [directory],
+        activeSessionStore: new ActiveSessionStore(storeFile),
+      });
+      expect(
+        (bridge as any).sessionManager.get("bridge-codex-queue")
+          .codexQueuedInput,
+      ).toMatchObject({
+        itemId: "queued-1",
+        text: "Please inspect this image next",
+        imageCount: 1,
+        images: [{ base64: "aGVsbG8=", mimeType: "image/png" }],
+      });
+      bridge.close();
+      expect(
+        new ActiveSessionStore(storeFile).list()[0].codexQueuedInput,
+      ).toMatchObject({ itemId: "queued-1", imageCount: 1 });
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
   });
 
   it("acknowledges push registration only after relay success", async () => {
@@ -834,6 +1692,36 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     bridge.close();
   });
 
+  it("scopes get_history_delta not-found errors to the requested session", async () => {
+    const bridge = new BridgeWebSocketServer({ server: httpServer });
+    const ws = {
+      readyState: OPEN_STATE,
+      send: vi.fn(),
+    } as any;
+
+    await (bridge as any).handleClientMessage(
+      {
+        type: "get_history_delta",
+        sessionId: "missing-session",
+        sinceSeq: 0,
+      },
+      ws,
+    );
+
+    expect(
+      ws.send.mock.calls
+        .map((call: unknown[]) => JSON.parse(call[0] as string))
+        .find((message: any) => message.type === "error"),
+    ).toEqual({
+      type: "error",
+      message: "Session missing-session not found",
+      errorCode: "session_not_found",
+      sessionId: "missing-session",
+    });
+
+    bridge.close();
+  });
+
   it("archives a Codex thread before recording the local archive marker", async () => {
     const bridge = new BridgeWebSocketServer({ server: httpServer });
     const archiveProjectPath = resolvePlatformPath("/tmp/project-archive");
@@ -902,10 +1790,9 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
       archiveThread: vi.fn().mockResolvedValue(undefined),
       stop: vi.fn(),
     };
-    const createStandalone = vi.spyOn(
-      bridge as any,
-      "createStandaloneCodexProcess",
-    ).mockResolvedValue(codexProcess);
+    const createStandalone = vi
+      .spyOn(bridge as any, "createStandaloneCodexProcess")
+      .mockResolvedValue(codexProcess);
     const archive = vi.fn(async () => {});
     (bridge as any).archiveStore = { archive };
 
@@ -1030,11 +1917,9 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
       send: vi.fn(),
     } as any;
     let resolveProject:
-      | ((value: { sessions: any[]; hasMore: boolean }) => void)
-      | undefined;
+      ((value: { sessions: any[]; hasMore: boolean }) => void) | undefined;
     let resolveList:
-      | ((value: { sessions: any[]; hasMore: boolean }) => void)
-      | undefined;
+      ((value: { sessions: any[]; hasMore: boolean }) => void) | undefined;
     getAllRecentSessionsMock
       .mockImplementationOnce(
         () =>
@@ -1434,9 +2319,7 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
         JSON.stringify({
           type: "directory_listing",
           path: root,
-          directories: [
-            { name: ".hidden", path: resolve(root, ".hidden") },
-          ],
+          directories: [{ name: ".hidden", path: resolve(root, ".hidden") }],
         }),
       );
     } finally {
@@ -1447,7 +2330,9 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
 
   it("rejects directory listing requests that resolve outside allowed roots", async () => {
     const root = mkdtempSync(resolve(tmpdir(), "ccpocket-directory-root-"));
-    const outside = mkdtempSync(resolve(tmpdir(), "ccpocket-directory-outside-"));
+    const outside = mkdtempSync(
+      resolve(tmpdir(), "ccpocket-directory-outside-"),
+    );
     const bridge = new BridgeWebSocketServer({
       server: httpServer,
       allowedDirs: [root],
@@ -1514,7 +2399,9 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     const createStandalone = vi
       .spyOn(bridge as any, "createStandaloneCodexProcess")
       .mockResolvedValue(codexProcess);
-    vi.spyOn(bridge as any, "broadcastSessionList").mockImplementation(() => {});
+    vi.spyOn(bridge as any, "broadcastSessionList").mockImplementation(
+      () => {},
+    );
 
     await (bridge as any).refreshCodexMetadata("/tmp/project-a");
 
@@ -1547,7 +2434,9 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     vi.spyOn(bridge as any, "createStandaloneCodexProcess").mockResolvedValue(
       codexProcess,
     );
-    vi.spyOn(bridge as any, "broadcastSessionList").mockImplementation(() => {});
+    vi.spyOn(bridge as any, "broadcastSessionList").mockImplementation(
+      () => {},
+    );
 
     await (bridge as any).refreshCodexMetadata();
 
@@ -1626,7 +2515,9 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
 
     await Promise.resolve();
 
-    const sends = ws.send.mock.calls.map((c: unknown[]) => JSON.parse(c[0] as string));
+    const sends = ws.send.mock.calls.map((c: unknown[]) =>
+      JSON.parse(c[0] as string),
+    );
     expect(sends).toContainEqual(
       expect.objectContaining({
         type: "error",
@@ -1684,7 +2575,9 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(refreshCodexMetadata).toHaveBeenCalledWith(resolve("/tmp/project-a"));
+    expect(refreshCodexMetadata).toHaveBeenCalledWith(
+      resolve("/tmp/project-a"),
+    );
     bridge.close();
   });
 
@@ -1887,10 +2780,14 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
 
     await Promise.resolve();
     await Promise.resolve();
-    const resumeSends = ws.send.mock.calls.map((c: unknown[]) => JSON.parse(c[0] as string));
+    const resumeSends = ws.send.mock.calls.map((c: unknown[]) =>
+      JSON.parse(c[0] as string),
+    );
     expect(resumeSends.some((m: any) => m.type === "past_history")).toBe(false);
 
-    const created = resumeSends.find((m: any) => m.type === "system" && m.subtype === "session_created");
+    const created = resumeSends.find(
+      (m: any) => m.type === "system" && m.subtype === "session_created",
+    );
     expect(created).toBeDefined();
     expect(created.provider).toBe("claude");
     expect(created.sourceSessionId).toBeUndefined();
@@ -1903,13 +2800,21 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
       ws,
     );
 
-    const historySends = ws.send.mock.calls.map((c: unknown[]) => JSON.parse(c[0] as string));
+    const historySends = ws.send.mock.calls.map((c: unknown[]) =>
+      JSON.parse(c[0] as string),
+    );
     expect(historySends[0]).toMatchObject({
       type: "past_history",
       sessionId: newSessionId,
     });
-    expect(historySends[1]).toMatchObject({ type: "history", sessionId: newSessionId });
-    expect(historySends[2]).toMatchObject({ type: "status", sessionId: newSessionId });
+    expect(historySends[1]).toMatchObject({
+      type: "history",
+      sessionId: newSessionId,
+    });
+    expect(historySends[2]).toMatchObject({
+      type: "status",
+      sessionId: newSessionId,
+    });
 
     bridge.close();
   });
@@ -1969,10 +2874,7 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     });
     expect(
       (bridge as any).sessionManager.get("s-1").process.sendInput.mock.calls,
-    ).toEqual([
-      ["hello while resuming"],
-      ["second queued input"],
-    ]);
+    ).toEqual([["hello while resuming"], ["second queued input"]]);
 
     const sends = ws.send.mock.calls.map((call: unknown[]) =>
       JSON.parse(call[0] as string),
@@ -2035,8 +2937,7 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
         .map((call: unknown[]) => JSON.parse(call[0] as string))
         .find(
           (message: any) =>
-            message.type === "system" &&
-            message.subtype === "session_created",
+            message.type === "system" && message.subtype === "session_created",
         );
       expect(reconnectCreated?.sessionId).toBe("s-1");
     });
@@ -2045,8 +2946,7 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
       .map((call: unknown[]) => JSON.parse(call[0] as string))
       .find(
         (message: any) =>
-          message.type === "system" &&
-          message.subtype === "session_created",
+          message.type === "system" && message.subtype === "session_created",
       );
     expect(firstCreated?.sessionId).toBe("s-1");
     expect(getSessionHistoryMock).toHaveBeenCalledTimes(1);
@@ -2211,10 +3111,7 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
       projectPath: "/tmp/project-a",
       provider: "claude",
     };
-    const destroySpy = vi.spyOn(
-      (bridge as any).sessionManager,
-      "destroy",
-    );
+    const destroySpy = vi.spyOn((bridge as any).sessionManager, "destroy");
 
     vi.useFakeTimers();
     try {
@@ -2240,8 +3137,7 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
       .map((call: unknown[]) => JSON.parse(call[0] as string))
       .filter(
         (message: any) =>
-          message.type === "system" &&
-          message.subtype === "session_created",
+          message.type === "system" && message.subtype === "session_created",
       );
     expect(createdMessages).toHaveLength(1);
     expect(createdMessages[0].sessionId).toBe("s-1");
@@ -2457,7 +3353,9 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
       sessionId,
       fromSeq: second.seq,
       toSeq: second.seq,
-      messages: [{ seq: second.seq, message: { type: "status", status: "idle" } }],
+      messages: [
+        { seq: second.seq, message: { type: "status", status: "idle" } },
+      ],
       status: "idle",
     });
 
@@ -2515,16 +3413,65 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
       type: "past_history",
       sessionId,
       claudeSessionId: "claude-session-1",
-      messages: [
-        { role: "user" },
-        { role: "assistant" },
-      ],
+      messages: [{ role: "user" }, { role: "assistant" }],
     });
     expect(sends[1]).toMatchObject({
       type: "history_delta",
       sessionId,
     });
 
+    bridge.close();
+  });
+
+  it("loads large active Codex history from the bounded local reader before RPC", async () => {
+    getCodexSessionHistoryMock.mockResolvedValue(
+      Array.from({ length: 2000 }, (_, index) => ({
+        role: "assistant",
+        uuid: `local-assistant-${index}`,
+        content: [{ type: "text", text: `local history ${index}` }],
+      })),
+    );
+    const bridge = new BridgeWebSocketServer({ server: httpServer });
+    const ws = { readyState: OPEN_STATE, send: vi.fn() } as any;
+
+    await (bridge as any).handleClientMessage(
+      {
+        type: "start",
+        projectPath: "/tmp/project-codex",
+        provider: "codex",
+      },
+      ws,
+    );
+    const created = ws.send.mock.calls
+      .map((call: unknown[]) => JSON.parse(call[0] as string))
+      .find(
+        (message: any) =>
+          message.type === "system" && message.subtype === "session_created",
+      );
+    const session = (bridge as any).sessionManager.get(created.sessionId);
+    session.claudeSessionId = "thr_codex_large_active";
+
+    ws.send.mockClear();
+    await (bridge as any).handleClientMessage(
+      {
+        type: "get_history_delta",
+        sessionId: created.sessionId,
+        sinceSeq: 0,
+      },
+      ws,
+    );
+
+    expect(getCodexSessionHistoryMock).toHaveBeenCalledWith(
+      "thr_codex_large_active",
+    );
+    expect(session.process.readThread).not.toHaveBeenCalled();
+    const snapshot = ws.send.mock.calls
+      .map((call: unknown[]) => JSON.parse(call[0] as string))
+      .find((message: any) => message.type === "history_snapshot");
+    expect(snapshot.messages).toHaveLength(2000);
+    expect(snapshot.messages.at(-1).message.messageUuid).toBe(
+      "local-assistant-1999",
+    );
     bridge.close();
   });
 
@@ -3018,7 +3965,7 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
       ws,
     );
 
-    expect(getCodexSessionHistoryMock).not.toHaveBeenCalled();
+    expect(getCodexSessionHistoryMock).toHaveBeenCalledWith("thr_codex_empty");
     const sends = ws.send.mock.calls.map((c: unknown[]) =>
       JSON.parse(c[0] as string),
     );
@@ -3276,8 +4223,9 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
         { type: "get_history", sessionId },
         ws,
       );
-      const sentMessages = ws.send.mock.calls
-        .map((call: unknown[]) => JSON.parse(call[0] as string));
+      const sentMessages = ws.send.mock.calls.map((call: unknown[]) =>
+        JSON.parse(call[0] as string),
+      );
       const history = sentMessages.find(
         (message: any) => message.type === "history",
       );
@@ -3296,10 +4244,7 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     };
 
     const assertOrder = (order: string[]): void => {
-      expect(order.slice(0, 2)).toEqual([
-        "user",
-        "I will delegate this task.",
-      ]);
+      expect(order.slice(0, 2)).toEqual(["user", "I will delegate this task."]);
       expect(order.slice(-3)).toEqual([
         "subagent-use",
         "subagent-result",
@@ -4155,12 +5100,12 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     const sends = ws.send.mock.calls.map((c: unknown[]) =>
       JSON.parse(c[0] as string),
     );
-    expect(getCodexSessionHistoryMock).not.toHaveBeenCalled();
+    expect(getCodexSessionHistoryMock).toHaveBeenCalledWith("thr_codex_error");
     expect(sends).toEqual([
       {
         type: "error",
-        message:
-          "Failed to read Codex thread history: rpc unavailable",
+        sessionId,
+        message: "Failed to read Codex thread history: rpc unavailable",
       },
     ]);
 
@@ -4234,11 +5179,145 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
           role: "tool_result",
           toolUseId: "ig-1",
           toolName: "ImageGeneration",
-          images: [{ id: "img-1", url: "/images/img-1", mimeType: "image/png" }],
+          images: [
+            { id: "img-1", url: "/images/img-1", mimeType: "image/png" },
+          ],
         },
       ],
     });
     expect(historySends[1]).toMatchObject({ type: "history", messages: [] });
+
+    bridge.close();
+  });
+
+  it("skips image extraction for text-only long Claude histories", async () => {
+    getSessionHistoryMock.mockResolvedValue(
+      Array.from({ length: 250 }, (_, index) => ({
+        role: "user",
+        uuid: `user-msg-${index}`,
+        content: [{ type: "text", text: `Question ${index}` }],
+      })),
+    );
+    const imageStore = {
+      registerFromBase64: vi.fn(),
+    };
+
+    const bridge = new BridgeWebSocketServer({
+      server: httpServer,
+      imageStore: imageStore as any,
+    });
+    const ws = {
+      readyState: OPEN_STATE,
+      send: vi.fn(),
+    } as any;
+
+    await (bridge as any).handleClientMessage(
+      {
+        type: "resume_session",
+        sessionId: "claude-session-text-only",
+        projectPath: "/tmp/project-a",
+        provider: "claude",
+      },
+      ws,
+    );
+
+    await Promise.resolve();
+    await Promise.resolve();
+    const created = ws.send.mock.calls
+      .map((c: unknown[]) => JSON.parse(c[0] as string))
+      .find((m: any) => m.type === "system" && m.subtype === "session_created");
+
+    ws.send.mockClear();
+    await (bridge as any).handleClientMessage(
+      { type: "get_history", sessionId: created.sessionId },
+      ws,
+    );
+
+    expect(extractMessageImagesMock).not.toHaveBeenCalled();
+    const pastHistory = ws.send.mock.calls
+      .map((c: unknown[]) => JSON.parse(c[0] as string))
+      .find((message: any) => message.type === "past_history");
+    expect(pastHistory.messages).toHaveLength(250);
+
+    bridge.close();
+  });
+
+  it("coalesces overlapping text-only long Codex history restores", async () => {
+    codexThreadToSessionHistoryMock.mockReturnValue(
+      Array.from({ length: 250 }, (_, index) => ({
+        role: "user",
+        uuid: `codex:user-turn:${index + 1}`,
+        content: [{ type: "text", text: `Question ${index}` }],
+      })),
+    );
+    const imageStore = {
+      registerFromBase64: vi.fn(),
+    };
+    let resolveThreadRead: ((value: unknown) => void) | undefined;
+    const threadRead = new Promise<unknown>((resolve) => {
+      resolveThreadRead = resolve;
+    });
+
+    const bridge = new BridgeWebSocketServer({
+      server: httpServer,
+      imageStore: imageStore as any,
+    });
+    const ws = {
+      readyState: OPEN_STATE,
+      send: vi.fn(),
+    } as any;
+    const secondWs = {
+      readyState: OPEN_STATE,
+      send: vi.fn(),
+    } as any;
+
+    await (bridge as any).handleClientMessage(
+      {
+        type: "start",
+        projectPath: "/tmp/project-codex",
+        provider: "codex",
+      },
+      ws,
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const created = ws.send.mock.calls
+      .map((c: unknown[]) => JSON.parse(c[0] as string))
+      .find((m: any) => m.type === "system" && m.subtype === "session_created");
+    const sessionId = created.sessionId as string;
+    const session = (bridge as any).sessionManager.get(sessionId);
+    session.claudeSessionId = "thr_codex_text_only";
+    session.process.readThread.mockReturnValue(threadRead);
+
+    ws.send.mockClear();
+    const firstRequest = (bridge as any).handleClientMessage(
+      { type: "get_history", sessionId },
+      ws,
+    );
+    await Promise.resolve();
+    await (bridge as any).handleClientMessage(
+      { type: "get_history_delta", sessionId, sinceSeq: 0 },
+      ws,
+    );
+    const secondClientRequest = (bridge as any).handleClientMessage(
+      { type: "get_history", sessionId },
+      secondWs,
+    );
+
+    expect(session.process.readThread).toHaveBeenCalledTimes(1);
+    resolveThreadRead?.({ id: "thr_codex_text_only", turns: [] });
+    await Promise.all([firstRequest, secondClientRequest]);
+
+    expect(extractMessageImagesMock).not.toHaveBeenCalled();
+    const history = ws.send.mock.calls
+      .map((c: unknown[]) => JSON.parse(c[0] as string))
+      .find((message: any) => message.type === "history");
+    expect(history.messages).toHaveLength(250);
+    const secondClientHistory = secondWs.send.mock.calls
+      .map((c: unknown[]) => JSON.parse(c[0] as string))
+      .find((message: any) => message.type === "history");
+    expect(secondClientHistory.messages).toHaveLength(250);
 
     bridge.close();
   });
@@ -4428,7 +5507,9 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
 
     await Promise.resolve();
 
-    const sends = ws.send.mock.calls.map((c: unknown[]) => JSON.parse(c[0] as string));
+    const sends = ws.send.mock.calls.map((c: unknown[]) =>
+      JSON.parse(c[0] as string),
+    );
     const created = sends.find(
       (m: any) => m.type === "system" && m.subtype === "session_created",
     );
@@ -4537,7 +5618,9 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
         .map((c: unknown[]) => JSON.parse(c[0] as string))
         .find((m: any) => m.type === "diff_result");
       expect(diffResult.error).toBeUndefined();
-      expect(diffResult.diff).toContain("diff --git a/initial.txt b/initial.txt");
+      expect(diffResult.diff).toContain(
+        "diff --git a/initial.txt b/initial.txt",
+      );
       expect(diffResult.diff).toContain("diff --git a/docs/啊.md b/docs/啊.md");
       expect(diffResult.diff).not.toContain("\\345\\225");
     } finally {
@@ -4550,7 +5633,10 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     const projectPath = mkdtempSync(resolve(tmpdir(), "ccpocket-bridge-"));
     const pngBase64 =
       "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
-    writeFileSync(resolve(projectPath, "pixel.png"), Buffer.from(pngBase64, "base64"));
+    writeFileSync(
+      resolve(projectPath, "pixel.png"),
+      Buffer.from(pngBase64, "base64"),
+    );
 
     const bridge = new BridgeWebSocketServer({
       server: httpServer,
@@ -4704,7 +5790,9 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     await Promise.resolve();
     await Promise.resolve();
 
-    const sends = ws.send.mock.calls.map((c: unknown[]) => JSON.parse(c[0] as string));
+    const sends = ws.send.mock.calls.map((c: unknown[]) =>
+      JSON.parse(c[0] as string),
+    );
     const created = sends.find(
       (m: any) => m.type === "system" && m.subtype === "session_created",
     );
@@ -4745,8 +5833,12 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     await Promise.resolve();
     await Promise.resolve();
 
-    const sends = ws.send.mock.calls.map((c: unknown[]) => JSON.parse(c[0] as string));
-    const created = sends.find((m: any) => m.type === "system" && m.subtype === "session_created");
+    const sends = ws.send.mock.calls.map((c: unknown[]) =>
+      JSON.parse(c[0] as string),
+    );
+    const created = sends.find(
+      (m: any) => m.type === "system" && m.subtype === "session_created",
+    );
     expect(created).toBeDefined();
     expect(created.provider).toBe("codex");
     expect(created.sourceSessionId).toBeUndefined();
@@ -4758,8 +5850,7 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     );
     const sessionCreatedIndex = sends.findIndex(
       (message: any) =>
-        message.type === "system" &&
-        message.subtype === "session_created",
+        message.type === "system" && message.subtype === "session_created",
     );
     expect(resumeStartedIndex).toBeGreaterThanOrEqual(0);
     expect(resumeStartedIndex).toBeLessThan(sessionCreatedIndex);
@@ -4769,6 +5860,69 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
       projectPath: "/tmp/project-codex",
       resumeRequestId: "link-request-codex",
     });
+
+    bridge.close();
+  });
+
+  it("joins an in-flight Codex resume after reconnect with a new request id", async () => {
+    let resolveHistory!: (messages: unknown[]) => void;
+    getCodexSessionHistoryMock.mockReturnValue(
+      new Promise<unknown[]>((resolve) => {
+        resolveHistory = resolve;
+      }),
+    );
+    const bridge = new BridgeWebSocketServer({ server: httpServer });
+    const firstWs = {
+      readyState: OPEN_STATE,
+      send: vi.fn(),
+    } as any;
+    const reconnectWs = {
+      readyState: OPEN_STATE,
+      send: vi.fn(),
+    } as any;
+    const baseRequest = {
+      type: "resume_session",
+      sessionId: "codex-thread-reconnect",
+      projectPath: "/tmp/project-codex",
+      provider: "codex",
+    };
+
+    void (bridge as any).handleClientMessage(
+      { ...baseRequest, resumeRequestId: "resume-before-disconnect" },
+      firstWs,
+    );
+    await vi.waitFor(() => {
+      expect(getCodexSessionHistoryMock).toHaveBeenCalledTimes(1);
+    });
+    (bridge as any).clearPendingClaudeResumeInputs(firstWs);
+
+    void (bridge as any).handleClientMessage(
+      { ...baseRequest, resumeRequestId: "resume-after-reconnect" },
+      reconnectWs,
+    );
+    expect(getCodexSessionHistoryMock).toHaveBeenCalledTimes(1);
+
+    resolveHistory([]);
+    await vi.waitFor(() => {
+      const created = reconnectWs.send.mock.calls
+        .map((call: unknown[]) => JSON.parse(call[0] as string))
+        .find(
+          (message: any) =>
+            message.type === "system" && message.subtype === "session_created",
+        );
+      expect(created).toMatchObject({
+        sessionId: "s-1",
+        resumeRequestId: "resume-after-reconnect",
+      });
+    });
+    expect(
+      firstWs.send.mock.calls
+        .map((call: unknown[]) => JSON.parse(call[0] as string))
+        .some(
+          (message: any) =>
+            message.type === "system" && message.subtype === "session_created",
+        ),
+    ).toBe(false);
 
     bridge.close();
   });
@@ -4804,8 +5958,7 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
       .map((call: unknown[]) => JSON.parse(call[0] as string))
       .find(
         (message: any) =>
-          message.type === "system" &&
-          message.subtype === "session_created",
+          message.type === "system" && message.subtype === "session_created",
       );
 
     await (bridge as any).handleClientMessage(
@@ -4878,15 +6031,13 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
       .map((call: unknown[]) => JSON.parse(call[0] as string))
       .find(
         (message: any) =>
-          message.type === "system" &&
-          message.subtype === "session_created",
+          message.type === "system" && message.subtype === "session_created",
       );
     const reconnectCreated = reconnectWs.send.mock.calls
       .map((call: unknown[]) => JSON.parse(call[0] as string))
       .find(
         (message: any) =>
-          message.type === "system" &&
-          message.subtype === "session_created",
+          message.type === "system" && message.subtype === "session_created",
       );
 
     expect(firstCreated.sessionId).toBe("s-1");
@@ -4922,8 +6073,7 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
       .map((call: unknown[]) => JSON.parse(call[0] as string))
       .find(
         (message: any) =>
-          message.type === "system" &&
-          message.subtype === "session_created",
+          message.type === "system" && message.subtype === "session_created",
       );
 
     await (bridge as any).handleClientMessage(
@@ -4967,8 +6117,12 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     const session = (bridge as any).sessionManager.get("s-1");
     expect(session.codexOptions?.sandboxMode).toBe("danger-full-access");
 
-    const sends = ws.send.mock.calls.map((c: unknown[]) => JSON.parse(c[0] as string));
-    const created = sends.find((m: any) => m.type === "system" && m.subtype === "session_created");
+    const sends = ws.send.mock.calls.map((c: unknown[]) =>
+      JSON.parse(c[0] as string),
+    );
+    const created = sends.find(
+      (m: any) => m.type === "system" && m.subtype === "session_created",
+    );
     expect(created?.sandboxMode).toBe("off");
 
     bridge.close();
@@ -5008,8 +6162,12 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     await Promise.resolve();
     await Promise.resolve();
 
-    const sends = ws.send.mock.calls.map((c: unknown[]) => JSON.parse(c[0] as string));
-    const created = sends.find((m: any) => m.type === "system" && m.subtype === "session_created");
+    const sends = ws.send.mock.calls.map((c: unknown[]) =>
+      JSON.parse(c[0] as string),
+    );
+    const created = sends.find(
+      (m: any) => m.type === "system" && m.subtype === "session_created",
+    );
     expect(created).toBeDefined();
     expect(created.provider).toBe("codex");
     expect(created.projectPath).toBe(resolve("/tmp/project-main"));
@@ -5034,13 +6192,18 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     );
     await Promise.resolve();
 
-    const sends = ws.send.mock.calls.map((c: unknown[]) => JSON.parse(c[0] as string));
-    const created = sends.find((m: any) => m.type === "system" && m.subtype === "session_created");
+    const sends = ws.send.mock.calls.map((c: unknown[]) =>
+      JSON.parse(c[0] as string),
+    );
+    const created = sends.find(
+      (m: any) => m.type === "system" && m.subtype === "session_created",
+    );
     expect(created).toBeDefined();
     const sessionId = created.sessionId as string;
 
     const session = (bridge as any).sessionManager.get(sessionId);
-    const setPermissionModeMock = session.process.setPermissionMode as ReturnType<typeof vi.fn>;
+    const setPermissionModeMock = session.process
+      .setPermissionMode as ReturnType<typeof vi.fn>;
 
     const callCountBefore = ws.send.mock.calls.length;
     (bridge as any).handleClientMessage(
@@ -5075,7 +6238,9 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
       .mockImplementation((...args: any[]) => {
         if (failFirstCreate) {
           failFirstCreate = false;
-          throw new Error('Permission mode "auto" is unavailable for your plan');
+          throw new Error(
+            'Permission mode "auto" is unavailable for your plan',
+          );
         }
         return realCreate(...args);
       });
@@ -5095,9 +6260,15 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     expect(createSpy.mock.calls[0]?.[1]?.permissionMode).toBe("auto");
     expect(createSpy.mock.calls[1]?.[1]?.permissionMode).toBe("default");
 
-    const sends = ws.send.mock.calls.map((c: unknown[]) => JSON.parse(c[0] as string));
-    const created = sends.find((m: any) => m.type === "system" && m.subtype === "session_created");
-    const tip = sends.find((m: any) => m.type === "system" && m.subtype === "tip");
+    const sends = ws.send.mock.calls.map((c: unknown[]) =>
+      JSON.parse(c[0] as string),
+    );
+    const created = sends.find(
+      (m: any) => m.type === "system" && m.subtype === "session_created",
+    );
+    const tip = sends.find(
+      (m: any) => m.type === "system" && m.subtype === "tip",
+    );
 
     expect(created).toMatchObject({
       permissionMode: "default",
@@ -5129,7 +6300,9 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
       .mockImplementation((...args: any[]) => {
         if (failFirstCreate) {
           failFirstCreate = false;
-          throw new Error('Permission mode "auto" is unavailable for your plan');
+          throw new Error(
+            'Permission mode "auto" is unavailable for your plan',
+          );
         }
         return realCreate(...args);
       });
@@ -5150,9 +6323,15 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     expect(createSpy.mock.calls[0]?.[1]?.permissionMode).toBe("auto");
     expect(createSpy.mock.calls[1]?.[1]?.permissionMode).toBe("default");
 
-    const sends = ws.send.mock.calls.map((c: unknown[]) => JSON.parse(c[0] as string));
-    const created = sends.find((m: any) => m.type === "system" && m.subtype === "session_created");
-    const tip = sends.find((m: any) => m.type === "system" && m.subtype === "tip");
+    const sends = ws.send.mock.calls.map((c: unknown[]) =>
+      JSON.parse(c[0] as string),
+    );
+    const created = sends.find(
+      (m: any) => m.type === "system" && m.subtype === "session_created",
+    );
+    const tip = sends.find(
+      (m: any) => m.type === "system" && m.subtype === "tip",
+    );
 
     expect(created).toMatchObject({
       permissionMode: "default",
@@ -5185,13 +6364,18 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     );
     await Promise.resolve();
 
-    const sends = ws.send.mock.calls.map((c: unknown[]) => JSON.parse(c[0] as string));
-    const created = sends.find((m: any) => m.type === "system" && m.subtype === "session_created");
+    const sends = ws.send.mock.calls.map((c: unknown[]) =>
+      JSON.parse(c[0] as string),
+    );
+    const created = sends.find(
+      (m: any) => m.type === "system" && m.subtype === "session_created",
+    );
     expect(created).toBeDefined();
 
     const sessionId = created.sessionId as string;
     const session = (bridge as any).sessionManager.get(sessionId);
-    const setPermissionModeMock = session.process.setPermissionMode as ReturnType<typeof vi.fn>;
+    const setPermissionModeMock = session.process
+      .setPermissionMode as ReturnType<typeof vi.fn>;
     setPermissionModeMock.mockRejectedValue(
       new Error('Permission mode "auto" is unavailable for your plan'),
     );
@@ -5235,8 +6419,12 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     );
     await Promise.resolve();
 
-    const sends = ws.send.mock.calls.map((c: unknown[]) => JSON.parse(c[0] as string));
-    const created = sends.find((m: any) => m.type === "system" && m.subtype === "session_created");
+    const sends = ws.send.mock.calls.map((c: unknown[]) =>
+      JSON.parse(c[0] as string),
+    );
+    const created = sends.find(
+      (m: any) => m.type === "system" && m.subtype === "session_created",
+    );
     expect(created).toBeDefined();
     const sessionId = created.sessionId as string;
 
@@ -5358,8 +6546,7 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
       .map((call: unknown[]) => JSON.parse(call[0] as string))
       .find(
         (message: any) =>
-          message.type === "system" &&
-          message.subtype === "session_created",
+          message.type === "system" && message.subtype === "session_created",
       );
     const oldSessionId = created.sessionId as string;
     const session = (bridge as any).sessionManager.get(oldSessionId);
@@ -5408,8 +6595,7 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
       .map((call: unknown[]) => JSON.parse(call[0] as string))
       .find(
         (message: any) =>
-          message.type === "system" &&
-          message.subtype === "session_created",
+          message.type === "system" && message.subtype === "session_created",
       );
     const session = (bridge as any).sessionManager.get(created.sessionId);
     expect(session.codexOptions).toMatchObject({
@@ -5457,6 +6643,9 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
 
   it("preserves and coerces Codex review settings across sandbox restart", async () => {
     const bridge = new BridgeWebSocketServer({ server: httpServer });
+    vi.spyOn(bridge as any, "refreshCodexMetadata").mockResolvedValue(
+      undefined,
+    );
     const ws = {
       readyState: OPEN_STATE,
       send: vi.fn(),
@@ -5476,8 +6665,7 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
       .map((call: unknown[]) => JSON.parse(call[0] as string))
       .find(
         (message: any) =>
-          message.type === "system" &&
-          message.subtype === "session_created",
+          message.type === "system" && message.subtype === "session_created",
       );
     const oldSession = (bridge as any).sessionManager.get(created.sessionId);
     oldSession.codexSettings = {
@@ -5518,7 +6706,9 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     const resumedSummary = (bridge as any).sessionManager.list()[0];
-    const resumedSession = (bridge as any).sessionManager.get(resumedSummary.id);
+    const resumedSession = (bridge as any).sessionManager.get(
+      resumedSummary.id,
+    );
     expect(resumedSession.codexOptions).toMatchObject({
       threadId: "thread-managed-sandbox",
       approvalsReviewer: "user",
@@ -5528,6 +6718,165 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     });
     bridge.close();
   });
+
+  it.each([
+    [
+      "permission",
+      {
+        type: "set_permission_mode",
+        mode: "plan",
+        planMode: true,
+      },
+    ],
+    [
+      "sandbox",
+      {
+        type: "set_sandbox_mode",
+        sandboxMode: "off",
+      },
+    ],
+  ])(
+    "does not resurrect a stopped Codex session during %s restart",
+    async (_kind, restartMessage) => {
+      const bridge = new BridgeWebSocketServer({ server: httpServer });
+      const ws = {
+        readyState: OPEN_STATE,
+        send: vi.fn(),
+      } as any;
+      let resolveHistory!: (messages: unknown[]) => void;
+      const pendingHistory = new Promise<unknown[]>((resolve) => {
+        resolveHistory = resolve;
+      });
+      const getHistory = vi
+        .spyOn(bridge as any, "getCodexThreadHistory")
+        .mockReturnValue(pendingHistory);
+
+      try {
+        await (bridge as any).handleClientMessage(
+          {
+            type: "start",
+            projectPath: "/tmp/project-codex-stop-during-restart",
+            provider: "codex",
+          },
+          ws,
+        );
+        const session = (bridge as any).sessionManager.list()[0];
+        const oldSession = (bridge as any).sessionManager.get(session.id);
+        oldSession.claudeSessionId = "thread-stop-during-restart";
+        oldSession.history.push({ type: "user_input", text: "hello" });
+        oldSession.status = "running";
+        ws.send.mockClear();
+
+        await (bridge as any).handleClientMessage(
+          { ...restartMessage, sessionId: oldSession.id },
+          ws,
+        );
+        await vi.waitFor(() => expect(getHistory).toHaveBeenCalledOnce());
+        expect((bridge as any).sessionManager.list()).toHaveLength(1);
+
+        await (bridge as any).handleClientMessage(
+          { type: "stop_session", sessionId: oldSession.id },
+          ws,
+        );
+        resolveHistory([]);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect((bridge as any).sessionManager.list()).toHaveLength(0);
+        const sent = ws.send.mock.calls.map((call: unknown[]) =>
+          JSON.parse(call[0] as string),
+        );
+        expect(
+          sent.some(
+            (message: any) =>
+              message.type === "system" &&
+              message.subtype === "session_created" &&
+              message.sourceSessionId === oldSession.id,
+          ),
+        ).toBe(false);
+      } finally {
+        resolveHistory([]);
+        bridge.close();
+      }
+    },
+  );
+
+  it.each([
+    [
+      "custom permission",
+      {
+        type: "set_permission_mode",
+        mode: "default",
+        codexPermissionsMode: "custom",
+      },
+    ],
+    [
+      "sandbox",
+      {
+        type: "set_sandbox_mode",
+        sandboxMode: "off",
+      },
+    ],
+  ])(
+    "resumes a restored Codex thread during an immediate %s change",
+    async (_kind, restartMessage) => {
+      const bridge = new BridgeWebSocketServer({ server: httpServer });
+      const ws = { readyState: OPEN_STATE, send: vi.fn() } as any;
+      const oldSessionId = (bridge as any).sessionManager.create(
+        "/tmp/project-codex-restored-mode-change",
+        undefined,
+        undefined,
+        undefined,
+        "codex",
+        {
+          threadId: "thread-restored-mode-change",
+          approvalPolicy: "on-request",
+          sandboxMode: "workspace-write",
+      },
+        "bridge-restored-mode-change",
+        true,
+    );
+      let resolveHistory!: (messages: unknown[]) => void;
+      const pendingHistory = new Promise<unknown[]>((resolve) => {
+        resolveHistory = resolve;
+    });
+      const getHistory = vi
+        .spyOn(bridge as any, "getCodexThreadHistory")
+        .mockReturnValue(pendingHistory);
+
+      try {
+        const operation = (bridge as any).handleClientMessage(
+          { ...restartMessage, sessionId: oldSessionId },
+          ws,
+        );
+        await vi.waitFor(() => expect(getHistory).toHaveBeenCalledOnce());
+        expect((bridge as any).sessionManager.list()).toHaveLength(1);
+
+        const restoredHistory = [
+      {
+            role: "user",
+            content: [{ type: "text", text: "existing long thread" }],
+      },
+        ];
+        resolveHistory(restoredHistory);
+        await operation;
+        await vi.waitFor(() =>
+          expect((bridge as any).sessionManager.list()).toHaveLength(1),
+    );
+
+        const replacementSummary = (bridge as any).sessionManager.list()[0];
+        const replacement = (bridge as any).sessionManager.get(
+          replacementSummary.id,
+        );
+        expect(replacement.codexOptions).toMatchObject({
+          threadId: "thread-restored-mode-change",
+    });
+        expect(replacement.pastMessages).toEqual(restoredHistory);
+      } finally {
+        resolveHistory([]);
+    bridge.close();
+      }
+    },
+  );
 
   it("updates codex model in-place and broadcasts session settings", async () => {
     const bridge = new BridgeWebSocketServer({ server: httpServer });
@@ -5594,9 +6943,7 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
       model: "gpt-5.4-mini",
       modelReasoningEffort: "low",
     });
-    expect(
-      messages.find((m: any) => m.type === "session_list"),
-    ).toMatchObject({
+    expect(messages.find((m: any) => m.type === "session_list")).toMatchObject({
       sessions: expect.arrayContaining([
         expect.objectContaining({
           id: sessionId,
@@ -5660,6 +7007,8 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
       .find((m: any) => m.type === "system" && m.subtype === "session_created");
     const sessionId = created.sessionId as string;
     const session = (bridge as any).sessionManager.get(sessionId);
+    session.claudeSessionId = "thread-goal";
+    session.process.sessionId = "thread-goal";
     ws.send.mockClear();
 
     await (bridge as any).handleClientMessage(
@@ -5680,12 +7029,19 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
       ws,
     );
 
-    expect(session.process.getGoal).toHaveBeenCalledOnce();
-    expect(session.process.setGoal).toHaveBeenCalledWith({
+    expect(session.process.getGoalByThreadId).toHaveBeenCalledWith(
+      "thread-goal",
+    );
+    expect(session.process.setGoalByThreadId).toHaveBeenCalledWith(
+      "thread-goal",
+      {
       objective: "Ship Goal support",
       status: "active",
-    });
-    expect(session.process.clearGoal).toHaveBeenCalledOnce();
+      },
+    );
+    expect(session.process.clearGoalByThreadId).toHaveBeenCalledWith(
+      "thread-goal",
+    );
     const goals = ws.send.mock.calls
       .map((c: unknown[]) => JSON.parse(c[0] as string))
       .filter((m: any) => m.type === "goal_state");
@@ -5719,8 +7075,12 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     );
     await Promise.resolve();
 
-    const sends = ws.send.mock.calls.map((c: unknown[]) => JSON.parse(c[0] as string));
-    const created = sends.find((m: any) => m.type === "system" && m.subtype === "session_created");
+    const sends = ws.send.mock.calls.map((c: unknown[]) =>
+      JSON.parse(c[0] as string),
+    );
+    const created = sends.find(
+      (m: any) => m.type === "system" && m.subtype === "session_created",
+    );
     expect(created).toBeDefined();
     const oldSessionId = created.sessionId as string;
 
@@ -5766,8 +7126,12 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     );
     await Promise.resolve();
 
-    const sends = ws.send.mock.calls.map((c: unknown[]) => JSON.parse(c[0] as string));
-    const created = sends.find((m: any) => m.type === "system" && m.subtype === "session_created");
+    const sends = ws.send.mock.calls.map((c: unknown[]) =>
+      JSON.parse(c[0] as string),
+    );
+    const created = sends.find(
+      (m: any) => m.type === "system" && m.subtype === "session_created",
+    );
     expect(created).toBeDefined();
     const sessionId = created.sessionId as string;
     const session = (bridge as any).sessionManager.get(sessionId);
@@ -5784,7 +7148,9 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
       ws,
     );
 
-    const lastMessages = ws.send.mock.calls.map((c: unknown[]) => JSON.parse(c[0] as string));
+    const lastMessages = ws.send.mock.calls.map((c: unknown[]) =>
+      JSON.parse(c[0] as string),
+    );
     const errors = lastMessages.filter((m: any) => m.type === "error");
     // No errors should be produced for valid permission mode on codex
     expect(errors.length).toBe(0);
@@ -5927,8 +7293,12 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     );
     await Promise.resolve();
 
-    const initialMessages = ws.send.mock.calls.map((c: unknown[]) => JSON.parse(c[0] as string));
-    const created = initialMessages.find((m: any) => m.type === "system" && m.subtype === "session_created");
+    const initialMessages = ws.send.mock.calls.map((c: unknown[]) =>
+      JSON.parse(c[0] as string),
+    );
+    const created = initialMessages.find(
+      (m: any) => m.type === "system" && m.subtype === "session_created",
+    );
     expect(created).toBeDefined();
     const oldSessionId = created.sessionId as string;
     const session = (bridge as any).sessionManager.get(oldSessionId);
@@ -5978,8 +7348,12 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     );
     await Promise.resolve();
 
-    const sends = ws.send.mock.calls.map((c: unknown[]) => JSON.parse(c[0] as string));
-    const created = sends.find((m: any) => m.type === "system" && m.subtype === "session_created");
+    const sends = ws.send.mock.calls.map((c: unknown[]) =>
+      JSON.parse(c[0] as string),
+    );
+    const created = sends.find(
+      (m: any) => m.type === "system" && m.subtype === "session_created",
+    );
     expect(created).toMatchObject({
       provider: "codex",
       permissionMode: "bypassPermissions",
@@ -6141,8 +7515,12 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     );
     await Promise.resolve();
 
-    const sends = ws.send.mock.calls.map((c: unknown[]) => JSON.parse(c[0] as string));
-    const created = sends.find((m: any) => m.type === "system" && m.subtype === "session_created");
+    const sends = ws.send.mock.calls.map((c: unknown[]) =>
+      JSON.parse(c[0] as string),
+    );
+    const created = sends.find(
+      (m: any) => m.type === "system" && m.subtype === "session_created",
+    );
     expect(created).toBeDefined();
     const sessionId = created.sessionId as string;
 
@@ -6168,7 +7546,9 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     expect(bundle.sessionId).toBe(sessionId);
     expect(bundle.session.provider).toBe("claude");
     // History may contain a system/tip (git_not_available) before the running status
-    expect(bundle.historySummary.some((s: string) => s.includes("running"))).toBe(true);
+    expect(
+      bundle.historySummary.some((s: string) => s.includes("running")),
+    ).toBe(true);
     expect(Array.isArray(bundle.debugTrace)).toBe(true);
     expect(typeof bundle.traceFilePath).toBe("string");
     expect(typeof bundle.savedBundlePath).toBe("string");
@@ -6221,8 +7601,12 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     );
     await Promise.resolve();
 
-    const sends = ws.send.mock.calls.map((c: unknown[]) => JSON.parse(c[0] as string));
-    const created = sends.find((m: any) => m.type === "system" && m.subtype === "session_created");
+    const sends = ws.send.mock.calls.map((c: unknown[]) =>
+      JSON.parse(c[0] as string),
+    );
+    const created = sends.find(
+      (m: any) => m.type === "system" && m.subtype === "session_created",
+    );
     const sessionId = created.sessionId as string;
     expect((bridge as any).debugEvents.has(sessionId)).toBe(true);
 
@@ -6255,12 +7639,18 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     );
     await Promise.resolve();
 
-    const sends = ws.send.mock.calls.map((c: unknown[]) => JSON.parse(c[0] as string));
-    const created = sends.find((m: any) => m.type === "system" && m.subtype === "session_created");
+    const sends = ws.send.mock.calls.map((c: unknown[]) =>
+      JSON.parse(c[0] as string),
+    );
+    const created = sends.find(
+      (m: any) => m.type === "system" && m.subtype === "session_created",
+    );
     const sessionId = created.sessionId as string;
     const session = (bridge as any).sessionManager.get(sessionId);
     session.claudeSessionId = "claude-session-1";
-    (session.process.getPendingPermission as ReturnType<typeof vi.fn>).mockReturnValue({
+    (
+      session.process.getPendingPermission as ReturnType<typeof vi.fn>
+    ).mockReturnValue({
       toolUseId: "tool-exit-1",
       toolName: "ExitPlanMode",
       input: { plan: "original plan text" },
@@ -6501,7 +7891,9 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     });
 
     expect(
-      ws.send.mock.calls.map((call: unknown[]) => JSON.parse(call[0] as string)),
+      ws.send.mock.calls.map((call: unknown[]) =>
+        JSON.parse(call[0] as string),
+      ),
     ).toEqual([
       { type: "stream_delta", text: "answer ", sessionId: "s-1" },
       { type: "thinking_delta", text: "thought", sessionId: "s-1" },
@@ -6537,7 +7929,9 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     });
 
     expect(
-      ws.send.mock.calls.map((call: unknown[]) => JSON.parse(call[0] as string)),
+      ws.send.mock.calls.map((call: unknown[]) =>
+        JSON.parse(call[0] as string),
+      ),
     ).toEqual([
       { type: "stream_delta", text: "one", sessionId: "s-1" },
       { type: "status", status: "idle", sessionId: "s-1" },
@@ -6571,8 +7965,9 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     const messages = ws.send.mock.calls.map((call: unknown[]) =>
       JSON.parse(call[0] as string),
     );
-    expect(messages.map((message: { text: string }) => message.text).join(""))
-      .toBe("A😀BC");
+    expect(
+      messages.map((message: { text: string }) => message.text).join(""),
+    ).toBe("A😀BC");
     expect(
       messages.every(
         (message: { text: string }) => Array.from(message.text).length <= 2,
@@ -6771,7 +8166,10 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
       initialize: vi.fn(async () => {}),
     };
 
-    const bridge = new BridgeWebSocketServer({ server: httpServer, firebaseAuth: mockAuth as any });
+    const bridge = new BridgeWebSocketServer({
+      server: httpServer,
+      firebaseAuth: mockAuth as any,
+    });
     (bridge as any).tokenLocales.set("token-1", "en");
     (bridge as any).broadcastSessionMessage("s-1", {
       type: "permission_request",
@@ -6810,7 +8208,10 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
       initialize: vi.fn(async () => {}),
     };
 
-    const bridge = new BridgeWebSocketServer({ server: httpServer, firebaseAuth: mockAuth as any });
+    const bridge = new BridgeWebSocketServer({
+      server: httpServer,
+      firebaseAuth: mockAuth as any,
+    });
     (bridge as any).tokenLocales.set("token-1", "en");
     (bridge as any).broadcastSessionMessage("s-1", {
       type: "result",
@@ -6939,8 +8340,12 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     );
     await Promise.resolve();
 
-    const sends = ws.send.mock.calls.map((c: unknown[]) => JSON.parse(c[0] as string));
-    const created = sends.find((m: any) => m.type === "system" && m.subtype === "session_created");
+    const sends = ws.send.mock.calls.map((c: unknown[]) =>
+      JSON.parse(c[0] as string),
+    );
+    const created = sends.find(
+      (m: any) => m.type === "system" && m.subtype === "session_created",
+    );
     expect(created).toBeDefined();
     const sessionId = created.sessionId as string;
 
@@ -7073,7 +8478,9 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
       sessionId,
       queued: true,
     });
-    expect(session.process.dispatchInput).toHaveBeenCalledWith("after approval");
+    expect(session.process.dispatchInput).toHaveBeenCalledWith(
+      "after approval",
+    );
     expect(session.process.interrupt).not.toHaveBeenCalled();
 
     bridge.close();
@@ -7171,7 +8578,9 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     const peerMessages = otherWs.send.mock.calls.map((c: unknown[]) =>
       JSON.parse(c[0] as string),
     );
-    expect(peerMessages.find((m: any) => m.type === "user_input")).toMatchObject({
+    expect(
+      peerMessages.find((m: any) => m.type === "user_input"),
+    ).toMatchObject({
       type: "user_input",
       sessionId,
       text: "hello from phone",
@@ -7208,7 +8617,9 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
       .map((c: unknown[]) => JSON.parse(c[0] as string))
       .find((m: any) => m.type === "system" && m.subtype === "session_created");
     const sessionId = created.sessionId as string;
-    const baseSeq = (bridge as any).sessionManager.get(sessionId).historyRevision;
+    const baseSeq = (bridge as any).sessionManager.get(
+      sessionId,
+    ).historyRevision;
     (bridge as any).sessionManager.appendHistory(sessionId, {
       type: "user_input",
       text: "from another client",
@@ -7334,8 +8745,12 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     );
     await Promise.resolve();
 
-    const sends = ws.send.mock.calls.map((c: unknown[]) => JSON.parse(c[0] as string));
-    const created = sends.find((m: any) => m.type === "system" && m.subtype === "session_created");
+    const sends = ws.send.mock.calls.map((c: unknown[]) =>
+      JSON.parse(c[0] as string),
+    );
+    const created = sends.find(
+      (m: any) => m.type === "system" && m.subtype === "session_created",
+    );
     expect(created).toBeDefined();
     const sessionId = created.sessionId as string;
 
@@ -7352,7 +8767,9 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
       ws,
     );
 
-    let sent = ws.send.mock.calls.map((c: unknown[]) => JSON.parse(c[0] as string));
+    let sent = ws.send.mock.calls.map((c: unknown[]) =>
+      JSON.parse(c[0] as string),
+    );
     expect(sent.find((m: any) => m.type === "input_ack")).toMatchObject({
       type: "input_ack",
       sessionId,
@@ -7403,7 +8820,9 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     );
 
     const session = (bridge as any).sessionManager.get(sessionId);
-    const userInput = session.history.find((message: any) => message.type === "user_input");
+    const userInput = session.history.find(
+      (message: any) => message.type === "user_input",
+    );
     expect(userInput).toMatchObject({
       type: "user_input",
       text: "first codex turn",
@@ -7469,7 +8888,9 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     const peerMessages = otherWs.send.mock.calls.map((c: unknown[]) =>
       JSON.parse(c[0] as string),
     );
-    expect(peerMessages.find((m: any) => m.type === "user_input")).toMatchObject({
+    expect(
+      peerMessages.find((m: any) => m.type === "user_input"),
+    ).toMatchObject({
       type: "user_input",
       sessionId,
       text: "codex from mac",
@@ -7528,7 +8949,7 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
         content: [{ type: "text", text: "second codex turn" }],
       },
     ];
-    const rollbackThread = session.process.rollbackThread;
+    const rollbackThreadById = session.process.rollbackThreadById;
 
     ws.send.mockClear();
     await (bridge as any).handleClientMessage(
@@ -7542,10 +8963,12 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     );
     await Promise.resolve();
 
-    expect(rollbackThread).toHaveBeenCalledWith(2);
+    expect(rollbackThreadById).toHaveBeenCalledWith("thread-rollback", 2);
     expect(getCodexSessionHistoryMock).not.toHaveBeenCalled();
 
-    const sends = ws.send.mock.calls.map((c: unknown[]) => JSON.parse(c[0] as string));
+    const sends = ws.send.mock.calls.map((c: unknown[]) =>
+      JSON.parse(c[0] as string),
+    );
     expect(sends.find((m: any) => m.type === "rewind_result")).toMatchObject({
       success: true,
       mode: "conversation",
@@ -7559,7 +8982,9 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
       sourceSessionId: sessionId,
     });
     const newSession = (bridge as any).sessionManager.get(newCreated.sessionId);
-    expect(newSession.codexOptions).toMatchObject({ threadId: "thread-rollback" });
+    expect(newSession.codexOptions).toMatchObject({
+      threadId: "thread-rollback",
+    });
     expect(newSession.pastMessages).toEqual([]);
 
     bridge.close();
@@ -7567,6 +8992,10 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
 
   it("forks codex conversation at a target turn and rolls back only the fork", async () => {
     const bridge = new BridgeWebSocketServer({ server: httpServer });
+    const persistActiveSessions = vi.spyOn(
+      bridge as any,
+      "persistActiveSessions",
+    );
     const ws = {
       readyState: OPEN_STATE,
       send: vi.fn(),
@@ -7587,8 +9016,9 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
       .find((m: any) => m.type === "system" && m.subtype === "session_created");
     const sessionId = created.sessionId as string;
     const session = (bridge as any).sessionManager.get(sessionId);
+    session.claudeSessionId = "thread-source";
     session.process.sessionId = "thread-source";
-    session.process.forkThread.mockResolvedValueOnce({
+    session.process.forkThreadById.mockResolvedValueOnce({
       threadId: "thread-forked",
       thread: { id: "thread-forked", turns: [] },
     });
@@ -7632,14 +9062,19 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(session.process.forkThread).toHaveBeenCalledTimes(1);
+    expect(session.process.forkThreadById).toHaveBeenCalledWith(
+      "thread-source",
+    );
     expect(session.process.rollbackThreadById).toHaveBeenCalledWith(
       "thread-forked",
       1,
     );
+    expect(persistActiveSessions).toHaveBeenCalled();
     expect(getCodexSessionHistoryMock).not.toHaveBeenCalled();
 
-    const sends = ws.send.mock.calls.map((c: unknown[]) => JSON.parse(c[0] as string));
+    const sends = ws.send.mock.calls.map((c: unknown[]) =>
+      JSON.parse(c[0] as string),
+    );
     const newCreated = sends.find(
       (m: any) => m.type === "system" && m.subtype === "session_created",
     );
@@ -7651,7 +9086,9 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     const oldSession = (bridge as any).sessionManager.get(sessionId);
     expect(oldSession).toBeDefined();
     const newSession = (bridge as any).sessionManager.get(newCreated.sessionId);
-    expect(newSession.codexOptions).toMatchObject({ threadId: "thread-forked" });
+    expect(newSession.codexOptions).toMatchObject({
+      threadId: "thread-forked",
+    });
     expect(newSession.pastMessages).toMatchObject([
       {
         role: "user",
@@ -7667,6 +9104,94 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
 
     bridge.close();
   });
+
+  it.each(["rewind", "fork"] as const)(
+    "does not resurrect a Codex session stopped during %s",
+    async (action) => {
+      const bridge = new BridgeWebSocketServer({ server: httpServer });
+      const ws = { readyState: OPEN_STATE, send: vi.fn() } as any;
+      await (bridge as any).handleClientMessage(
+        {
+          type: "start",
+          projectPath: "/tmp/project-codex",
+          provider: "codex",
+        },
+        ws,
+      );
+      const created = ws.send.mock.calls
+        .map((call: unknown[]) => JSON.parse(call[0] as string))
+        .find(
+          (message: any) =>
+            message.type === "system" && message.subtype === "session_created",
+        );
+      const session = (bridge as any).sessionManager.get(created.sessionId);
+      session.claudeSessionId = "thread-stop-race";
+      session.process.sessionId = "thread-stop-race";
+      session.pastMessages = [
+        {
+          role: "user",
+          uuid: "codex:user-turn:1",
+          content: [{ type: "text", text: "Keep stopped" }],
+        },
+      ];
+      let finishRpc!: (value: Record<string, unknown>) => void;
+      const pendingRpc = new Promise<Record<string, unknown>>((resolve) => {
+        finishRpc = resolve;
+      });
+      if (action === "rewind") {
+        session.process.rollbackThreadById.mockReturnValueOnce(pendingRpc);
+      } else {
+        session.process.forkThreadById.mockReturnValueOnce(pendingRpc);
+      }
+
+      ws.send.mockClear();
+      void (bridge as any).handleClientMessage(
+        action === "rewind"
+          ? {
+              type: "rewind",
+              sessionId: created.sessionId,
+              targetUuid: "codex:user-turn:1",
+              mode: "conversation",
+            }
+          : {
+              type: "fork",
+              sessionId: created.sessionId,
+              targetUuid: "codex:user-turn:1",
+            },
+        ws,
+      );
+      await vi.waitFor(() => {
+        const rpc =
+          action === "rewind"
+            ? session.process.rollbackThreadById
+            : session.process.forkThreadById;
+        expect(rpc).toHaveBeenCalled();
+      });
+
+      await (bridge as any).handleClientMessage(
+        { type: "stop_session", sessionId: created.sessionId },
+        ws,
+      );
+      finishRpc(
+        action === "rewind"
+          ? { turns: [] }
+          : { threadId: "forked-after-stop", thread: { turns: [] } },
+      );
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect((bridge as any).sessionManager.list()).toEqual([]);
+      expect(
+        ws.send.mock.calls
+          .map((call: unknown[]) => JSON.parse(call[0] as string))
+          .some(
+            (message: any) =>
+              message.type === "system" &&
+              message.subtype === "session_created",
+          ),
+      ).toBe(false);
+      bridge.close();
+    },
+  );
 
   it("rejects codex code rewind modes", async () => {
     const bridge = new BridgeWebSocketServer({ server: httpServer });
@@ -7873,7 +9398,9 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     const peerMessages = otherWs.send.mock.calls.map((c: unknown[]) =>
       JSON.parse(c[0] as string),
     );
-    expect(peerMessages.find((m: any) => m.type === "user_input")).toMatchObject({
+    expect(
+      peerMessages.find((m: any) => m.type === "user_input"),
+    ).toMatchObject({
       type: "user_input",
       sessionId,
       text: "steer now",
@@ -7994,8 +9521,12 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     );
     await Promise.resolve();
 
-    const sends = ws.send.mock.calls.map((c: unknown[]) => JSON.parse(c[0] as string));
-    const created = sends.find((m: any) => m.type === "system" && m.subtype === "session_created");
+    const sends = ws.send.mock.calls.map((c: unknown[]) =>
+      JSON.parse(c[0] as string),
+    );
+    const created = sends.find(
+      (m: any) => m.type === "system" && m.subtype === "session_created",
+    );
     const sessionId = created.sessionId as string;
 
     ws.send.mockClear();
@@ -8007,13 +9538,20 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
 
     // Send rewind (conversation mode)
     (bridge as any).handleClientMessage(
-      { type: "rewind", sessionId, targetUuid: "user-msg-1", mode: "conversation" },
+      {
+        type: "rewind",
+        sessionId,
+        targetUuid: "user-msg-1",
+        mode: "conversation",
+      },
       ws,
     );
     await Promise.resolve();
     await Promise.resolve();
 
-    const rewindSends = ws.send.mock.calls.map((c: unknown[]) => JSON.parse(c[0] as string));
+    const rewindSends = ws.send.mock.calls.map((c: unknown[]) =>
+      JSON.parse(c[0] as string),
+    );
     expect(rewindSends[0]).toEqual({
       type: "stream_delta",
       text: "before rewind",
@@ -8033,13 +9571,21 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     const ws = { readyState: OPEN_STATE, send: vi.fn() } as any;
 
     (bridge as any).handleClientMessage(
-      { type: "start", projectPath: "/tmp/rewind-both-test", provider: "claude" },
+      {
+        type: "start",
+        projectPath: "/tmp/rewind-both-test",
+        provider: "claude",
+      },
       ws,
     );
     await Promise.resolve();
 
-    const sends = ws.send.mock.calls.map((c: unknown[]) => JSON.parse(c[0] as string));
-    const created = sends.find((m: any) => m.type === "system" && m.subtype === "session_created");
+    const sends = ws.send.mock.calls.map((c: unknown[]) =>
+      JSON.parse(c[0] as string),
+    );
+    const created = sends.find(
+      (m: any) => m.type === "system" && m.subtype === "session_created",
+    );
     const sessionId = created.sessionId as string;
 
     ws.send.mockClear();
@@ -8052,7 +9598,9 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     await Promise.resolve();
     await Promise.resolve();
 
-    const rewindSends = ws.send.mock.calls.map((c: unknown[]) => JSON.parse(c[0] as string));
+    const rewindSends = ws.send.mock.calls.map((c: unknown[]) =>
+      JSON.parse(c[0] as string),
+    );
     const rewindCreated = rewindSends.find(
       (m: any) => m.type === "system" && m.subtype === "session_created",
     );
@@ -8145,13 +9693,11 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
       ]),
     );
 
-    const payload = await (bridge as any).listRecentCodexThreads(
-      {
+    const payload = await (bridge as any).listRecentCodexThreads({
         type: "list_recent_sessions",
         provider: "codex",
         projectPath: "/tmp/project-codex",
-      },
-    );
+    });
 
     expect(session.process.listThreads).toHaveBeenCalledWith({
       limit: 20,
@@ -8220,13 +9766,11 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
       stop,
     }));
 
-    const payload = await (bridge as any).listRecentCodexThreads(
-      {
+    const payload = await (bridge as any).listRecentCodexThreads({
         type: "list_recent_sessions",
         provider: "codex",
         projectPath: "/tmp/project-codex",
-      },
-    );
+    });
 
     expect((bridge as any).createStandaloneCodexProcess).toHaveBeenCalledWith(
       "/tmp/project-codex",
@@ -8374,7 +9918,9 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
       ws,
     );
 
-    const sends = ws.send.mock.calls.map((c: unknown[]) => JSON.parse(c[0] as string));
+    const sends = ws.send.mock.calls.map((c: unknown[]) =>
+      JSON.parse(c[0] as string),
+    );
     expect(sends).toContainEqual({
       type: "git_commit_result",
       success: false,
@@ -8417,7 +9963,9 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
       ws,
     );
 
-    const sends = ws.send.mock.calls.map((c: unknown[]) => JSON.parse(c[0] as string));
+    const sends = ws.send.mock.calls.map((c: unknown[]) =>
+      JSON.parse(c[0] as string),
+    );
     expect(sends).toContainEqual({
       type: "git_commit_result",
       success: false,
@@ -8476,7 +10024,9 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
       "feat: generated by claude",
     );
 
-    const sends = ws.send.mock.calls.map((c: unknown[]) => JSON.parse(c[0] as string));
+    const sends = ws.send.mock.calls.map((c: unknown[]) =>
+      JSON.parse(c[0] as string),
+    );
     expect(sends).toContainEqual({
       type: "git_commit_result",
       success: true,
@@ -8537,7 +10087,9 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
       "fix: generated by codex",
     );
 
-    const sends = ws.send.mock.calls.map((c: unknown[]) => JSON.parse(c[0] as string));
+    const sends = ws.send.mock.calls.map((c: unknown[]) =>
+      JSON.parse(c[0] as string),
+    );
     expect(sends).toContainEqual({
       type: "git_commit_result",
       success: true,

--- a/packages/bridge/src/websocket.ts
+++ b/packages/bridge/src/websocket.ts
@@ -42,6 +42,7 @@ import {
 import {
   getAllRecentSessions,
   getCodexSessionHistory,
+  boundCodexSessionHistory,
   getSessionHistory,
   codexUserTurnUuid,
   codexThreadToSessionHistory,
@@ -64,6 +65,10 @@ import {
 import type { GalleryStore } from "./gallery-store.js";
 import type { ProjectHistory } from "./project-history.js";
 import { ArchiveStore } from "./archive-store.js";
+import {
+  ActiveSessionStore,
+  type PersistedActiveSession,
+} from "./active-session-store.js";
 import { WorktreeStore } from "./worktree-store.js";
 import {
   listWorktrees,
@@ -124,9 +129,8 @@ type ResumeOperation = {
   provider: Provider;
   sourceSessionId: string;
   projectPath: string;
-  resumeRequestId?: string;
   fingerprint: string;
-  waiters: Set<WebSocket>;
+  waiters: Map<WebSocket, string | undefined>;
   timeout?: ReturnType<typeof setTimeout>;
   completed?: {
     sessionId: string;
@@ -137,11 +141,7 @@ type ResumeOperation = {
 const RESUME_OPERATION_TIMEOUT_MS = 5 * 60 * 1000;
 const RESUME_COMPLETED_TTL_MS = 30 * 1000;
 type ClaudePermissionMode =
-  | "default"
-  | "auto"
-  | "acceptEdits"
-  | "bypassPermissions"
-  | "plan";
+  "default" | "auto" | "acceptEdits" | "bypassPermissions" | "plan";
 
 // ---- Available model lists (delivered to clients via session_list) ----
 
@@ -249,7 +249,11 @@ function countCodexUserTurnsInSession(session: SessionInfo): number {
   if (Array.isArray(session.pastMessages)) {
     for (const message of session.pastMessages) {
       if (!message || typeof message !== "object") continue;
-      const item = message as { role?: unknown; uuid?: unknown; isMeta?: unknown };
+      const item = message as {
+        role?: unknown;
+        uuid?: unknown;
+        isMeta?: unknown;
+      };
       if (item.role === "user" && item.isMeta !== true) {
         observe(typeof item.uuid === "string" ? item.uuid : undefined);
       }
@@ -298,7 +302,9 @@ function normalizeHistoryContent(
         id: typeof value.id === "string" ? value.id : undefined,
         name: typeof value.name === "string" ? value.name : undefined,
         input:
-          value.input && typeof value.input === "object" && !Array.isArray(value.input)
+          value.input &&
+          typeof value.input === "object" &&
+          !Array.isArray(value.input)
             ? (value.input as Record<string, unknown>)
             : undefined,
       });
@@ -328,7 +334,11 @@ function buildCodexHistoryPrefix(
       messages.push({ ...item });
       return;
     }
-    if (item.role === "assistant" && userOrdinal > 0 && userOrdinal <= targetOrdinal) {
+    if (
+      item.role === "assistant" &&
+      userOrdinal > 0 &&
+      userOrdinal <= targetOrdinal
+    ) {
       messages.push({ ...item });
     }
   };
@@ -368,8 +378,9 @@ function buildCodexHistoryPrefix(
 }
 
 function countCodexHistoryUserTurns(messages: SessionHistoryMessage[]): number {
-  return messages.filter((message) => message.role === "user" && !message.isMeta)
-    .length;
+  return messages.filter(
+    (message) => message.role === "user" && !message.isMeta,
+  ).length;
 }
 
 // ---- Codex mode mapping helpers ----
@@ -596,6 +607,11 @@ function normalizeNonNegativeLimit(
     : fallback;
 }
 
+function parsePersistedDate(value: string, fallback: Date): Date {
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? fallback : parsed;
+}
+
 function codexThreadToRecentSession(
   thread: CodexThreadSummary,
   indexed?: CodexSessionIndexMetadata,
@@ -612,6 +628,9 @@ function codexThreadToRecentSession(
     summary: indexed?.summary || thread.preview || undefined,
     firstPrompt: indexed?.firstPrompt || thread.preview || "",
     ...(indexed?.lastPrompt ? { lastPrompt: indexed.lastPrompt } : {}),
+    ...(indexed?.lastResponse || indexed?.summary
+      ? { lastResponse: indexed?.lastResponse || indexed?.summary }
+      : {}),
     created: threadTimestampToIso(thread.createdAt),
     modified: threadTimestampToIso(thread.updatedAt),
     gitBranch: thread.gitBranch ?? "",
@@ -627,11 +646,21 @@ function recentSessionModifiedTime(session: unknown): number {
   return typeof modified === "string" ? new Date(modified).getTime() || 0 : 0;
 }
 
-function recentSessionDedupeKey(session: unknown, fallbackIndex: number): string {
+function recentSessionDedupeKey(
+  session: unknown,
+  fallbackIndex: number,
+): string {
   const value = session as { provider?: unknown; sessionId?: unknown };
-  return typeof value.provider === "string" && typeof value.sessionId === "string"
+  return typeof value.provider === "string" &&
+    typeof value.sessionId === "string"
     ? `${value.provider}:${value.sessionId}`
     : `unknown:${fallbackIndex}`;
+}
+
+function activeSessionKey(
+  session: Pick<PersistedActiveSession, "provider" | "providerSessionId">,
+): string {
+  return `${session.provider}:${session.providerSessionId}`;
 }
 
 function mergeRecentSessionPages(sessions: unknown[]): unknown[] {
@@ -660,6 +689,7 @@ export interface BridgeServerOptions {
   firebaseAuth?: FirebaseAuthClient;
   promptHistoryBackup?: PromptHistoryBackupStore;
   promptHistoryStore?: PromptHistoryStore;
+  activeSessionStore?: ActiveSessionStore | null;
   platform?: NodeJS.Platform;
   fileListMaxEntries?: number;
   fileListMaxBytes?: number;
@@ -710,6 +740,10 @@ export class BridgeWebSocketServer {
   private debugEvents = new Map<string, DebugTraceEvent[]>();
   private notifiedPermissionToolUses = new Map<string, Set<string>>();
   private archiveStore: ArchiveStore;
+  private activeSessionStore: ActiveSessionStore | null;
+  private deferredActiveSessions = new Map<string, PersistedActiveSession>();
+  private restoredClaudeHistoryIds = new Map<string, string>();
+  private restoredClaudeHistoryLoads = new Map<string, Promise<void>>();
   private codexProfiles: string[] = [];
   private defaultCodexProfile: string | undefined;
   private codexAutoReviewDisabled = false;
@@ -752,11 +786,18 @@ export class BridgeWebSocketServer {
   private deltaBatches = new Map<WebSocket, Map<string, DeltaBatch>>();
   private platform: NodeJS.Platform;
   private clientSupportedServerMessages = new WeakMap<WebSocket, Set<string>>();
+  private codexHistoryResponsesInFlight = new WeakMap<WebSocket, Set<string>>();
+  private codexCanonicalHistoryInFlight = new Map<
+    string,
+    Promise<HistoryEntry[] | null>
+  >();
   private pendingClaudeResumeInputs = new WeakMap<
     WebSocket,
     Map<string, InputClientMessage[]>
   >();
   private resumeOperations = new Map<string, ResumeOperation>();
+  /** Cancels an async Codex restart when the old session is explicitly stopped. */
+  private sessionReplacementTokens = new Map<string, symbol>();
 
   constructor(options: BridgeServerOptions) {
     const {
@@ -771,6 +812,7 @@ export class BridgeWebSocketServer {
       firebaseAuth,
       promptHistoryBackup,
       promptHistoryStore,
+      activeSessionStore,
       platform,
       fileListMaxEntries,
       fileListMaxBytes,
@@ -788,6 +830,13 @@ export class BridgeWebSocketServer {
     this.pushRelay = new PushRelayClient({ firebaseAuth });
     this.promptHistoryBackup = promptHistoryBackup ?? null;
     this.promptHistoryStore = promptHistoryStore ?? null;
+    this.activeSessionStore =
+      activeSessionStore === undefined
+        ? process.env.NODE_ENV === "test" ||
+          process.env.BRIDGE_DISABLE_ACTIVE_SESSIONS === "1"
+          ? null
+          : new ActiveSessionStore()
+        : activeSessionStore;
     this.platform = platform ?? process.platform;
     this.fileListMaxEntries = normalizePositiveLimit(
       fileListMaxEntries,
@@ -854,6 +903,7 @@ export class BridgeWebSocketServer {
       this.worktreeStore,
       () => this.broadcastSessionList(),
     );
+    this.restorePersistedActiveSessions();
 
     this.wss.on("connection", (ws, req) => {
       // API key authentication
@@ -884,8 +934,8 @@ export class BridgeWebSocketServer {
    */
   private isPathAllowed(path: string): boolean {
     if (this.allowedDirs.length === 0) return true;
-    return this.allowedDirs.some(
-      (dir) => isPathWithinAllowedDirectory(path, dir, this.platform),
+    return this.allowedDirs.some((dir) =>
+      isPathWithinAllowedDirectory(path, dir, this.platform),
     );
   }
 
@@ -980,7 +1030,8 @@ export class BridgeWebSocketServer {
       sourceSessionId,
       resumeRequestId,
     } = params;
-    const derivedCodexSettings = provider === "codex"
+    const derivedCodexSettings =
+      provider === "codex"
       ? withDerivedCodexPermissionsMode(session?.codexSettings)
       : session?.codexSettings;
 
@@ -993,11 +1044,7 @@ export class BridgeWebSocketServer {
       ...(permissionMode
         ? {
             permissionMode: permissionMode as
-              | "default"
-              | "auto"
-              | "acceptEdits"
-              | "bypassPermissions"
-              | "plan",
+              "default" | "auto" | "acceptEdits" | "bypassPermissions" | "plan",
           }
         : {}),
       ...((approvalsReviewer ?? derivedCodexSettings?.approvalsReviewer)
@@ -1010,10 +1057,7 @@ export class BridgeWebSocketServer {
         ? {
             codexPermissionsMode: (codexPermissionsMode ??
               derivedCodexSettings?.codexPermissionsMode) as
-              | "default"
-              | "autoReview"
-              | "fullAccess"
-              | "custom",
+              "default" | "autoReview" | "fullAccess" | "custom",
           }
         : {}),
       ...((executionMode ??
@@ -1071,8 +1115,7 @@ export class BridgeWebSocketServer {
       ...(apps ? { apps } : {}),
       ...(appMetadata
         ? {
-            appMetadata:
-              appMetadata as SystemServerMessage["appMetadata"],
+            appMetadata: appMetadata as SystemServerMessage["appMetadata"],
           }
         : {}),
       ...(plugins ? { plugins } : {}),
@@ -1101,10 +1144,7 @@ export class BridgeWebSocketServer {
       }
       if (derivedCodexSettings.codexPermissionsMode !== undefined) {
         msg.codexPermissionsMode = derivedCodexSettings.codexPermissionsMode as
-          | "default"
-          | "autoReview"
-          | "fullAccess"
-          | "custom";
+          "default" | "autoReview" | "fullAccess" | "custom";
       }
       if (derivedCodexSettings.modelReasoningEffort !== undefined) {
         msg.modelReasoningEffort = derivedCodexSettings.modelReasoningEffort;
@@ -1166,7 +1206,10 @@ export class BridgeWebSocketServer {
       });
       return;
     }
-    if (session.status !== "idle" || (codexProcess.status ?? session.status) !== "idle") {
+    if (
+      session.status !== "idle" ||
+      (!session.dormant && (codexProcess.status ?? session.status) !== "idle")
+    ) {
       this.send(ws, {
         type: "rewind_result",
         success: false,
@@ -1228,7 +1271,12 @@ export class BridgeWebSocketServer {
         }
       : undefined;
 
-    const rolledBackThread = await codexProcess.rollbackThread(numTurns);
+    const rolledBackThread = await this.withCodexSessionRpc(
+      session,
+      (process, activeThreadId) =>
+        process.rollbackThreadById(activeThreadId, numTurns),
+    );
+    if (this.sessionManager.get(sessionId) !== session) return;
 
     const pastMessages = this.codexHistoryFromThreadOrFallback({
       thread: rolledBackThread,
@@ -1266,6 +1314,7 @@ export class BridgeWebSocketServer {
         sourceSessionId: sessionId,
       }),
     );
+    this.persistActiveSessions();
     this.sendSessionList(ws);
   }
 
@@ -1295,7 +1344,10 @@ export class BridgeWebSocketServer {
       });
       return;
     }
-    if (session.status !== "idle" || (codexProcess.status ?? session.status) !== "idle") {
+    if (
+      session.status !== "idle" ||
+      (!session.dormant && (codexProcess.status ?? session.status) !== "idle")
+    ) {
       this.send(ws, {
         type: "error",
         message: "Cannot fork while Codex is running",
@@ -1332,16 +1384,21 @@ export class BridgeWebSocketServer {
         }
       : undefined;
 
-    const forked = await codexProcess.forkThread();
-    const forkedThreadId = forked.threadId;
     const turnsToDrop = totalUserTurns - targetOrdinal;
-    let forkedThread: unknown = forked.thread;
-    if (turnsToDrop > 0) {
-      forkedThread = await codexProcess.rollbackThreadById(
-        forkedThreadId,
-        turnsToDrop,
+    const { forkedThreadId, forkedThread } = await this.withCodexSessionRpc(
+      session,
+      async (process, activeThreadId) => {
+        const forked = await process.forkThreadById(activeThreadId);
+        return {
+          forkedThreadId: forked.threadId,
+          forkedThread:
+            turnsToDrop > 0
+              ? await process.rollbackThreadById(forked.threadId, turnsToDrop)
+              : forked.thread,
+        };
+      },
       );
-    }
+    if (this.sessionManager.get(sessionId) !== session) return;
 
     const pastMessages = this.codexHistoryFromThreadOrFallback({
       thread: forkedThread,
@@ -1373,6 +1430,7 @@ export class BridgeWebSocketServer {
         sourceSessionId: sessionId,
       }),
     );
+    this.persistActiveSessions();
     this.sendSessionList(ws);
   }
 
@@ -1452,7 +1510,44 @@ export class BridgeWebSocketServer {
     return undefined;
   }
 
+  private beginCodexHistoryResponse(ws: WebSocket, sessionId: string): boolean {
+    let sessionIds = this.codexHistoryResponsesInFlight.get(ws);
+    if (!sessionIds) {
+      sessionIds = new Set<string>();
+      this.codexHistoryResponsesInFlight.set(ws, sessionIds);
+    }
+    if (sessionIds.has(sessionId)) return false;
+    sessionIds.add(sessionId);
+    return true;
+  }
+
+  private endCodexHistoryResponse(ws: WebSocket, sessionId: string): void {
+    const sessionIds = this.codexHistoryResponsesInFlight.get(ws);
+    if (!sessionIds) return;
+    sessionIds.delete(sessionId);
+    if (sessionIds.size === 0) {
+      this.codexHistoryResponsesInFlight.delete(ws);
+    }
+  }
+
   private async codexCanonicalHistoryEntries(
+    session: SessionInfo,
+  ): Promise<HistoryEntry[] | null> {
+    const existing = this.codexCanonicalHistoryInFlight.get(session.id);
+    if (existing) return existing;
+
+    const request = this.loadCodexCanonicalHistoryEntries(session);
+    this.codexCanonicalHistoryInFlight.set(session.id, request);
+    try {
+      return await request;
+    } finally {
+      if (this.codexCanonicalHistoryInFlight.get(session.id) === request) {
+        this.codexCanonicalHistoryInFlight.delete(session.id);
+      }
+    }
+  }
+
+  private async loadCodexCanonicalHistoryEntries(
     session: SessionInfo,
   ): Promise<HistoryEntry[] | null> {
     const threadId = this.codexThreadIdForSession(session);
@@ -1460,10 +1555,10 @@ export class BridgeWebSocketServer {
 
     const history = session.codexInitialHistoryPending
       ? ((session.pastMessages ?? []) as SessionHistoryMessage[])
-      : await this.getCodexThreadHistoryFromRpc(
+      : await this.getCodexThreadHistory(
           threadId,
           session.projectPath,
-          session.process as CodexProcess,
+          session.dormant ? undefined : (session.process as CodexProcess),
         );
     session.claudeSessionId = threadId;
 
@@ -1472,11 +1567,7 @@ export class BridgeWebSocketServer {
       seq: index + 1,
       message,
     }));
-    this.applyCodexCanonicalHistoryBaseline(
-      session,
-      history,
-      entries,
-    );
+    this.applyCodexCanonicalHistoryBaseline(session, history, entries);
     session.codexInitialHistoryPending = false;
     return entries;
   }
@@ -1695,11 +1786,7 @@ export class BridgeWebSocketServer {
   ): void {
     if (session.provider !== "codex") return;
     for (const message of history) {
-      if (
-        message.role !== "user" ||
-        !message.rawItemId ||
-        !message.uuid
-      ) {
+      if (message.role !== "user" || !message.rawItemId || !message.uuid) {
         continue;
       }
       session.codexUserTurnUuidByRawId ??= new Map<string, string>();
@@ -1749,19 +1836,18 @@ export class BridgeWebSocketServer {
     sessionId: string,
     session: SessionInfo,
   ): void {
-    const process = session.process instanceof CodexProcess
-      ? session.process
-      : undefined;
+    const process =
+      session.process instanceof CodexProcess ? session.process : undefined;
     const settings = session.codexSettings;
     this.send(ws, {
       type: "system",
       subtype: "codex_settings",
       sessionId,
       provider: "codex",
-      ...(settings?.model ?? process?.model
+      ...((settings?.model ?? process?.model)
         ? { model: settings?.model ?? process?.model }
         : {}),
-      ...(settings?.modelReasoningEffort ?? process?.modelReasoningEffort
+      ...((settings?.modelReasoningEffort ?? process?.modelReasoningEffort)
         ? {
             modelReasoningEffort:
               settings?.modelReasoningEffort ?? process?.modelReasoningEffort,
@@ -1799,6 +1885,7 @@ export class BridgeWebSocketServer {
     } catch (err) {
       this.send(ws, {
         type: "error",
+        sessionId,
         message: `Failed to read Codex thread history: ${
           err instanceof Error ? err.message : String(err)
         }`,
@@ -1833,6 +1920,7 @@ export class BridgeWebSocketServer {
     } catch (err) {
       this.send(ws, {
         type: "error",
+        sessionId,
         message: `Failed to read Codex thread history: ${
           err instanceof Error ? err.message : String(err)
         }`,
@@ -1847,7 +1935,8 @@ export class BridgeWebSocketServer {
     resultKind: "delta" | "snapshot",
   ): boolean {
     if (!this.codexThreadIdForSession(session)) return false;
-    const resetRevision = session.codexHistoryResetRevision ??
+    const resetRevision =
+      session.codexHistoryResetRevision ??
       session.codexCanonicalHistoryRevision;
     if (typeof resetRevision !== "number") return true;
     if (sinceSeq < resetRevision) return true;
@@ -1928,7 +2017,9 @@ export class BridgeWebSocketServer {
     };
   }
 
-  private sessionHistoryText(content: SessionHistoryMessage["content"]): string {
+  private sessionHistoryText(
+    content: SessionHistoryMessage["content"],
+  ): string {
     if (typeof content === "string") return content;
     if (!Array.isArray(content)) return "";
     return content
@@ -1949,9 +2040,7 @@ export class BridgeWebSocketServer {
     content: SessionHistoryMessage["content"],
   ): AssistantContent[] {
     if (typeof content === "string") {
-      return content.trim().length > 0
-        ? [{ type: "text", text: content }]
-        : [];
+      return content.trim().length > 0 ? [{ type: "text", text: content }] : [];
     }
     if (!Array.isArray(content)) return [];
     const items: AssistantContent[] = [];
@@ -2028,13 +2117,13 @@ export class BridgeWebSocketServer {
       }
     }
 
+    const expectedImageCount =
+      typeof msg.imageCount === "number" && msg.imageCount > 0
+        ? msg.imageCount
+        : 0;
     const messageUuid = typeof msg.uuid === "string" ? msg.uuid : undefined;
     const providerSessionId = session.claudeSessionId;
-    if (
-      refs.length === existingImages.length &&
-      messageUuid &&
-      providerSessionId
-    ) {
+    if (refs.length < expectedImageCount && messageUuid && providerSessionId) {
       try {
         const extracted = await extractMessageImages(
           providerSessionId,
@@ -2085,7 +2174,10 @@ export class BridgeWebSocketServer {
     const refs: ImageRef[] = [...existingImages];
     if (paths.size > 0) {
       refs.push(
-        ...(await this.imageStore.registerImages([...paths], session.projectPath)),
+        ...(await this.imageStore.registerImages(
+          [...paths],
+          session.projectPath,
+        )),
       );
     }
 
@@ -2120,7 +2212,7 @@ export class BridgeWebSocketServer {
     const isStandalone = process !== activeProcess;
     try {
       const thread = await process.readThread(threadId, true);
-      return codexThreadToSessionHistory(thread);
+      return boundCodexSessionHistory(codexThreadToSessionHistory(thread));
     } catch (err) {
       if (this.isCodexThreadNotMaterializedError(err)) return [];
       throw err;
@@ -2142,11 +2234,37 @@ export class BridgeWebSocketServer {
   private async getCodexThreadHistory(
     threadId: string,
     projectPath?: string,
+    preferredProcess?: CodexProcess,
   ): Promise<SessionHistoryMessage[]> {
+    const localHistory = await getCodexSessionHistory(threadId);
+    if (localHistory.length > 0) return localHistory;
     if (!this.getActiveCodexProcess() && process.env.NODE_ENV === "test") {
-      return getCodexSessionHistory(threadId);
+      return localHistory;
     }
-    return this.getCodexThreadHistoryFromRpc(threadId, projectPath);
+    return this.getCodexThreadHistoryFromRpc(
+      threadId,
+      projectPath,
+      preferredProcess,
+    );
+  }
+
+  private async withCodexSessionRpc<T>(
+    session: SessionInfo,
+    operation: (process: CodexProcess, threadId: string) => Promise<T>,
+  ): Promise<T> {
+    const threadId = this.codexThreadIdForSession(session);
+    if (!threadId) throw new Error("No Codex thread ID available");
+    const sessionProcess = session.process as CodexProcess;
+    const process = session.dormant
+      ? await this.createStandaloneCodexProcess(
+          session.worktreePath ?? session.projectPath,
+        )
+      : sessionProcess;
+    try {
+      return await operation(process, threadId);
+    } finally {
+      if (process !== sessionProcess) process.stop();
+    }
   }
 
   private codexHistoryFromThreadOrFallback(params: {
@@ -2166,6 +2284,8 @@ export class BridgeWebSocketServer {
     options?: StartOptions & { permissionMode?: ClaudePermissionMode };
     pastMessages?: unknown[];
     worktreeOptions?: WorktreeOptions;
+    restoredBridgeSessionId?: string;
+    deferProcessStart?: boolean;
   }): {
     sessionId: string;
     permissionMode: ClaudePermissionMode;
@@ -2180,6 +2300,10 @@ export class BridgeWebSocketServer {
         params.options,
         params.pastMessages,
         params.worktreeOptions,
+        undefined,
+        undefined,
+        params.restoredBridgeSessionId,
+        params.deferProcessStart,
       );
       return {
         sessionId,
@@ -2192,10 +2316,7 @@ export class BridgeWebSocketServer {
         usedFallback: false,
       };
     } catch (err) {
-      if (
-        initialMode !== "auto" ||
-        !isClaudeAutoModeUnavailableError(err)
-      ) {
+      if (initialMode !== "auto" || !isClaudeAutoModeUnavailableError(err)) {
         throw err;
       }
       const fallbackOptions = {
@@ -2207,6 +2328,10 @@ export class BridgeWebSocketServer {
         fallbackOptions,
         params.pastMessages,
         params.worktreeOptions,
+        undefined,
+        undefined,
+        params.restoredBridgeSessionId,
+        params.deferProcessStart,
       );
       return {
         sessionId,
@@ -2218,12 +2343,305 @@ export class BridgeWebSocketServer {
     }
   }
 
+  private restorePersistedActiveSessions(): void {
+    if (!this.activeSessionStore) return;
+    const records = this.activeSessionStore.list();
+    let restoredCount = 0;
+
+    for (const record of records) {
+      this.deferredActiveSessions.set(activeSessionKey(record), record);
+    }
+
+    for (const record of records) {
+      const projectPath = resolvePlatformPath(
+        record.projectPath,
+        this.platform,
+      );
+      if (!existsSync(projectPath) || !this.isPathAllowed(projectPath)) {
+        console.warn(
+          `[active-sessions] Skipping ${record.providerSessionId}: project path is unavailable or disallowed`,
+        );
+        continue;
+      }
+
+      let worktreeOptions: WorktreeOptions | undefined;
+      if (record.worktreePath) {
+        const worktreePath = resolvePlatformPath(
+          record.worktreePath,
+          this.platform,
+        );
+        if (!existsSync(worktreePath) || !this.isPathAllowed(worktreePath)) {
+          console.warn(
+            `[active-sessions] Skipping ${record.providerSessionId}: worktree path is unavailable or disallowed`,
+          );
+          continue;
+        }
+        worktreeOptions = {
+          existingWorktreePath: worktreePath,
+          worktreeBranch: record.worktreeBranch,
+        };
+      }
+
+      let restoredCodexSettings = record.codexSettings;
+      if (
+        record.provider === "codex" &&
+        record.codexSettings?.additionalWritableRoots
+      ) {
+        const normalizedRoots = this.normalizeAdditionalWritableRoots(
+          record.codexSettings.additionalWritableRoots,
+          projectPath,
+        );
+        if (normalizedRoots.deniedRoot) {
+          console.warn(
+            `[active-sessions] Skipping ${record.providerSessionId}: writable root is no longer allowed (${normalizedRoots.deniedRoot})`,
+          );
+          continue;
+        }
+        restoredCodexSettings = {
+          ...record.codexSettings,
+          additionalWritableRoots: normalizedRoots.roots,
+        };
+      }
+
+      try {
+        const sessionId =
+          record.provider === "claude"
+            ? this.createClaudeSessionWithFallback({
+                projectPath,
+                options: {
+                  sessionId: record.providerSessionId,
+                  permissionMode:
+                    record.permissionMode as StartOptions["permissionMode"],
+                  model: record.model ?? record.claudeSettings?.model,
+                  effort: record.claudeSettings?.effort,
+                  maxTurns: record.claudeSettings?.maxTurns,
+                  maxBudgetUsd: record.claudeSettings?.maxBudgetUsd,
+                  fallbackModel: record.claudeSettings?.fallbackModel,
+                  persistSession: record.claudeSettings?.persistSession,
+                  sandboxEnabled: record.sandboxEnabled,
+                },
+                worktreeOptions,
+                restoredBridgeSessionId: record.bridgeSessionId,
+                deferProcessStart: true,
+              }).sessionId
+            : this.sessionManager.create(
+                projectPath,
+                undefined,
+                undefined,
+                worktreeOptions,
+                "codex",
+                this.withCodexAutoReviewPolicy({
+                  ...(restoredCodexSettings ?? {}),
+                  threadId: record.providerSessionId,
+                  collaborationMode: record.planMode ? "plan" : "default",
+                } as CodexStartOptions),
+                record.bridgeSessionId,
+                true,
+              );
+        const session = this.sessionManager.get(sessionId);
+        if (!session) continue;
+        session.name = record.name;
+        session.restoredLastMessage = record.lastMessage;
+        session.createdAt = parsePersistedDate(
+          record.createdAt,
+          session.createdAt,
+        );
+        session.lastActivityAt = parsePersistedDate(
+          record.lastActivityAt,
+          session.lastActivityAt,
+        );
+        if (record.provider === "codex" && record.codexQueuedInput) {
+          const queued = record.codexQueuedInput;
+          const restoredImageRefs = queued.images?.flatMap((image) => {
+            const ref = this.imageStore?.registerFromBase64(
+              image.base64,
+              image.mimeType,
+            );
+            return ref ? [ref] : [];
+          });
+          session.codexQueuedInput = {
+            ...queued,
+            images: queued.images?.map((image) => ({ ...image })),
+            imageRefs:
+              restoredImageRefs && restoredImageRefs.length > 0
+                ? restoredImageRefs
+                : undefined,
+            skills: queued.skills?.map((skill) => ({ ...skill })),
+            mentions: queued.mentions?.map((mention) => ({ ...mention })),
+          };
+        }
+        this.deferredActiveSessions.delete(activeSessionKey(record));
+        if (record.provider === "claude") {
+          this.restoredClaudeHistoryIds.set(
+            sessionId,
+            record.providerSessionId,
+          );
+        }
+        restoredCount += 1;
+      } catch (err) {
+        console.warn(
+          `[active-sessions] Failed to restore ${record.providerSessionId}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+    }
+
+    this.persistActiveSessions();
+    if (restoredCount > 0) {
+      console.log(`[active-sessions] Restored ${restoredCount} session(s)`);
+    }
+  }
+
+  private loadRestoredClaudeHistory(
+    bridgeSessionId: string,
+    providerSessionId: string,
+  ): void {
+    const load = getSessionHistory(providerSessionId)
+      .then((pastMessages) => {
+        const session = this.sessionManager.get(bridgeSessionId);
+        if (
+          session?.provider === "claude" &&
+          session.claudeSessionId === providerSessionId
+        ) {
+          session.pastMessages =
+            pastMessages.length > 0 ? pastMessages : undefined;
+          this.restoredClaudeHistoryIds.delete(bridgeSessionId);
+        }
+      })
+      .catch((err) => {
+        console.warn(
+          `[active-sessions] Failed to load history for ${providerSessionId}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      })
+      .finally(() => {
+        if (this.restoredClaudeHistoryLoads.get(bridgeSessionId) === load) {
+          this.restoredClaudeHistoryLoads.delete(bridgeSessionId);
+        }
+      });
+    this.restoredClaudeHistoryLoads.set(bridgeSessionId, load);
+  }
+
+  private async waitForRestoredClaudeHistory(
+    bridgeSessionId: string,
+  ): Promise<void> {
+    if (!this.restoredClaudeHistoryLoads.has(bridgeSessionId)) {
+      const providerSessionId =
+        this.restoredClaudeHistoryIds.get(bridgeSessionId);
+      if (providerSessionId) {
+        this.loadRestoredClaudeHistory(bridgeSessionId, providerSessionId);
+      }
+    }
+    await this.restoredClaudeHistoryLoads.get(bridgeSessionId);
+  }
+
+  private activateRestoredQueuedSession(
+    ws: WebSocket,
+    session: SessionInfo,
+  ): void {
+    if (!session.dormant || !session.codexQueuedInput) return;
+    try {
+      this.sessionManager.activate(session.id);
+    } catch (err) {
+      this.send(ws, {
+        type: "error",
+        sessionId: session.id,
+        message: `Failed to reactivate queued session: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      });
+    }
+  }
+
+  private persistActiveSessions(): boolean {
+    if (!this.activeSessionStore) return true;
+    const records: PersistedActiveSession[] = [
+      ...this.deferredActiveSessions.values(),
+    ];
+    for (const summary of this.sessionManager.list()) {
+      if (!summary.claudeSessionId) continue;
+      records.push({
+        bridgeSessionId: summary.id,
+        providerSessionId: summary.claudeSessionId,
+        provider: summary.provider,
+        projectPath: summary.projectPath,
+        ...(summary.name ? { name: summary.name } : {}),
+        createdAt: summary.createdAt,
+        lastActivityAt: summary.lastActivityAt,
+        lastMessage: summary.lastMessage,
+        ...(summary.worktreePath ? { worktreePath: summary.worktreePath } : {}),
+        ...(summary.worktreeBranch
+          ? { worktreeBranch: summary.worktreeBranch }
+          : {}),
+        ...(summary.permissionMode
+          ? { permissionMode: summary.permissionMode }
+          : {}),
+        ...(summary.model ? { model: summary.model } : {}),
+        ...(summary.sandboxEnabled !== undefined
+          ? { sandboxEnabled: summary.sandboxEnabled }
+          : {}),
+        ...(summary.claudeSettings
+          ? { claudeSettings: { ...summary.claudeSettings } }
+          : {}),
+        ...(summary.planMode !== undefined
+          ? { planMode: summary.planMode }
+          : {}),
+        ...(summary.codexSettings
+          ? {
+              codexSettings: {
+                ...summary.codexSettings,
+                additionalWritableRoots:
+                  summary.codexSettings.additionalWritableRoots == null
+                    ? undefined
+                    : [...summary.codexSettings.additionalWritableRoots],
+              },
+            }
+          : {}),
+        ...(summary.queuedInput
+          ? {
+              codexQueuedInput: this.sessionManager.get(summary.id)
+                ?.codexQueuedInput,
+            }
+          : {}),
+      });
+    }
+    try {
+      this.activeSessionStore.replace(records);
+      return true;
+    } catch (err) {
+      console.error(
+        `[active-sessions] Failed to persist recovery state: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      return false;
+    }
+  }
+
+  private removeDeferredActiveSession(
+    matches: (record: PersistedActiveSession) => boolean,
+  ): boolean {
+    let removed = false;
+    for (const [key, record] of this.deferredActiveSessions) {
+      if (!matches(record)) continue;
+      this.deferredActiveSessions.delete(key);
+      removed = true;
+    }
+    return removed;
+  }
+
   close(): void {
     console.log("[ws] Shutting down...");
+    this.persistActiveSessions();
+    this.sessionReplacementTokens.clear();
     for (const operation of this.resumeOperations.values()) {
       if (operation.timeout) clearTimeout(operation.timeout);
     }
     this.resumeOperations.clear();
+    this.restoredClaudeHistoryIds.clear();
+    this.restoredClaudeHistoryLoads.clear();
     this.flushAllDeltaBatches();
     this.sessionManager.destroyAll();
     this.flushAllDeltaBatches();
@@ -2426,8 +2844,7 @@ export class BridgeWebSocketServer {
             executionMode: effectiveExecutionMode,
             planMode: effectivePlanMode,
             usedFallback: autoFallbackUsed,
-          } =
-            provider === "claude"
+          } = provider === "claude"
               ? this.createClaudeSessionWithFallback({
                   projectPath,
                   options: {
@@ -2532,7 +2949,9 @@ export class BridgeWebSocketServer {
                     : executionMode,
                 planMode: provider === "claude" ? effectivePlanMode : planMode,
                 sandboxMode: createdSession?.codexSettings?.sandboxMode
-                  ? sandboxModeToExternal(createdSession.codexSettings.sandboxMode)
+                  ? sandboxModeToExternal(
+                      createdSession.codexSettings.sandboxMode,
+                    )
                   : msg.sandboxMode,
                 codexPermissionsMode:
                   createdSession?.codexSettings?.codexPermissionsMode,
@@ -2615,6 +3034,18 @@ export class BridgeWebSocketServer {
           });
           return;
         }
+        try {
+          this.sessionManager.activate(session.id);
+        } catch (err) {
+          this.send(ws, {
+            type: "error",
+            sessionId: session.id,
+            message: `Failed to reactivate session: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          });
+          return;
+        }
         const text = msg.text;
         const clientMessageId = msg.clientMessageId;
         const baseSeq = msg.baseSeq;
@@ -2647,8 +3078,7 @@ export class BridgeWebSocketServer {
         // Register images in the image store so they can be served via HTTP
         // when the client re-enters the session and loads history.
         let imageRefs:
-          | Array<{ id: string; url: string; mimeType: string }>
-          | undefined;
+          Array<{ id: string; url: string; mimeType: string }> | undefined;
         if (images.length > 0 && this.imageStore) {
           imageRefs = [];
           for (const img of images) {
@@ -2878,9 +3308,7 @@ export class BridgeWebSocketServer {
                     imageData,
                   ]);
                   queuedAfterResolve =
-                    typeof result === "boolean"
-                      ? result
-                      : isAgentBusySnapshot;
+                    typeof result === "boolean" ? result : isAgentBusySnapshot;
                   if (queuedAfterResolve) claudeProc.interrupt();
                 }
               } else {
@@ -2892,9 +3320,7 @@ export class BridgeWebSocketServer {
                 } else {
                   const result = session.process.sendInput(text);
                   queuedAfterResolve =
-                    typeof result === "boolean"
-                      ? result
-                      : isAgentBusySnapshot;
+                    typeof result === "boolean" ? result : isAgentBusySnapshot;
                   if (queuedAfterResolve) claudeProc.interrupt();
                 }
               }
@@ -3057,7 +3483,8 @@ export class BridgeWebSocketServer {
         );
         operation
           .then(() => {
-            if (!this.isCurrentPushTokenOperation(msg.token, generation)) return;
+            if (!this.isCurrentPushTokenOperation(msg.token, generation))
+              return;
             console.log("[ws] push_register: token registered successfully");
             if (supportsRegistrationResult) {
               this.send(ws, {
@@ -3073,7 +3500,8 @@ export class BridgeWebSocketServer {
             this.tokenPrivacyMode.set(msg.token, privacyMode);
           })
           .catch((err) => {
-            if (!this.isCurrentPushTokenOperation(msg.token, generation)) return;
+            if (!this.isCurrentPushTokenOperation(msg.token, generation))
+              return;
             const detail = err instanceof Error ? err.message : String(err);
             console.error(`[ws] push_register failed: ${detail}`);
             const error = `Failed to register push token: ${detail}`;
@@ -3107,13 +3535,15 @@ export class BridgeWebSocketServer {
           this.pushRelay.unregisterToken(msg.token),
         )
           .then(() => {
-            if (!this.isCurrentPushTokenOperation(msg.token, generation)) return;
+            if (!this.isCurrentPushTokenOperation(msg.token, generation))
+              return;
             console.log(
               "[ws] push_unregister: token unregistered successfully",
             );
           })
           .catch((err) => {
-            if (!this.isCurrentPushTokenOperation(msg.token, generation)) return;
+            if (!this.isCurrentPushTokenOperation(msg.token, generation))
+              return;
             const detail = err instanceof Error ? err.message : String(err);
             console.error(`[ws] push_unregister failed: ${detail}`);
             this.send(ws, {
@@ -3142,8 +3572,9 @@ export class BridgeWebSocketServer {
           // Permission mode for Codex requires a session restart (like sandbox mode).
           // approvalPolicy and collaborationMode are thread-level settings that
           // only take effect reliably at thread/start or thread/resume time.
-          const normalizedCodexPermissionsMode =
-            normalizeCodexPermissionsMode(msg.codexPermissionsMode);
+          const normalizedCodexPermissionsMode = normalizeCodexPermissionsMode(
+            msg.codexPermissionsMode,
+          );
           const requestedCodexPermissionsMode =
             this.codexAutoReviewDisabled &&
             normalizedCodexPermissionsMode === "autoReview"
@@ -3159,9 +3590,15 @@ export class BridgeWebSocketServer {
             : undefined;
           const process = session.process as CodexProcess;
           const currentApproval = normalizeCodexApprovalPolicy(
-            process.approvalPolicy,
+            session.dormant
+              ? (session.codexSettings?.approvalPolicy ??
+                  session.codexStartOptions?.approvalPolicy)
+              : process.approvalPolicy,
           );
-          const currentReviewer = process.approvalsReviewer;
+          const currentReviewer = session.dormant
+            ? (session.codexSettings?.approvalsReviewer ??
+              session.codexStartOptions?.approvalsReviewer)
+            : process.approvalsReviewer;
           const currentSandboxMode = session.codexSettings?.sandboxMode;
           const currentPermissionsMode = normalizeCodexPermissionsMode(
             session.codexSettings?.codexPermissionsMode,
@@ -3227,7 +3664,9 @@ export class BridgeWebSocketServer {
           const newCollaboration: "plan" | "default" = planMode
             ? "plan"
             : "default";
-          const currentCollaboration = process.collaborationMode;
+          const currentCollaboration =
+            session.codexStartOptions?.collaborationMode ??
+            process.collaborationMode;
           if (
             newApproval === currentApproval &&
             newReviewer === currentReviewer &&
@@ -3262,6 +3701,17 @@ export class BridgeWebSocketServer {
               codexPermissionsMode: newPermissionsMode,
               sandboxMode: newSandboxMode,
             };
+            if (session.codexStartOptions) {
+              session.codexStartOptions = {
+                ...session.codexStartOptions,
+                approvalPolicy: newApproval,
+                approvalsReviewer:
+                  newReviewer as CodexStartOptions["approvalsReviewer"],
+                codexPermissionsMode: newPermissionsMode,
+                sandboxMode: newSandboxMode as CodexStartOptions["sandboxMode"],
+                collaborationMode: newCollaboration,
+              };
+            }
             session.lastActivityAt = new Date();
             this.broadcast({
               type: "system",
@@ -3297,19 +3747,22 @@ export class BridgeWebSocketServer {
           const worktreePath = session.worktreePath;
           const worktreeBranch = session.worktreeBranch;
           const sessionName = session.name;
-
-          this.destroySession(oldSessionId);
-          console.log(
-            `[ws] Permission mode change: destroyed session ${oldSessionId}`,
-          );
-
           const hasUserMessages =
             session.history?.some(
               (m: Record<string, unknown>) =>
                 m.type === "user_input" || m.type === "assistant",
             ) ||
             (session.pastMessages && session.pastMessages.length > 0);
-          if (!threadId || !hasUserMessages) {
+          const shouldResumeThread =
+            Boolean(threadId) && (hasUserMessages || session.dormant === true);
+          const replacementToken = shouldResumeThread
+            ? Symbol(oldSessionId)
+            : undefined;
+          if (replacementToken) {
+            this.sessionReplacementTokens.set(oldSessionId, replacementToken);
+          }
+
+          if (!threadId || !shouldResumeThread) {
             const newId = this.sessionManager.create(
               projectPath,
               undefined,
@@ -3321,9 +3774,7 @@ export class BridgeWebSocketServer {
               this.withCodexAutoReviewPolicy({
                 approvalPolicy: newApproval,
                 approvalsReviewer: newReviewer as
-                  | "user"
-                  | "auto_review"
-                  | "guardian_subagent",
+                  "user" | "auto_review" | "guardian_subagent",
                 codexPermissionsMode: newPermissionsMode,
                 sandboxMode: newSandboxMode as
                   | "read-only"
@@ -3335,16 +3786,13 @@ export class BridgeWebSocketServer {
                   oldSettings.modelReasoningEffort as CodexStartOptions["modelReasoningEffort"],
                 serviceTier: oldSettings.serviceTier,
                 networkAccessEnabled: oldSettings.networkAccessEnabled as
-                  | boolean
-                  | undefined,
+                  boolean | undefined,
                 webSearchMode: oldSettings.webSearchMode as
-                  | "disabled"
-                  | "cached"
-                  | "live"
-                  | undefined,
+                  "disabled" | "cached" | "live" | undefined,
                 collaborationMode: newCollaboration,
               }),
             );
+            this.destroySession(oldSessionId);
             const newSession = this.sessionManager.get(newId);
             if (newSession && sessionName) newSession.name = sessionName;
             this.broadcast(
@@ -3402,6 +3850,13 @@ export class BridgeWebSocketServer {
 
           this.getCodexThreadHistory(threadId, effectiveProjectPath)
             .then((pastMessages) => {
+              if (
+                this.sessionReplacementTokens.get(oldSessionId) !==
+                  replacementToken ||
+                this.sessionManager.get(oldSessionId) !== session
+              ) {
+                return;
+              }
               const newId = this.sessionManager.create(
                 effectiveProjectPath,
                 undefined,
@@ -3412,9 +3867,7 @@ export class BridgeWebSocketServer {
                   threadId,
                   approvalPolicy: newApproval,
                   approvalsReviewer: newReviewer as
-                    | "user"
-                    | "auto_review"
-                    | "guardian_subagent",
+                    "user" | "auto_review" | "guardian_subagent",
                   codexPermissionsMode: newPermissionsMode,
                   sandboxMode: newSandboxMode as
                     | "read-only"
@@ -3426,16 +3879,13 @@ export class BridgeWebSocketServer {
                     oldSettings.modelReasoningEffort as CodexStartOptions["modelReasoningEffort"],
                   serviceTier: oldSettings.serviceTier,
                   networkAccessEnabled: oldSettings.networkAccessEnabled as
-                    | boolean
-                    | undefined,
+                    boolean | undefined,
                   webSearchMode: oldSettings.webSearchMode as
-                    | "disabled"
-                    | "cached"
-                    | "live"
-                    | undefined,
+                    "disabled" | "cached" | "live" | undefined,
                   collaborationMode: newCollaboration,
                 }),
               );
+              this.destroySession(oldSessionId);
 
               const newSession = this.sessionManager.get(newId);
               if (newSession && sessionName) {
@@ -3478,8 +3928,16 @@ export class BridgeWebSocketServer {
               console.log(
                 `[ws] Permission mode change: created new session ${newId} (thread=${threadId}, mode=${msg.mode})`,
               );
+              this.sessionReplacementTokens.delete(oldSessionId);
             })
             .catch((err) => {
+              if (
+                this.sessionReplacementTokens.get(oldSessionId) !==
+                replacementToken
+              ) {
+                return;
+              }
+              this.sessionReplacementTokens.delete(oldSessionId);
               this.send(ws, {
                 type: "error",
                 message: `Failed to restart session for permission mode change: ${err}`,
@@ -3487,13 +3945,13 @@ export class BridgeWebSocketServer {
             });
           break;
         }
-        (session.process as SdkProcess)
+        void (session.process as SdkProcess)
           .setPermissionMode(msg.mode)
+          .then(() => {
+            this.broadcastSessionList();
+          })
           .catch((err) => {
-            if (
-              msg.mode === "auto" &&
-              isClaudeAutoModeUnavailableError(err)
-            ) {
+            if (msg.mode === "auto" && isClaudeAutoModeUnavailableError(err)) {
               this.send(ws, {
                 type: "error",
                 message:
@@ -3605,9 +4063,7 @@ export class BridgeWebSocketServer {
           serviceTier,
         });
         this.broadcastSessionList();
-        console.log(
-          `[ws] set_codex_speed(codex): serviceTier=${serviceTier}`,
-        );
+        console.log(`[ws] set_codex_speed(codex): serviceTier=${serviceTier}`);
         break;
       }
 
@@ -3622,7 +4078,10 @@ export class BridgeWebSocketServer {
           break;
         }
         try {
-          const goal = await (session.process as CodexProcess).getGoal();
+          const goal = await this.withCodexSessionRpc(
+            session,
+            (process, threadId) => process.getGoalByThreadId(threadId),
+          );
           session.codexGoal = goal;
           this.send(ws, { type: "goal_state", sessionId: session.id, goal });
         } catch (err) {
@@ -3640,18 +4099,23 @@ export class BridgeWebSocketServer {
         if (!session || session.provider !== "codex") {
           this.send(ws, {
             type: "error",
-            message: "Goal updates are only supported for active Codex sessions.",
+            message:
+              "Goal updates are only supported for active Codex sessions.",
             errorCode: "goal_set_unsupported",
           });
           break;
         }
         try {
-          const goal = await (session.process as CodexProcess).setGoal({
+          const goal = await this.withCodexSessionRpc(
+            session,
+            (process, threadId) =>
+              process.setGoalByThreadId(threadId, {
             ...(msg.objective !== undefined
               ? { objective: msg.objective }
               : {}),
             ...(msg.status !== undefined ? { status: msg.status } : {}),
-          });
+              }),
+          );
           session.codexGoal = goal;
           this.broadcastSessionMessage(session.id, {
             type: "goal_state",
@@ -3672,13 +4136,16 @@ export class BridgeWebSocketServer {
         if (!session || session.provider !== "codex") {
           this.send(ws, {
             type: "error",
-            message: "Goal clearing is only supported for active Codex sessions.",
+            message:
+              "Goal clearing is only supported for active Codex sessions.",
             errorCode: "goal_clear_unsupported",
           });
           break;
         }
         try {
-          await (session.process as CodexProcess).clearGoal();
+          await this.withCodexSessionRpc(session, (process, threadId) =>
+            process.clearGoalByThreadId(threadId),
+          );
           session.codexGoal = null;
           this.broadcastSessionMessage(session.id, {
             type: "goal_state",
@@ -3730,8 +4197,24 @@ export class BridgeWebSocketServer {
           const worktreePath = session.worktreePath;
           const worktreeBranch = session.worktreeBranch;
           const sessionName = session.name;
-          const permissionMode = (session.process as SdkProcess).permissionMode;
-          const model = (session.process as SdkProcess).model;
+          await this.waitForRestoredClaudeHistory(oldSessionId);
+          if (this.sessionManager.get(oldSessionId) !== session) {
+            break;
+          }
+          const claudeProcess = session.process as SdkProcess;
+          const retainedStartOptions: StartOptions = {
+            ...(session.claudeSettings ?? {}),
+            ...(session.claudeStartOptions ?? {}),
+            sessionId: claudeSessionId,
+            permissionMode:
+              claudeProcess.permissionMode ??
+              session.claudeStartOptions?.permissionMode,
+            model:
+              claudeProcess.model ??
+              session.claudeStartOptions?.model ??
+              session.claudeSettings?.model,
+            sandboxEnabled: newEnabled,
+          };
 
           this.destroySession(oldSessionId);
           console.log(
@@ -3740,13 +4223,8 @@ export class BridgeWebSocketServer {
 
           const newId = this.sessionManager.create(
             projectPath,
-            {
-              sessionId: claudeSessionId,
-              permissionMode,
-              model,
-              sandboxEnabled: newEnabled,
-            },
-            undefined,
+            retainedStartOptions,
+            session.pastMessages,
             worktreePath
               ? { existingWorktreePath: worktreePath, worktreeBranch }
               : undefined,
@@ -3798,8 +4276,8 @@ export class BridgeWebSocketServer {
 
         // Sandbox mode is a thread-level setting — it can only be applied at
         // thread/start or thread/resume time, not per-turn. To apply the new
-        // mode we destroy the current session and resume the same Codex thread
-        // with the updated sandbox parameter (same pattern as clearContext).
+        // mode we load its history, then replace it with a resumed Codex thread
+        // using the updated sandbox parameter (same pattern as clearContext).
         const oldSessionId = session.id;
         const threadId = session.claudeSessionId;
         const projectPath = session.projectPath;
@@ -3807,8 +4285,9 @@ export class BridgeWebSocketServer {
         const worktreePath = session.worktreePath;
         const worktreeBranch = session.worktreeBranch;
         const sessionName = session.name;
-        const collaborationMode = (session.process as CodexProcess)
-          .collaborationMode;
+        const collaborationMode =
+          session.codexStartOptions?.collaborationMode ??
+          (session.process as CodexProcess).collaborationMode;
         const executionMode =
           oldSettings.approvalPolicy === "never" ? "fullAccess" : "default";
         const planMode = collaborationMode === "plan";
@@ -3817,23 +4296,26 @@ export class BridgeWebSocketServer {
           executionMode,
           planMode,
         );
-
-        this.destroySession(oldSessionId);
-        console.log(
-          `[ws] Sandbox mode change: destroyed session ${oldSessionId}`,
-        );
-
-        // Check if the user actually exchanged messages in this session.
-        // session.history always contains system events (init, status, etc.)
-        // even before the first user turn, so we check for user_input/assistant
-        // messages specifically.
         const hasUserMessages =
           session.history?.some(
             (m: Record<string, unknown>) =>
               m.type === "user_input" || m.type === "assistant",
           ) ||
           (session.pastMessages && session.pastMessages.length > 0);
-        if (!threadId || !hasUserMessages) {
+        const shouldResumeThread =
+          Boolean(threadId) && (hasUserMessages || session.dormant === true);
+        const replacementToken = shouldResumeThread
+          ? Symbol(oldSessionId)
+          : undefined;
+        if (replacementToken) {
+          this.sessionReplacementTokens.set(oldSessionId, replacementToken);
+        }
+
+        // Check if the user actually exchanged messages in this session.
+        // session.history always contains system events (init, status, etc.)
+        // even before the first user turn, so we check for user_input/assistant
+        // messages specifically.
+        if (!threadId || !shouldResumeThread) {
           // Session has no thread yet, or has a thread but no messages exchanged.
           // Create a fresh session with the new sandbox — no resume needed.
           // (A thread with no messages cannot be resumed — Codex returns
@@ -3848,36 +4330,24 @@ export class BridgeWebSocketServer {
             "codex",
             this.withCodexAutoReviewPolicy({
               approvalPolicy: oldSettings.approvalPolicy as
-                | "never"
-                | "on-request"
-                | undefined,
+                "never" | "on-request" | undefined,
               approvalsReviewer: oldSettings.approvalsReviewer as
-                | "user"
-                | "auto_review"
-                | "guardian_subagent"
-                | undefined,
+                "user" | "auto_review" | "guardian_subagent" | undefined,
               codexPermissionsMode: oldSettings.codexPermissionsMode as
-                | "default"
-                | "autoReview"
-                | "fullAccess"
-                | "custom"
-                | undefined,
+                "default" | "autoReview" | "fullAccess" | "custom" | undefined,
               sandboxMode: newSandboxMode,
               model: oldSettings.model,
               modelReasoningEffort:
                 oldSettings.modelReasoningEffort as CodexStartOptions["modelReasoningEffort"],
               serviceTier: oldSettings.serviceTier,
               networkAccessEnabled: oldSettings.networkAccessEnabled as
-                | boolean
-                | undefined,
+                boolean | undefined,
               webSearchMode: oldSettings.webSearchMode as
-                | "disabled"
-                | "cached"
-                | "live"
-                | undefined,
+                "disabled" | "cached" | "live" | undefined,
               collaborationMode,
             }),
           );
+          this.destroySession(oldSessionId);
           const newSession = this.sessionManager.get(newId);
           if (newSession && sessionName) newSession.name = sessionName;
           this.broadcast(
@@ -3928,6 +4398,13 @@ export class BridgeWebSocketServer {
 
         this.getCodexThreadHistory(threadId, effectiveProjectPath)
           .then((pastMessages) => {
+            if (
+              this.sessionReplacementTokens.get(oldSessionId) !==
+                replacementToken ||
+              this.sessionManager.get(oldSessionId) !== session
+            ) {
+              return;
+            }
             const newId = this.sessionManager.create(
               effectiveProjectPath,
               undefined,
@@ -3937,14 +4414,9 @@ export class BridgeWebSocketServer {
               this.withCodexAutoReviewPolicy({
                 threadId,
                 approvalPolicy: oldSettings.approvalPolicy as
-                  | "never"
-                  | "on-request"
-                  | undefined,
+                  "never" | "on-request" | undefined,
                 approvalsReviewer: oldSettings.approvalsReviewer as
-                  | "user"
-                  | "auto_review"
-                  | "guardian_subagent"
-                  | undefined,
+                  "user" | "auto_review" | "guardian_subagent" | undefined,
                 codexPermissionsMode: oldSettings.codexPermissionsMode as
                   | "default"
                   | "autoReview"
@@ -3957,16 +4429,13 @@ export class BridgeWebSocketServer {
                   oldSettings.modelReasoningEffort as CodexStartOptions["modelReasoningEffort"],
                 serviceTier: oldSettings.serviceTier,
                 networkAccessEnabled: oldSettings.networkAccessEnabled as
-                  | boolean
-                  | undefined,
+                  boolean | undefined,
                 webSearchMode: oldSettings.webSearchMode as
-                  | "disabled"
-                  | "cached"
-                  | "live"
-                  | undefined,
+                  "disabled" | "cached" | "live" | undefined,
                 collaborationMode,
               }),
             );
+            this.destroySession(oldSessionId);
 
             // Restore session name
             const newSession = this.sessionManager.get(newId);
@@ -4006,8 +4475,16 @@ export class BridgeWebSocketServer {
             console.log(
               `[ws] Sandbox mode change: created new session ${newId} (thread=${threadId}, sandbox=${newSandboxMode})`,
             );
+            this.sessionReplacementTokens.delete(oldSessionId);
           })
           .catch((err) => {
+            if (
+              this.sessionReplacementTokens.get(oldSessionId) !==
+              replacementToken
+            ) {
+              return;
+            }
+            this.sessionReplacementTokens.delete(oldSessionId);
             this.send(ws, {
               type: "error",
               message: `Failed to restart session for sandbox mode change: ${err}`,
@@ -4123,11 +4600,7 @@ export class BridgeWebSocketServer {
         }
         const handled = (session.process as SdkProcess).approveAlways(msg.id);
         if (handled === false) {
-          this.sendToolActionError(
-            ws,
-            msg,
-            "No matching pending tool action.",
-          );
+          this.sendToolActionError(ws, msg, "No matching pending tool action.");
         }
         break;
       }
@@ -4157,11 +4630,7 @@ export class BridgeWebSocketServer {
           msg.message,
         );
         if (handled === false) {
-          this.sendToolActionError(
-            ws,
-            msg,
-            "No matching pending tool action.",
-          );
+          this.sendToolActionError(ws, msg, "No matching pending tool action.");
         }
         break;
       }
@@ -4191,11 +4660,7 @@ export class BridgeWebSocketServer {
           msg.result,
         );
         if (handled === false) {
-          this.sendToolActionError(
-            ws,
-            msg,
-            "No matching pending tool action.",
-          );
+          this.sendToolActionError(ws, msg, "No matching pending tool action.");
         }
         break;
       }
@@ -4235,6 +4700,12 @@ export class BridgeWebSocketServer {
 
       case "stop_session": {
         const session = this.sessionManager.get(msg.sessionId);
+        const cancelledReplacement = this.sessionReplacementTokens.delete(
+          msg.sessionId,
+        );
+        const removedDeferred = this.removeDeferredActiveSession(
+          (record) => record.bridgeSessionId === msg.sessionId,
+        );
         if (session) {
           // Notify clients before destroying (destroy removes listeners)
           this.broadcastSessionMessage(msg.sessionId, {
@@ -4252,24 +4723,36 @@ export class BridgeWebSocketServer {
           this.notifiedPermissionToolUses.delete(msg.sessionId);
           this.broadcastSessionList();
         } else {
+          if (removedDeferred || cancelledReplacement) {
+            this.persistActiveSessions();
+          }
           this.send(ws, {
-            type: "error",
-            message: `Session ${msg.sessionId} not found`,
-          });
+            type: "result",
+            subtype: "stopped",
+            sessionId: msg.sessionId,
+          } as Record<string, unknown>);
         }
         break;
       }
 
       case "get_history": {
+        await this.waitForRestoredClaudeHistory(msg.sessionId);
         const session = this.sessionManager.get(msg.sessionId);
         if (session) {
           if (session.provider === "codex") {
-            const handled = await this.sendCodexCanonicalLegacyHistory(
+            if (!this.beginCodexHistoryResponse(ws, msg.sessionId)) break;
+            let handled: boolean;
+            try {
+              handled = await this.sendCodexCanonicalLegacyHistory(
               ws,
               msg.sessionId,
               session,
             );
+            } finally {
+              this.endCodexHistoryResponse(ws, msg.sessionId);
+            }
             if (handled) {
+              this.activateRestoredQueuedSession(ws, session);
               break;
             }
           }
@@ -4306,6 +4789,7 @@ export class BridgeWebSocketServer {
           }
 
           this.sendCachedCommands(ws, msg.sessionId, session);
+          this.activateRestoredQueuedSession(ws, session);
         } else {
           this.send(ws, {
             type: "error",
@@ -4369,6 +4853,7 @@ export class BridgeWebSocketServer {
       }
 
       case "get_history_delta": {
+        await this.waitForRestoredClaudeHistory(msg.sessionId);
         const session = this.sessionManager.get(msg.sessionId);
         if (session?.provider === "codex") {
           const result = this.sessionManager.getHistorySince(
@@ -4379,6 +4864,8 @@ export class BridgeWebSocketServer {
             this.send(ws, {
               type: "error",
               message: `Session ${msg.sessionId} not found`,
+              errorCode: "session_not_found",
+              sessionId: msg.sessionId,
             });
             break;
           }
@@ -4390,11 +4877,17 @@ export class BridgeWebSocketServer {
               result.kind,
             )
           ) {
+            if (!this.beginCodexHistoryResponse(ws, msg.sessionId)) break;
+            try {
             await this.sendCodexCanonicalHistorySnapshot(
               ws,
               msg.sessionId,
               session,
             );
+            } finally {
+              this.endCodexHistoryResponse(ws, msg.sessionId);
+            }
+            this.activateRestoredQueuedSession(ws, session);
             break;
           }
 
@@ -4411,6 +4904,7 @@ export class BridgeWebSocketServer {
           this.sendCodexCurrentSettings(ws, msg.sessionId, session);
           this.sendCodexQueueState(ws, msg.sessionId, session);
           this.sendCodexGoalState(ws, msg.sessionId, session);
+          this.activateRestoredQueuedSession(ws, session);
           break;
         }
 
@@ -4423,6 +4917,8 @@ export class BridgeWebSocketServer {
             this.send(ws, {
               type: "error",
               message: `Session ${msg.sessionId} not found`,
+              errorCode: "session_not_found",
+              sessionId: msg.sessionId,
             });
             break;
           }
@@ -4440,9 +4936,7 @@ export class BridgeWebSocketServer {
           }
           this.send(ws, {
             type:
-              result.kind === "snapshot"
-                ? "history_snapshot"
-                : "history_delta",
+              result.kind === "snapshot" ? "history_snapshot" : "history_delta",
             sessionId: msg.sessionId,
             fromSeq: result.fromSeq,
             toSeq: result.toSeq,
@@ -4454,6 +4948,8 @@ export class BridgeWebSocketServer {
           this.send(ws, {
             type: "error",
             message: `Session ${msg.sessionId} not found`,
+            errorCode: "session_not_found",
+            sessionId: msg.sessionId,
           });
         }
         break;
@@ -4647,6 +5143,15 @@ export class BridgeWebSocketServer {
             provider,
             archiveProjectPath,
           );
+          if (
+            this.removeDeferredActiveSession(
+              (record) =>
+                record.provider === provider &&
+                record.providerSessionId === sessionId,
+            )
+          ) {
+            this.persistActiveSessions();
+          }
         })()
           .then(() => {
             this.send(ws, {
@@ -4741,8 +5246,7 @@ export class BridgeWebSocketServer {
         // via get_history(sessionId) to avoid duplicate/missed replay races.
         if (provider === "codex") {
           const wtMapping = this.worktreeStore.get(sessionRefId);
-          const effectiveProjectPath =
-            resolvePlatformPath(
+          const effectiveProjectPath = resolvePlatformPath(
               wtMapping?.projectPath ?? resumeProjectPath,
               this.platform,
             );
@@ -4753,8 +5257,7 @@ export class BridgeWebSocketServer {
                 effectiveProjectPath,
               )
             : undefined;
-          const additionalWritableRoots =
-            this.normalizeAdditionalWritableRoots(
+          const additionalWritableRoots = this.normalizeAdditionalWritableRoots(
               msg.additionalWritableRoots,
               effectiveProjectPath,
             );
@@ -4880,7 +5383,9 @@ export class BridgeWebSocketServer {
               projectPath: effectiveProjectPath,
               session: createdSession,
               sandboxMode: createdSession?.codexSettings?.sandboxMode
-                ? sandboxModeToExternal(createdSession.codexSettings.sandboxMode)
+                ? sandboxModeToExternal(
+                    createdSession.codexSettings.sandboxMode,
+                  )
                 : undefined,
               approvalsReviewer:
                 createdSession?.codexSettings?.approvalsReviewer,
@@ -5329,7 +5834,9 @@ export class BridgeWebSocketServer {
             const ext = extname(absPath).toLowerCase();
             if (BridgeWebSocketServer.FILE_PEEK_IMAGE_EXTENSIONS.has(ext)) {
               const mimeType = BridgeWebSocketServer.mimeTypeForExt(ext);
-              if (resolvedFileStat.size > BridgeWebSocketServer.MAX_IMAGE_SIZE) {
+              if (
+                resolvedFileStat.size > BridgeWebSocketServer.MAX_IMAGE_SIZE
+              ) {
                 this.send(ws, {
                   type: "file_content",
                   filePath: msg.filePath,
@@ -5776,7 +6283,7 @@ export class BridgeWebSocketServer {
                         : session.codexSettings?.model,
                   });
                 })()
-              : msg.message ?? "";
+              : (msg.message ?? "");
           const result = gitCommit(msg.projectPath, message);
           this.send(ws, {
             type: "git_commit_result",
@@ -6109,8 +6616,12 @@ export class BridgeWebSocketServer {
         };
 
         if (session.provider === "codex") {
-          this.rewindCodexConversation(ws, msg.sessionId, msg.targetUuid, msg.mode)
-            .catch(handleError);
+          this.rewindCodexConversation(
+            ws,
+            msg.sessionId,
+            msg.targetUuid,
+            msg.mode,
+          ).catch(handleError);
           break;
         }
 
@@ -6225,14 +6736,16 @@ export class BridgeWebSocketServer {
       }
 
       case "fork": {
-        this.forkCodexSession(ws, msg.sessionId, msg.targetUuid).catch((err) => {
+        this.forkCodexSession(ws, msg.sessionId, msg.targetUuid).catch(
+          (err) => {
           const errMsg = err instanceof Error ? err.message : String(err);
           this.send(ws, {
             type: "error",
             message: errMsg,
             errorCode: "fork_failed",
           });
-        });
+          },
+        );
         break;
       }
 
@@ -6599,8 +7112,22 @@ export class BridgeWebSocketServer {
       networkAccessEnabled: msg.networkAccessEnabled,
       webSearchMode: msg.webSearchMode,
       additionalWritableRoots: [...(msg.additionalWritableRoots ?? [])].sort(),
-      resumeRequestId: msg.resumeRequestId,
     });
+  }
+
+  private correlateResumeMessage(
+    message: SystemServerMessage,
+    resumeRequestId?: string,
+  ): SystemServerMessage {
+    const correlated = { ...message } as SystemServerMessage & {
+      resumeRequestId?: string;
+    };
+    if (resumeRequestId) {
+      correlated.resumeRequestId = resumeRequestId;
+    } else {
+      delete correlated.resumeRequestId;
+    }
+    return correlated;
   }
 
   private clearResumeOperation(key: string, operation: ResumeOperation): void {
@@ -6683,14 +7210,20 @@ export class BridgeWebSocketServer {
 
     if (operation) {
       if (operation.completed) {
-        this.send(ws, operation.completed.message);
+        this.send(
+          ws,
+          this.correlateResumeMessage(
+            operation.completed.message,
+            request.resumeRequestId,
+          ),
+        );
         this.flushPendingClaudeResumeInputs(
           ws,
           sourceSessionId,
           operation.completed.sessionId,
         );
       } else {
-        operation.waiters.add(ws);
+        operation.waiters.set(ws, request.resumeRequestId);
       }
       return { key, operationId: operation.id, isOwner: false };
     }
@@ -6701,9 +7234,8 @@ export class BridgeWebSocketServer {
       provider,
       sourceSessionId,
       projectPath,
-      resumeRequestId: request.resumeRequestId,
       fingerprint,
-      waiters: new Set([ws]),
+      waiters: new Map([[ws, request.resumeRequestId]]),
     };
     const timeout = setTimeout(() => {
       this.failResumeOperation(
@@ -6732,8 +7264,8 @@ export class BridgeWebSocketServer {
       message,
       completedAt: Date.now(),
     };
-    for (const waiter of operation.waiters) {
-      this.send(waiter, message);
+    for (const [waiter, resumeRequestId] of operation.waiters) {
+      this.send(waiter, this.correlateResumeMessage(message, resumeRequestId));
       this.flushPendingClaudeResumeInputs(
         waiter,
         operation.sourceSessionId,
@@ -6758,12 +7290,14 @@ export class BridgeWebSocketServer {
     const operation = this.resumeOperations.get(key);
     if (!operation || operation.id !== operationId) return;
     this.clearResumeOperation(key, operation);
-    for (const waiter of operation.waiters) {
-      this.rejectPendingClaudeResumeInputs(
-        waiter,
-        operation.sourceSessionId,
-      );
-      this.sendResumeFailed(waiter, operation);
+    for (const [waiter, resumeRequestId] of operation.waiters) {
+      this.rejectPendingClaudeResumeInputs(waiter, operation.sourceSessionId);
+      this.sendResumeFailed(waiter, {
+        provider: operation.provider,
+        sourceSessionId: operation.sourceSessionId,
+        projectPath: operation.projectPath,
+        resumeRequestId,
+      });
       this.send(waiter, { type: "error", message });
     }
   }
@@ -6874,7 +7408,9 @@ export class BridgeWebSocketServer {
     // 1. Try running session first
     const runningSession = this.sessionManager.get(sessionId);
     if (runningSession) {
+      const previousName = runningSession.name;
       this.sessionManager.renameSession(sessionId, name);
+      let success = true;
 
       // Persist to provider storage
       if (
@@ -6890,17 +7426,29 @@ export class BridgeWebSocketServer {
         runningSession.provider === "codex" &&
         runningSession.process
       ) {
+        if (runningSession.dormant && runningSession.claudeSessionId) {
+          success = await renameCodexSession(
+            runningSession.claudeSessionId,
+            name,
+          );
+        } else {
         try {
           await (
             runningSession.process as import("./codex-process.js").CodexProcess
           ).renameThread(name ?? "");
         } catch (err) {
+            success = false;
           console.warn(`[websocket] Failed to rename Codex thread:`, err);
         }
       }
+      }
+
+      if (!success) {
+        this.sessionManager.renameSession(sessionId, previousName ?? null);
+      }
 
       this.broadcastSessionList();
-      this.send(ws, { type: "rename_result", sessionId, name, success: true });
+      this.send(ws, { type: "rename_result", sessionId, name, success });
       return;
     }
 
@@ -6982,6 +7530,7 @@ export class BridgeWebSocketServer {
   /** Broadcast session list to all connected clients. */
   private broadcastSessionList(): void {
     this.pruneDebugEvents();
+    this.persistActiveSessions();
     const sessions = this.sessionManager.list();
     this.broadcast({
       type: "session_list",
@@ -7021,6 +7570,9 @@ export class BridgeWebSocketServer {
     msg: ServerMessage,
     exclude?: WebSocket,
   ): void {
+    if (msg.type === "assistant" || msg.type === "conversation_queue") {
+      this.persistActiveSessions();
+    }
     if (this.shouldBatchDelta(msg, exclude)) {
       this.trackSessionMessage(sessionId, msg);
       const chunks = this.splitDeltaText(msg.text);
@@ -7148,6 +7700,8 @@ export class BridgeWebSocketServer {
 
   private destroySession(sessionId: string): void {
     this.flushSessionDeltaBatches(sessionId);
+    this.restoredClaudeHistoryIds.delete(sessionId);
+    this.restoredClaudeHistoryLoads.delete(sessionId);
     this.sessionManager.destroy(sessionId);
   }
 
@@ -7306,9 +7860,7 @@ export class BridgeWebSocketServer {
     return this.codexMetadataRequest;
   }
 
-  private async loadAndApplyCodexMetadata(
-    projectPath?: string,
-  ): Promise<void> {
+  private async loadAndApplyCodexMetadata(projectPath?: string): Promise<void> {
     const activeProcess = this.getActiveCodexProcess();
     const codexProcess =
       activeProcess ?? (await this.createStandaloneCodexProcess(projectPath));
@@ -7335,7 +7887,9 @@ export class BridgeWebSocketServer {
         this.applyCodexModels(modelResult.value);
       } else {
         if (modelResult.status === "rejected") {
-          console.warn(`[ws] Failed to load Codex models: ${modelResult.reason}`);
+          console.warn(
+            `[ws] Failed to load Codex models: ${modelResult.reason}`,
+          );
         }
         this.applyFallbackCodexModels();
       }
@@ -7411,7 +7965,8 @@ export class BridgeWebSocketServer {
     if (typeof modelSource.listAvailableModelMetadata === "function") {
       return modelSource.listAvailableModelMetadata();
     }
-    const models = typeof modelSource.listAvailableModels === "function"
+    const models =
+      typeof modelSource.listAvailableModels === "function"
       ? await modelSource.listAvailableModels()
       : [];
     return models.map((model) => ({
@@ -7917,13 +8472,15 @@ export class BridgeWebSocketServer {
   ): boolean {
     const type = typeof msg.type === "string" ? msg.type : "";
     if (!OPT_IN_SERVER_MESSAGES.has(type)) return true;
-    return (
-      this.clientSupportedServerMessages.get(ws)?.has(type) ?? false
-    );
+    return this.clientSupportedServerMessages.get(ws)?.has(type) ?? false;
   }
 
-  private hasInputConflictSince(session: SessionInfo, baseSeq: number): boolean {
-    const codexResetRevision = session.codexHistoryResetRevision ??
+  private hasInputConflictSince(
+    session: SessionInfo,
+    baseSeq: number,
+  ): boolean {
+    const codexResetRevision =
+      session.codexHistoryResetRevision ??
       session.codexCanonicalHistoryRevision;
     if (
       session.provider === "codex" &&
@@ -8023,7 +8580,9 @@ export class BridgeWebSocketServer {
       apps: cached.apps,
       ...(cached.appMetadata ? { appMetadata: cached.appMetadata } : {}),
       plugins: cached.plugins,
-      ...(cached.pluginMetadata ? { pluginMetadata: cached.pluginMetadata } : {}),
+      ...(cached.pluginMetadata
+        ? { pluginMetadata: cached.pluginMetadata }
+        : {}),
     });
   }
 

--- a/packages/bridge/src/websocket.ts
+++ b/packages/bridge/src/websocket.ts
@@ -2049,7 +2049,8 @@ export class BridgeWebSocketServer {
         items.push({ type: "text", text: item.text });
       } else if (
         item.type === "thinking" &&
-        typeof item.thinking === "string"
+        typeof item.thinking === "string" &&
+        item.thinking.trim().length > 0
       ) {
         items.push({ type: "thinking", thinking: item.thinking });
       } else if (


### PR DESCRIPTION
## Summary

- persist active Claude and Codex sessions across Bridge restarts and restore them lazily
- clear acknowledged pending starts so reconnects do not create duplicate blank sessions
- bound and deduplicate history loading so large sessions do not exhaust Bridge memory
- recover interrupted Claude subscription sessions and preserve partial useful responses
- suppress internal Claude diagnostics, empty thinking cards, restored init chips, and API-equivalent cost estimates for subscription authentication
- hide SDK-injected task notifications and avoid duplicating Claude's inline API errors
- preserve queued Codex input and session settings through process exits and mode restarts

## Verification

- Bridge type-check passed
- 105 focused Claude SDK/Bridge tests passed
- 389 focused Bridge tests passed across SDK, session, session-index, and websocket suites
- 109 focused Flutter chat/history tests passed
- the six timestamp-visibility tests pass against the exact upstream merge tree used by GitHub Actions
- combined Android release APK built successfully
- no emulator/E2E tests were run