### PR TITLE
fix(chat): keep question cards usable and current

### DIFF
--- a/apps/mobile/lib/features/claude_session/claude_session_screen.dart
+++ b/apps/mobile/lib/features/claude_session/claude_session_screen.dart
@@ -1215,6 +1215,7 @@ class _ChatScreenBody extends HookWidget {
                                 children: [
                                   if (askToolUseId != null && askInput != null)
                                     AskUserQuestionWidget(
+                                      key: ValueKey('ask_user_$askToolUseId'),
                                       toolUseId: askToolUseId,
                                       input: askInput,
                                       agentName: 'Claude',

--- a/apps/mobile/lib/features/codex_session/codex_session_screen.dart
+++ b/apps/mobile/lib/features/codex_session/codex_session_screen.dart
@@ -1317,6 +1317,7 @@ class _CodexChatBody extends HookWidget {
                                   if (askToolUseId case final askId?
                                       when askInput != null)
                                     AskUserQuestionWidget(
+                                      key: ValueKey('ask_user_$askId'),
                                       toolUseId: askId,
                                       input: askInput,
                                       agentName: 'Codex',

--- a/apps/mobile/lib/widgets/bubbles/ask_user_question_widget.dart
+++ b/apps/mobile/lib/widgets/bubbles/ask_user_question_widget.dart
@@ -64,6 +64,25 @@ class _AskUserQuestionWidgetState extends State<AskUserQuestionWidget> {
   }
 
   @override
+  void didUpdateWidget(covariant AskUserQuestionWidget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.toolUseId == widget.toolUseId) return;
+    _singleAnswers.clear();
+    _multiAnswers.clear();
+    _customInputs.clear();
+    for (final controller in _customControllers.values) {
+      controller.clear();
+    }
+    _currentPage = 0;
+    _answered = false;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted && _pageController.hasClients) {
+        _pageController.jumpToPage(0);
+      }
+    });
+  }
+
+  @override
   void dispose() {
     for (final c in _customControllers.values) {
       c.dispose();
@@ -423,7 +442,7 @@ class _AskUserQuestionWidgetState extends State<AskUserQuestionWidget> {
                     if (index == questions.length) {
                       return _AskSummaryPage(
                         questions: questions,
-                        scrollable: widget.scrollable,
+                        maxHeight: (availableHeight - keyboardHeight) * 0.42,
                         singleAnswers: _singleAnswers,
                         onResetAll: _resetAll,
                         onSubmitAll: _sendAllAnswers,
@@ -435,6 +454,7 @@ class _AskUserQuestionWidgetState extends State<AskUserQuestionWidget> {
                       questionIndex: index,
                       isMultiQuestion: true,
                       scrollable: widget.scrollable,
+                      maxHeight: (availableHeight - keyboardHeight) * 0.42,
                       allowsCustomInput: true,
                       singleAnswers: _singleAnswers,
                       multiAnswers: _multiAnswers,
@@ -511,6 +531,7 @@ class _AskQuestionLayout extends StatelessWidget {
   final int questionIndex;
   final bool isMultiQuestion;
   final bool scrollable;
+  final double? maxHeight;
   final bool alwaysShowTextInput;
   final bool allowsCustomInput;
   final Map<int, String> singleAnswers;
@@ -541,6 +562,7 @@ class _AskQuestionLayout extends StatelessWidget {
     required this.onCustomTextChanged,
     required this.onShowCustomInput,
     this.alwaysShowTextInput = false,
+    this.maxHeight,
   });
 
   @override
@@ -647,9 +669,20 @@ class _AskQuestionLayout extends StatelessWidget {
       ],
     );
 
-    if (!scrollable) return content;
+    if (!scrollable && maxHeight == null) return content;
 
-    return SingleChildScrollView(child: content);
+    final scrollView = SingleChildScrollView(
+      key: maxHeight == null
+          ? null
+          : ValueKey('ask_question_${questionIndex}_scroll_view'),
+      child: content,
+    );
+    if (maxHeight == null) return scrollView;
+
+    return ConstrainedBox(
+      constraints: BoxConstraints(maxHeight: maxHeight!),
+      child: scrollView,
+    );
   }
 }
 
@@ -875,7 +908,7 @@ class _AskTextInputRow extends StatelessWidget {
 
 class _AskSummaryPage extends StatelessWidget {
   final List<Map<String, dynamic>> questions;
-  final bool scrollable;
+  final double maxHeight;
   final Map<int, String> singleAnswers;
   final ValueChanged<int> onGoToPage;
   final VoidCallback onResetAll;
@@ -883,7 +916,7 @@ class _AskSummaryPage extends StatelessWidget {
 
   const _AskSummaryPage({
     required this.questions,
-    required this.scrollable,
+    required this.maxHeight,
     required this.singleAnswers,
     required this.onGoToPage,
     required this.onResetAll,
@@ -939,9 +972,13 @@ class _AskSummaryPage extends StatelessWidget {
       ],
     );
 
-    if (!scrollable) return content;
-
-    return SingleChildScrollView(child: content);
+    return ConstrainedBox(
+      constraints: BoxConstraints(maxHeight: maxHeight),
+      child: SingleChildScrollView(
+        key: const ValueKey('ask_summary_scroll_view'),
+        child: content,
+      ),
+    );
   }
 }
 

--- a/apps/mobile/lib/widgets/session_card.dart
+++ b/apps/mobile/lib/widgets/session_card.dart
@@ -254,6 +254,9 @@ class _RunningSessionCardState extends State<RunningSessionCard> {
                           )
                         : hasQuestionPrompt
                         ? _AskUserArea(
+                            key: ValueKey(
+                              'session_question_${permission.toolUseId}',
+                            ),
                             permission: permission,
                             statusColor: statusColor,
                             onAnswer: (result) => widget.onAnswer?.call(
@@ -281,6 +284,9 @@ class _RunningSessionCardState extends State<RunningSessionCard> {
                   : switch (permission.toolName) {
                       'AskUserQuestion' ||
                       'McpElicitation' when hasQuestionPrompt => _AskUserArea(
+                        key: ValueKey(
+                          'session_question_${permission.toolUseId}',
+                        ),
                         permission: permission,
                         statusColor: statusColor,
                         onAnswer: (result) =>
@@ -1200,6 +1206,7 @@ class _AskUserArea extends StatefulWidget {
   final VoidCallback onTap;
 
   const _AskUserArea({
+    super.key,
     required this.permission,
     required this.statusColor,
     required this.onAnswer,
@@ -1238,6 +1245,24 @@ class _AskUserAreaState extends State<_AskUserArea> {
   void initState() {
     super.initState();
     _pageController = PageController();
+  }
+
+  @override
+  void didUpdateWidget(covariant _AskUserArea oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.permission.toolUseId == widget.permission.toolUseId) return;
+    _singleAnswers.clear();
+    _multiAnswers.clear();
+    _customInputs.clear();
+    for (final controller in _customControllers.values) {
+      controller.clear();
+    }
+    _currentPage = 0;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted && _pageController.hasClients) {
+        _pageController.jumpToPage(0);
+      }
+    });
   }
 
   @override

--- a/apps/mobile/test/ask_user_question_widget_test.dart
+++ b/apps/mobile/test/ask_user_question_widget_test.dart
@@ -396,6 +396,121 @@ void main() {
       expect(answered, false);
     });
 
+    testWidgets(
+      'long summary remains scrollable when parent scrolling is disabled',
+      (tester) async {
+        var answered = false;
+        final longAnswer = List.filled(
+          12,
+          'A detailed answer that must remain reviewable before submission.',
+        ).join(' ');
+
+        await tester.pumpWidget(
+          _wrap(
+            AskUserQuestionWidget(
+              toolUseId: 'test-long-summary',
+              scrollable: false,
+              input: {
+                'questions': [
+                  for (var i = 0; i < 3; i++)
+                    {
+                      'question': 'Question ${i + 1}?',
+                      'header': 'Section ${i + 1}',
+                      'options': [
+                        {
+                          'label': 'Answer ${i + 1}',
+                          'value': '$longAnswer ${i + 1}',
+                          'description': '',
+                        },
+                      ],
+                      'multiSelect': false,
+                    },
+                ],
+              },
+              onAnswer: (_, _) => answered = true,
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        for (var i = 0; i < 3; i++) {
+          await tester.tap(
+            find.byKey(ValueKey('ask_option_${i}_Answer ${i + 1}')),
+          );
+          await tester.pumpAndSettle();
+        }
+
+        final summaryScrollView = find.byKey(
+          const ValueKey('ask_summary_scroll_view'),
+        );
+        expect(summaryScrollView, findsOneWidget);
+
+        await tester.drag(summaryScrollView, const Offset(0, -1000));
+        await tester.pumpAndSettle();
+        await tester.tap(
+          find.byKey(const ValueKey('ask_submit_summary_button')),
+        );
+        await tester.pumpAndSettle();
+
+        expect(answered, isTrue);
+      },
+    );
+
+    testWidgets(
+      'long option page remains scrollable when parent scrolling is disabled',
+      (tester) async {
+        await tester.pumpWidget(
+          _wrap(
+            AskUserQuestionWidget(
+              toolUseId: 'test-long-options',
+              scrollable: false,
+              input: {
+                'questions': [
+                  {
+                    'question': 'Choose an approach',
+                    'header': 'Approach',
+                    'options': [
+                      for (var i = 0; i < 5; i++)
+                        {
+                          'label': 'Approach ${i + 1}',
+                          'description': List.filled(
+                            3,
+                            'Detailed explanation for this approach.',
+                          ).join(' '),
+                        },
+                    ],
+                    'multiSelect': false,
+                  },
+                  {
+                    'question': 'Confirm?',
+                    'header': 'Confirm',
+                    'options': [
+                      {'label': 'Yes', 'description': ''},
+                    ],
+                    'multiSelect': false,
+                  },
+                ],
+              },
+              onAnswer: (_, _) {},
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final questionScrollView = find.byKey(
+          const ValueKey('ask_question_0_scroll_view'),
+        );
+        expect(questionScrollView, findsOneWidget);
+
+        await tester.drag(questionScrollView, const Offset(0, -800));
+        await tester.pumpAndSettle();
+        await tester.tap(find.byKey(const ValueKey('ask_option_0_Approach 5')));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Confirm?'), findsOneWidget);
+      },
+    );
+
     testWidgets('custom answer in multi-question uses Next button', (
       tester,
     ) async {
@@ -587,6 +702,50 @@ void main() {
       // After answering
       expect(find.text('Answered'), findsOneWidget);
       expect(find.text('Claude is asking'), findsNothing);
+    });
+
+    testWidgets('resets answered state when a new tool replaces it', (
+      tester,
+    ) async {
+      String? answeredId;
+      String? answeredResult;
+
+      Widget question(String toolUseId, String prompt, String option) => _wrap(
+        AskUserQuestionWidget(
+          toolUseId: toolUseId,
+          input: {
+            'questions': [
+              {
+                'question': prompt,
+                'header': 'Choice',
+                'options': [
+                  {'label': option, 'description': ''},
+                ],
+                'multiSelect': false,
+              },
+            ],
+          },
+          onAnswer: (id, result) {
+            answeredId = id;
+            answeredResult = result;
+          },
+        ),
+      );
+
+      await tester.pumpWidget(question('tool-old', 'Old question?', 'Old'));
+      await tester.tap(find.text('Old'));
+      await tester.pumpAndSettle();
+      expect(find.text('Answered'), findsOneWidget);
+
+      await tester.pumpWidget(question('tool-new', 'New question?', 'New'));
+      await tester.pump();
+
+      expect(find.text('Answered'), findsNothing);
+      expect(find.text('New question?'), findsOneWidget);
+      await tester.tap(find.text('New'));
+      await tester.pumpAndSettle();
+      expect(answeredId, 'tool-new');
+      expect(answeredResult, 'New');
     });
   });
 

--- a/apps/mobile/test/session_card_test.dart
+++ b/apps/mobile/test/session_card_test.dart
@@ -791,6 +791,75 @@ void main() {
       );
     });
 
+    testWidgets('new pending question does not inherit prior selections', (
+      tester,
+    ) async {
+      SessionInfo session(PermissionRequestMessage permission) => SessionInfo(
+        id: 'ask-replaced',
+        projectPath: '/home/user/my-app',
+        status: 'waiting_approval',
+        createdAt: '2026-08-23T00:00:00Z',
+        lastActivityAt: '2026-08-23T00:00:00Z',
+        pendingPermission: permission,
+      );
+
+      const oldPermission = PermissionRequestMessage(
+        toolUseId: 'ask-old',
+        toolName: 'AskUserQuestion',
+        input: {
+          'questions': [
+            {
+              'question': 'Old question?',
+              'header': 'Old',
+              'options': [
+                {'label': 'Old choice', 'description': ''},
+              ],
+              'multiSelect': true,
+            },
+          ],
+        },
+      );
+      const newPermission = PermissionRequestMessage(
+        toolUseId: 'ask-new',
+        toolName: 'AskUserQuestion',
+        input: {
+          'questions': [
+            {
+              'question': 'New question?',
+              'header': 'New',
+              'options': [
+                {'label': 'New choice', 'description': ''},
+              ],
+              'multiSelect': true,
+            },
+          ],
+        },
+      );
+
+      await tester.pumpWidget(
+        _wrap(
+          RunningSessionCard(session: session(oldPermission), onTap: () {}),
+        ),
+      );
+      await tester.tap(find.text('Old choice'));
+      await tester.pump();
+      expect(find.text('Confirm (1)'), findsOneWidget);
+
+      await tester.pumpWidget(
+        _wrap(
+          RunningSessionCard(session: session(newPermission), onTap: () {}),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('Old choice'), findsNothing);
+      expect(find.text('New question?'), findsOneWidget);
+      final confirm = tester.widget<FilledButton>(
+        find.widgetWithText(FilledButton, 'Confirm (0)'),
+      );
+      expect(confirm.onPressed, isNull);
+    });
+
     testWidgets('ask user custom input does not send on keyboard done', (
       tester,
     ) async {


### PR DESCRIPTION
## Summary

- keep the multiple-question submit action reachable when answers are long
- reset question-card state when a reused session card receives a different question
- prevent stale answers from leaking into replacement prompts

## Verification

- 68 focused question/session-card tests passed
- Dart analysis passed for all changed files
- consolidated Flutter suite passed: 1,567 tests with 4 skipped