### PR TITLE
fix(sessions): recover stalled archive requests

### DIFF
--- a/apps/mobile/lib/features/session_list/session_list_screen.dart
+++ b/apps/mobile/lib/features/session_list/session_list_screen.dart
@@ -32,6 +32,7 @@ import '../../widgets/new_session_sheet.dart';
 import '../../widgets/rename_session_dialog.dart';
 import '../settings/state/settings_cubit.dart';
 import '../settings/state/settings_state.dart';
+import 'state/archive_request_tracker.dart';
 import 'state/session_list_cubit.dart';
 import 'state/session_list_state.dart';
 import 'widgets/connect_form.dart';
@@ -229,7 +230,7 @@ class _SessionListScreenState extends State<SessionListScreen>
 
   // Only subscription that remains: session_created navigation
   StreamSubscription<ServerMessage>? _messageSub;
-  final Set<String> _archivingSessionIds = <String>{};
+  late final ArchiveRequestTracker _archiveRequests;
 
   // macOS app update
   AppUpdateInfo? _appUpdateInfo;
@@ -255,6 +256,10 @@ class _SessionListScreenState extends State<SessionListScreen>
   @override
   void initState() {
     super.initState();
+    _archiveRequests = ArchiveRequestTracker(
+      timeout: const Duration(seconds: 20),
+      onTimeout: _handleArchiveTimeout,
+    );
     WidgetsBinding.instance.addObserver(this);
     // session_created navigation (the only manual subscription)
     final bridge = context.read<BridgeService>();
@@ -312,8 +317,8 @@ class _SessionListScreenState extends State<SessionListScreen>
       }
 
       if (msg is ArchiveResultMessage) {
-        if (_archivingSessionIds.contains(msg.sessionId) && mounted) {
-          setState(() => _archivingSessionIds.remove(msg.sessionId));
+        if (_archiveRequests.complete(msg.sessionId) && mounted) {
+          setState(() {});
         }
         if (!mounted) return;
         final l = AppLocalizations.of(context);
@@ -660,6 +665,7 @@ class _SessionListScreenState extends State<SessionListScreen>
 
   @override
   void dispose() {
+    _archiveRequests.dispose();
     WidgetsBinding.instance.removeObserver(this);
     widget.deepLinkNotifier?.removeListener(_onDeepLink);
     _messageSub?.cancel();
@@ -1354,12 +1360,22 @@ class _SessionListScreenState extends State<SessionListScreen>
   }
 
   void _archiveSession(RecentSession session) {
-    if (_archivingSessionIds.contains(session.sessionId)) return;
-    setState(() => _archivingSessionIds.add(session.sessionId));
+    if (_archiveRequests.contains(session.sessionId)) return;
+    setState(() => _archiveRequests.start(session.sessionId));
     context.read<BridgeService>().archiveSession(
       sessionId: session.sessionId,
       provider: session.provider ?? 'claude',
       projectPath: session.projectPath,
+    );
+  }
+
+  void _handleArchiveTimeout(String _) {
+    if (!mounted) return;
+    setState(() {});
+    final bridge = context.read<BridgeService>();
+    bridge.requestRecentSessions(projectPath: bridge.currentProjectFilter);
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(AppLocalizations.of(context).responseTimedOut)),
     );
   }
 
@@ -1901,7 +1917,7 @@ class _SessionListScreenState extends State<SessionListScreen>
               isLoadingMore: slState.isLoadingMore,
               isInitialLoading: slState.isInitialLoading,
               hasMoreSessions: slState.hasMore,
-              archivingSessionIds: _archivingSessionIds,
+              archivingSessionIds: _archiveRequests.pendingSessionIds,
               unseenSessionIds: unseenSessionIds,
               currentProjectFilter: bridge.currentProjectFilter,
               onNewSession: _showNewSessionDialog,

--- a/apps/mobile/lib/features/session_list/state/archive_request_tracker.dart
+++ b/apps/mobile/lib/features/session_list/state/archive_request_tracker.dart
@@ -1,0 +1,34 @@
+import 'dart:async';
+
+class ArchiveRequestTracker {
+  final Duration timeout;
+  final void Function(String sessionId) onTimeout;
+  final Map<String, Timer> _timers = {};
+
+  ArchiveRequestTracker({required this.timeout, required this.onTimeout});
+
+  Set<String> get pendingSessionIds => Set.unmodifiable(_timers.keys);
+
+  bool contains(String sessionId) => _timers.containsKey(sessionId);
+
+  void start(String sessionId) {
+    _timers.remove(sessionId)?.cancel();
+    _timers[sessionId] = Timer(timeout, () {
+      if (_timers.remove(sessionId) == null) return;
+      onTimeout(sessionId);
+    });
+  }
+
+  bool complete(String sessionId) {
+    final timer = _timers.remove(sessionId);
+    timer?.cancel();
+    return timer != null;
+  }
+
+  void dispose() {
+    for (final timer in _timers.values) {
+      timer.cancel();
+    }
+    _timers.clear();
+  }
+}

--- a/apps/mobile/test/archive_request_tracker_test.dart
+++ b/apps/mobile/test/archive_request_tracker_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:ccpocket/features/session_list/state/archive_request_tracker.dart';
+
+void main() {
+  testWidgets('only unfinished archive requests time out', (tester) async {
+    final timedOut = <String>[];
+    final tracker = ArchiveRequestTracker(
+      timeout: const Duration(seconds: 1),
+      onTimeout: timedOut.add,
+    );
+    addTearDown(tracker.dispose);
+
+    tracker.start('completed');
+    tracker.start('stalled');
+    expect(tracker.pendingSessionIds, {'completed', 'stalled'});
+
+    expect(tracker.complete('completed'), isTrue);
+    await tester.pump(const Duration(milliseconds: 999));
+    expect(timedOut, isEmpty);
+
+    await tester.pump(const Duration(milliseconds: 1));
+    expect(timedOut, ['stalled']);
+    expect(tracker.pendingSessionIds, isEmpty);
+  });
+
+  testWidgets('dispose cancels pending timeouts', (tester) async {
+    final timedOut = <String>[];
+    final tracker = ArchiveRequestTracker(
+      timeout: const Duration(seconds: 1),
+      onTimeout: timedOut.add,
+    );
+
+    tracker.start('pending');
+    tracker.dispose();
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(timedOut, isEmpty);
+    expect(tracker.pendingSessionIds, isEmpty);
+  });
+}

--- a/packages/bridge/src/codex-process.test.ts
+++ b/packages/bridge/src/codex-process.test.ts
@@ -1600,6 +1600,28 @@ describe("CodexProcess (app-server)", () => {
     });
   });
 
+  it("times out a stalled thread/archive RPC", async () => {
+    vi.useFakeTimers();
+    const proc = new CodexProcess("linux");
+    const child = new FakeChildProcess();
+    attachFakeTransport(proc as any, child);
+
+    try {
+      const archiveResult = expect(
+        proc.archiveThread("thread-stalled"),
+      ).rejects.toThrow(
+        "Codex RPC thread/archive timed out after 15000ms",
+      );
+
+      await vi.advanceTimersByTimeAsync(15_000);
+      await archiveResult;
+      expect((proc as any).pendingRpc.size).toBe(0);
+    } finally {
+      proc.stop();
+      vi.useRealTimers();
+    }
+  });
+
   it("sends thread/read with includeTurns", async () => {
     const proc = new CodexProcess("linux");
     const initializePromise = proc.initializeOnly("/tmp/project-a");

--- a/packages/bridge/src/codex-process.ts
+++ b/packages/bridge/src/codex-process.ts
@@ -589,7 +589,7 @@ export class CodexProcess extends EventEmitter<CodexProcessEvents> {
    * can be archived without requiring a running process.
    */
   async archiveThread(threadId: string): Promise<void> {
-    await this.request("thread/archive", { threadId });
+    await this.request("thread/archive", { threadId }, 15_000);
   }
 
   async readThread(
@@ -3297,17 +3297,39 @@ export class CodexProcess extends EventEmitter<CodexProcessEvents> {
   private request(
     method: string,
     params?: Record<string, unknown>,
+    timeoutMs?: number,
   ): Promise<unknown> {
     const id = this.rpcSeq++;
     const envelope =
       params === undefined ? { id, method } : { id, method, params };
 
     return new Promise<unknown>((resolve, reject) => {
-      this.pendingRpc.set(id, { resolve, reject, method });
+      let timeout: NodeJS.Timeout | undefined;
+      const clearRequestTimeout = () => {
+        if (timeout) clearTimeout(timeout);
+      };
+      this.pendingRpc.set(id, {
+        resolve: (value) => {
+          clearRequestTimeout();
+          resolve(value);
+        },
+        reject: (error) => {
+          clearRequestTimeout();
+          reject(error);
+        },
+        method,
+      });
+      if (timeoutMs != null) {
+        timeout = setTimeout(() => {
+          if (!this.pendingRpc.delete(id)) return;
+          reject(new Error(`Codex RPC ${method} timed out after ${timeoutMs}ms`));
+        }, timeoutMs);
+      }
       try {
         this.writeEnvelope(envelope);
       } catch (err) {
         this.pendingRpc.delete(id);
+        clearRequestTimeout();
         reject(err instanceof Error ? err : new Error(String(err)));
       }
     });


### PR DESCRIPTION
## Summary

- track archive requests independently instead of leaving cards permanently busy
- clear timed-out or failed archive operations so users can retry
- make Codex archive failures terminate cleanly

## Verification

- focused archive tracker tests passed
- focused Codex process tests passed