### PR TITLE
fix(gallery): keep images scoped to their session

### DIFF
--- a/apps/mobile/lib/features/gallery/gallery_screen.dart
+++ b/apps/mobile/lib/features/gallery/gallery_screen.dart
@@ -1,15 +1,20 @@
+import 'dart:async';
+
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 
 import '../../l10n/app_localizations.dart';
+import '../../models/messages.dart';
 import '../../providers/bridge_cubits.dart';
 import '../../services/bridge_service.dart';
 import '../../widgets/workspace_pane_chrome.dart';
 import '../session_list/workspace_shell_screen.dart';
 import 'widgets/gallery_content.dart';
 import 'widgets/gallery_empty_state.dart';
+
+int _galleryRequestSequence = 0;
 
 @RoutePage()
 class GalleryScreen extends HookWidget {
@@ -30,6 +35,13 @@ class GalleryScreen extends HookWidget {
   Widget build(BuildContext context) {
     final selectedProject = useState<String?>(null);
     final isSessionMode = sessionId != null;
+    final scopedImages = useState<List<GalleryImage>>(const []);
+    final scopedLoading = useState(isSessionMode);
+    final requestId = useMemoized(
+      () => 'gallery-${++_galleryRequestSequence}',
+      [sessionId],
+    );
+    final bridge = context.read<BridgeService>();
     final shell = WorkspaceShellScreen.maybeOf(context);
     final chrome = resolveWorkspacePaneChrome(
       platform: Theme.of(context).platform,
@@ -41,13 +53,40 @@ class GalleryScreen extends HookWidget {
     );
 
     useEffect(() {
-      context.read<BridgeService>().requestGallery(sessionId: sessionId);
-      return null;
-    }, [sessionId]);
+      if (!isSessionMode) {
+        scopedLoading.value = false;
+        bridge.requestGallery(requestId: requestId);
+        return null;
+      }
 
-    final bridge = context.read<BridgeService>();
-    final images = context.watch<GalleryCubit>().state.isNotEmpty
-        ? context.watch<GalleryCubit>().state
+      scopedImages.value = const [];
+      scopedLoading.value = true;
+      final resultSub = bridge.galleryResults.listen((result) {
+        if (result.requestId != null && result.requestId != requestId) return;
+        if (result.sessionId != null && result.sessionId != sessionId) return;
+        if (result.project != null) return;
+        scopedImages.value = result.images;
+        scopedLoading.value = false;
+      });
+      final newImageSub = bridge.galleryNewImages.listen((image) {
+        if (image.sessionId != sessionId) return;
+        scopedImages.value = [
+          image,
+          ...scopedImages.value.where((existing) => existing.id != image.id),
+        ];
+      });
+      bridge.requestGallery(sessionId: sessionId, requestId: requestId);
+      return () {
+        unawaited(resultSub.cancel());
+        unawaited(newImageSub.cancel());
+      };
+    }, [bridge, isSessionMode, requestId, sessionId]);
+
+    final globalImages = context.watch<GalleryCubit>().state;
+    final images = isSessionMode
+        ? scopedImages.value
+        : globalImages.isNotEmpty
+        ? globalImages
         : bridge.galleryImages;
     final leading = onBack != null
         ? IconButton(
@@ -96,7 +135,12 @@ class GalleryScreen extends HookWidget {
           ]),
         ),
       ),
-      body: images.isEmpty
+      body: scopedLoading.value
+          ? const Center(
+              key: ValueKey('gallery_scope_loading'),
+              child: CircularProgressIndicator(),
+            )
+          : images.isEmpty
           ? GalleryEmptyState(isSessionMode: isSessionMode)
           : GalleryContent(
               images: images,
@@ -104,6 +148,13 @@ class GalleryScreen extends HookWidget {
               isSessionMode: isSessionMode,
               httpBaseUrl: bridge.httpBaseUrl ?? '',
               onProjectSelected: (p) => selectedProject.value = p,
+              onImageDeleted: isSessionMode
+                  ? (id) {
+                      scopedImages.value = scopedImages.value
+                          .where((image) => image.id != id)
+                          .toList();
+                    }
+                  : null,
             ),
     );
   }

--- a/apps/mobile/lib/features/gallery/widgets/gallery_content.dart
+++ b/apps/mobile/lib/features/gallery/widgets/gallery_content.dart
@@ -13,6 +13,7 @@ class GalleryContent extends StatelessWidget {
   final bool isSessionMode;
   final String httpBaseUrl;
   final ValueChanged<String?> onProjectSelected;
+  final ValueChanged<String>? onImageDeleted;
 
   const GalleryContent({
     super.key,
@@ -21,6 +22,7 @@ class GalleryContent extends StatelessWidget {
     required this.isSessionMode,
     required this.httpBaseUrl,
     required this.onProjectSelected,
+    this.onImageDeleted,
   });
 
   Map<String, int> _projectCounts() {
@@ -59,7 +61,11 @@ class GalleryContent extends StatelessWidget {
           images: filtered,
           initialIndex: index,
           httpBaseUrl: httpBaseUrl,
-          onDelete: (id) => bridge.deleteGalleryImage(id),
+          onDelete: (id) async {
+            final success = await bridge.deleteGalleryImage(id);
+            if (success) onImageDeleted?.call(id);
+            return success;
+          },
         ),
       ),
     );
@@ -75,6 +81,7 @@ class GalleryContent extends StatelessWidget {
     final bridge = context.read<BridgeService>();
     final success = await bridge.deleteGalleryImage(image.id);
     if (!context.mounted) return;
+    if (success) onImageDeleted?.call(image.id);
 
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(

--- a/apps/mobile/lib/models/messages.dart
+++ b/apps/mobile/lib/models/messages.dart
@@ -1004,6 +1004,9 @@ sealed class ServerMessage {
         images: (json['images'] as List)
             .map((i) => GalleryImage.fromJson(i as Map<String, dynamic>))
             .toList(),
+        project: json['project'] as String?,
+        sessionId: json['sessionId'] as String?,
+        requestId: json['requestId'] as String?,
       ),
       'gallery_new_image' => GalleryNewImageMessage(
         image: GalleryImage.fromJson(json['image'] as Map<String, dynamic>),
@@ -2466,7 +2469,15 @@ class PastHistoryMessage implements ServerMessage {
 
 class GalleryListMessage implements ServerMessage {
   final List<GalleryImage> images;
-  const GalleryListMessage({required this.images});
+  final String? project;
+  final String? sessionId;
+  final String? requestId;
+  const GalleryListMessage({
+    required this.images,
+    this.project,
+    this.sessionId,
+    this.requestId,
+  });
 }
 
 class GalleryNewImageMessage implements ServerMessage {
@@ -4400,12 +4411,16 @@ class ClientMessage {
     });
   }
 
-  factory ClientMessage.listGallery({String? project, String? sessionId}) =>
-      ClientMessage._(<String, dynamic>{
-        'type': 'list_gallery',
-        'project': ?project,
-        'sessionId': ?sessionId,
-      });
+  factory ClientMessage.listGallery({
+    String? project,
+    String? sessionId,
+    String? requestId,
+  }) => ClientMessage._(<String, dynamic>{
+    'type': 'list_gallery',
+    'project': ?project,
+    'sessionId': ?sessionId,
+    'requestId': ?requestId,
+  });
 
   factory ClientMessage.readFile(
     String projectPath,

--- a/apps/mobile/lib/services/bridge_service.dart
+++ b/apps/mobile/lib/services/bridge_service.dart
@@ -51,6 +51,9 @@ class BridgeService implements BridgeServiceBase {
   final _recentSessionsController =
       StreamController<List<RecentSession>>.broadcast();
   final _galleryController = StreamController<List<GalleryImage>>.broadcast();
+  final _galleryResultController =
+      StreamController<GalleryListMessage>.broadcast();
+  final _galleryNewImageController = StreamController<GalleryImage>.broadcast();
   final _fileListController = StreamController<List<String>>.broadcast();
   final _fileListMessageController =
       StreamController<FileListMessage>.broadcast();
@@ -183,6 +186,10 @@ class BridgeService implements BridgeServiceBase {
   Stream<List<RecentSession>> get recentSessionsStream =>
       _recentSessionsController.stream;
   Stream<List<GalleryImage>> get galleryStream => _galleryController.stream;
+  Stream<GalleryListMessage> get galleryResults =>
+      _galleryResultController.stream;
+  Stream<GalleryImage> get galleryNewImages =>
+      _galleryNewImageController.stream;
   Stream<List<String>> get projectHistoryStream =>
       _projectHistoryController.stream;
   Stream<bool> get codexAutoReviewPolicyStream =>
@@ -474,10 +481,18 @@ class BridgeService implements BridgeServiceBase {
               case PastHistoryMessage():
                 _taggedMessageController.add((msg, sessionId));
                 _messageController.add(msg);
-              case GalleryListMessage(:final images):
-                _galleryImages = images;
-                _galleryController.add(images);
+              case GalleryListMessage(
+                :final images,
+                :final project,
+                :final sessionId,
+              ):
+                _galleryResultController.add(msg);
+                if (project == null && sessionId == null) {
+                  _galleryImages = images;
+                  _galleryController.add(images);
+                }
               case GalleryNewImageMessage(:final image):
+                _galleryNewImageController.add(image);
                 _galleryImages = [image, ..._galleryImages];
                 _galleryController.add(_galleryImages);
               case FileContentMessage():
@@ -2202,8 +2217,14 @@ class BridgeService implements BridgeServiceBase {
     send(ClientMessage.removeWorktree(projectPath, worktreePath));
   }
 
-  void requestGallery({String? project, String? sessionId}) {
-    send(ClientMessage.listGallery(project: project, sessionId: sessionId));
+  void requestGallery({String? project, String? sessionId, String? requestId}) {
+    send(
+      ClientMessage.listGallery(
+        project: project,
+        sessionId: sessionId,
+        requestId: requestId,
+      ),
+    );
   }
 
   void requestWindowList() {
@@ -2790,6 +2811,8 @@ class BridgeService implements BridgeServiceBase {
     _sessionStoppedController.close();
     _recentSessionsController.close();
     _galleryController.close();
+    _galleryResultController.close();
+    _galleryNewImageController.close();
     _fileListController.close();
     _fileListMessageController.close();
     _projectHistoryController.close();

--- a/apps/mobile/test/gallery_screen_test.dart
+++ b/apps/mobile/test/gallery_screen_test.dart
@@ -15,12 +15,27 @@ import 'package:ccpocket/theme/app_theme.dart';
 class _MockBridgeService extends BridgeService {
   final _galleryStreamController =
       StreamController<List<GalleryImage>>.broadcast();
+  final _galleryResultController =
+      StreamController<GalleryListMessage>.broadcast();
+  final _galleryNewImageController = StreamController<GalleryImage>.broadcast();
   List<GalleryImage> _mockImages = [];
   bool galleryRequested = false;
+  bool autoRespond = true;
+  String? requestedProject;
+  String? requestedSessionId;
+  String? requestedRequestId;
 
   @override
   Stream<List<GalleryImage>> get galleryStream =>
       _galleryStreamController.stream;
+
+  @override
+  Stream<GalleryListMessage> get galleryResults =>
+      _galleryResultController.stream;
+
+  @override
+  Stream<GalleryImage> get galleryNewImages =>
+      _galleryNewImageController.stream;
 
   @override
   List<GalleryImage> get galleryImages => _mockImages;
@@ -29,15 +44,43 @@ class _MockBridgeService extends BridgeService {
   String? get httpBaseUrl => 'http://localhost:8765';
 
   @override
-  void requestGallery({String? project, String? sessionId}) {
+  void requestGallery({String? project, String? sessionId, String? requestId}) {
     galleryRequested = true;
-    // Immediately emit the mock images
-    _galleryStreamController.add(_mockImages);
+    requestedProject = project;
+    requestedSessionId = sessionId;
+    requestedRequestId = requestId;
+    if (!autoRespond) return;
+    if (sessionId == null && project == null) {
+      _galleryStreamController.add(_mockImages);
+    }
+    _galleryResultController.add(
+      GalleryListMessage(
+        images: _mockImages,
+        project: project,
+        sessionId: sessionId,
+        requestId: requestId,
+      ),
+    );
   }
 
   void setImages(List<GalleryImage> images) {
     _mockImages = images;
     _galleryStreamController.add(images);
+  }
+
+  void emitGalleryResult(GalleryListMessage result) {
+    _galleryResultController.add(result);
+  }
+
+  void emitNewImage(GalleryImage image) {
+    _galleryNewImageController.add(image);
+  }
+
+  @override
+  void dispose() {
+    _galleryStreamController.close();
+    _galleryResultController.close();
+    _galleryNewImageController.close();
   }
 }
 
@@ -169,6 +212,129 @@ void main() {
       // But should show image
       expect(find.text('project-a'), findsWidgets);
     });
+
+    testWidgets(
+      'session gallery hides cached images and ignores stale replies',
+      (tester) async {
+        final mock = _MockBridgeService()..autoRespond = false;
+        mock.setImages([
+          const GalleryImage(
+            id: 'session-a-image',
+            url: '/api/gallery/session-a-image',
+            mimeType: 'image/png',
+            projectPath: '/Users/demo/project-a',
+            projectName: 'project-a',
+            sessionId: 'session-a',
+            addedAt: '2025-01-15T10:30:00Z',
+            sizeBytes: 100,
+          ),
+        ]);
+
+        await tester.pumpWidget(
+          _wrapWithTheme(const GalleryScreen(sessionId: 'session-b'), mock),
+        );
+        await tester.pump();
+
+      expect(
+        find.byKey(const ValueKey('gallery_scope_loading')),
+        findsOneWidget,
+      );
+        expect(find.text('project-a'), findsNothing);
+        expect(mock.requestedSessionId, 'session-b');
+
+        mock.emitGalleryResult(
+          const GalleryListMessage(
+            images: [
+              GalleryImage(
+                id: 'stale',
+                url: '/api/gallery/stale',
+                mimeType: 'image/png',
+                projectPath: '/Users/demo/project-a',
+                projectName: 'project-a',
+                sessionId: 'session-a',
+                addedAt: '2025-01-15T10:30:00Z',
+                sizeBytes: 100,
+              ),
+            ],
+            sessionId: 'session-a',
+            requestId: 'older-request',
+          ),
+        );
+        await tester.pump();
+
+      expect(
+        find.byKey(const ValueKey('gallery_scope_loading')),
+        findsOneWidget,
+      );
+        expect(find.text('project-a'), findsNothing);
+
+        mock.emitGalleryResult(
+          GalleryListMessage(
+            images: const [
+              GalleryImage(
+                id: 'session-b-image',
+                url: '/api/gallery/session-b-image',
+                mimeType: 'image/png',
+                projectPath: '/Users/demo/project-b',
+                projectName: 'project-b',
+                sessionId: 'session-b',
+                addedAt: '2025-01-15T10:31:00Z',
+                sizeBytes: 200,
+              ),
+            ],
+            sessionId: 'session-b',
+            requestId: mock.requestedRequestId,
+          ),
+        );
+        await tester.pump();
+
+      expect(
+        find.byKey(const ValueKey('gallery_scope_loading')),
+        findsNothing,
+      );
+        expect(find.text('project-b'), findsWidgets);
+        expect(find.text('project-a'), findsNothing);
+      },
+    );
+
+    testWidgets('session gallery accepts new images only for its session', (
+      tester,
+    ) async {
+      final mock = _MockBridgeService();
+      await tester.pumpWidget(
+        _wrapWithTheme(const GalleryScreen(sessionId: 'session-b'), mock),
+      );
+      await tester.pump();
+
+      mock.emitNewImage(
+        const GalleryImage(
+          id: 'wrong-session',
+          url: '/api/gallery/wrong-session',
+          mimeType: 'image/png',
+          projectPath: '/Users/demo/project-a',
+          projectName: 'project-a',
+          sessionId: 'session-a',
+          addedAt: '2025-01-15T10:30:00Z',
+          sizeBytes: 100,
+        ),
+      );
+      mock.emitNewImage(
+        const GalleryImage(
+          id: 'right-session',
+          url: '/api/gallery/right-session',
+          mimeType: 'image/png',
+          projectPath: '/Users/demo/project-b',
+          projectName: 'project-b',
+          sessionId: 'session-b',
+          addedAt: '2025-01-15T10:31:00Z',
+          sizeBytes: 200,
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('project-b'), findsWidgets);
+      expect(find.text('project-a'), findsNothing);
+    });
   });
 
   group('GalleryImage model', () {
@@ -211,6 +377,8 @@ void main() {
     test('gallery_list parses correctly', () {
       final json = {
         'type': 'gallery_list',
+        'sessionId': 'session-a',
+        'requestId': 'gallery-1',
         'images': [
           {
             'id': 'img-1',
@@ -228,6 +396,8 @@ void main() {
       final gm = msg as GalleryListMessage;
       expect(gm.images.length, 1);
       expect(gm.images[0].id, 'img-1');
+      expect(gm.sessionId, 'session-a');
+      expect(gm.requestId, 'gallery-1');
     });
 
     test('gallery_new_image parses correctly', () {
@@ -257,10 +427,14 @@ void main() {
     });
 
     test('listGallery with project generates correct JSON', () {
-      final msg = ClientMessage.listGallery(project: '/path/to/proj');
+      final msg = ClientMessage.listGallery(
+        project: '/path/to/proj',
+        requestId: 'gallery-1',
+      );
       final json = msg.toJson();
       expect(json, contains('"type":"list_gallery"'));
       expect(json, contains('"project":"/path/to/proj"'));
+      expect(json, contains('"requestId":"gallery-1"'));
     });
   });
 }

--- a/apps/mobile/test/workspace_shell_screen_test.dart
+++ b/apps/mobile/test/workspace_shell_screen_test.dart
@@ -147,7 +147,7 @@ class _MockBridgeService extends BridgeService {
   }) {}
 
   @override
-  void requestGallery({String? project, String? sessionId}) {
+  void requestGallery({String? project, String? sessionId, String? requestId}) {
     _galleryController.add(_images);
   }
 

--- a/packages/bridge/src/parser.test.ts
+++ b/packages/bridge/src/parser.test.ts
@@ -633,9 +633,25 @@ describe("parseClientMessage", () => {
     ).toBeNull();
   });
 
-  it("parses list_gallery message", () => {
-    const msg = parseClientMessage('{"type":"list_gallery"}');
-    expect(msg).toEqual({ type: "list_gallery" });
+  it("parses scoped list_gallery message", () => {
+    const msg = parseClientMessage(
+      '{"type":"list_gallery","project":"/p","sessionId":"session-1","requestId":"gallery-1"}',
+    );
+    expect(msg).toEqual({
+      type: "list_gallery",
+      project: "/p",
+      sessionId: "session-1",
+      requestId: "gallery-1",
+    });
+  });
+
+  it("rejects invalid list_gallery correlation metadata", () => {
+    expect(
+      parseClientMessage('{"type":"list_gallery","requestId":""}'),
+    ).toBeNull();
+    expect(
+      parseClientMessage('{"type":"list_gallery","sessionId":42}'),
+    ).toBeNull();
   });
 
   it("parses list_files message", () => {

--- a/packages/bridge/src/parser.ts
+++ b/packages/bridge/src/parser.ts
@@ -264,7 +264,12 @@ export type ClientMessage =
       additionalWritableRoots?: string[];
       resumeRequestId?: string;
     }
-  | { type: "list_gallery"; project?: string; sessionId?: string }
+  | {
+      type: "list_gallery";
+      project?: string;
+      sessionId?: string;
+      requestId?: string;
+    }
   | {
       type: "read_file";
       projectPath: string;
@@ -629,6 +634,14 @@ export type ServerMessage =
       truncated?: boolean;
     }
   | { type: "project_history"; projects: string[] }
+  | {
+      type: "gallery_list";
+      images: GalleryImageInfo[];
+      project?: string;
+      sessionId?: string;
+      requestId?: string;
+    }
+  | { type: "gallery_new_image"; image: GalleryImageInfo }
   | {
       type: "directory_listing";
       path: string;
@@ -1425,6 +1438,17 @@ export function parseClientMessage(data: string): ClientMessage | null {
         }
         break;
       case "list_gallery":
+        if (!hasOnlyKeys(["type", "project", "sessionId", "requestId"]))
+          return null;
+        if (msg.project !== undefined && typeof msg.project !== "string")
+          return null;
+        if (msg.sessionId !== undefined && typeof msg.sessionId !== "string")
+          return null;
+        if (
+          msg.requestId !== undefined &&
+          (typeof msg.requestId !== "string" || msg.requestId.trim().length === 0)
+        )
+          return null;
         break;
       case "read_file":
         if (typeof msg.projectPath !== "string") return null;

--- a/packages/bridge/src/websocket.test.ts
+++ b/packages/bridge/src/websocket.test.ts
@@ -462,6 +462,42 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     httpServer.close();
   });
 
+  it("echoes gallery request scope and correlation metadata", async () => {
+    const list = vi.fn().mockReturnValue([]);
+    const bridge = new BridgeWebSocketServer({
+      server: httpServer,
+      galleryStore: { list } as any,
+    });
+    const ws = {
+      readyState: OPEN_STATE,
+      send: vi.fn(),
+    } as any;
+
+    await (bridge as any).handleClientMessage(
+      {
+        type: "list_gallery",
+        project: "/tmp/project-a",
+        sessionId: "session-a",
+        requestId: "gallery-1",
+      },
+      ws,
+    );
+
+    expect(list).toHaveBeenCalledWith({
+      projectPath: "/tmp/project-a",
+      sessionId: "session-a",
+    });
+    expect(JSON.parse(ws.send.mock.calls[0][0])).toEqual({
+      type: "gallery_list",
+      images: [],
+      project: "/tmp/project-a",
+      sessionId: "session-a",
+      requestId: "gallery-1",
+    });
+
+    bridge.close();
+  });
+
   it("acknowledges push registration only after relay success", async () => {
     const bridge = new BridgeWebSocketServer({ server: httpServer });
     const ws = {

--- a/packages/bridge/src/websocket.ts
+++ b/packages/bridge/src/websocket.ts
@@ -5157,15 +5157,21 @@ export class BridgeWebSocketServer {
             projectPath: msg.project,
             sessionId: msg.sessionId,
           });
-          this.send(ws, { type: "gallery_list", images } as Record<
-            string,
-            unknown
-          >);
+          this.send(ws, {
+            type: "gallery_list",
+            images,
+            project: msg.project,
+            sessionId: msg.sessionId,
+            requestId: msg.requestId,
+          });
         } else {
-          this.send(ws, { type: "gallery_list", images: [] } as Record<
-            string,
-            unknown
-          >);
+          this.send(ws, {
+            type: "gallery_list",
+            images: [],
+            project: msg.project,
+            sessionId: msg.sessionId,
+            requestId: msg.requestId,
+          });
         }
         break;
       }


### PR DESCRIPTION
## Summary

- carry project, session, and request correlation through gallery requests
- ignore stale or mismatched gallery responses in the mobile client
- prevent the home Gallery from attributing images to another session

## Verification

- focused Gallery widget tests passed
- Bridge parser and websocket tests passed
- verified in the combined Android audit build