### PR TITLE
fix(bridge): keep Codex retry warnings out of transcripts

### DIFF
--- a/packages/bridge/src/codex-process.test.ts
+++ b/packages/bridge/src/codex-process.test.ts
@@ -2789,6 +2789,40 @@ describe("CodexProcess (app-server)", () => {
     proc.stop();
   });
 
+  it("logs retryable runtime errors without adding transcript warnings", () => {
+    const proc = new CodexProcess("linux");
+    const messages: unknown[] = [];
+    const warningSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    proc.on("message", (message) => messages.push(message));
+
+    try {
+      (proc as any).handleNotification("error", {
+        error: { message: "Reconnecting... 1/5" },
+        willRetry: true,
+      });
+
+      expect(messages).toEqual([]);
+      expect(warningSpy).toHaveBeenCalledWith(
+        "[codex-process] Codex will retry: Reconnecting... 1/5",
+      );
+
+      (proc as any).handleNotification("error", {
+        error: { message: "Connection failed" },
+        willRetry: false,
+      });
+      expect(messages).toEqual([
+        {
+          type: "error",
+          errorCode: "codex_runtime_error",
+          message: "Connection failed",
+        },
+      ]);
+    } finally {
+      warningSpy.mockRestore();
+      proc.stop();
+    }
+  });
+
   it("installs a suggested remote plugin before accepting the elicitation", async () => {
     const proc = new CodexProcess("linux");
     const child = new FakeChildProcess();

--- a/packages/bridge/src/codex-process.ts
+++ b/packages/bridge/src/codex-process.ts
@@ -2657,10 +2657,14 @@ export class CodexProcess extends EventEmitter<CodexProcessEvents> {
       case "error": {
         const error = asRecord(params.error);
         const message = stringValue(error?.message) ?? "Codex runtime error";
+        if (params.willRetry === true) {
+          console.warn(`[codex-process] Codex will retry: ${message}`);
+          break;
+        }
         this.emitMessage({
           type: "error",
-          errorCode: params.willRetry ? "codex_warning" : "codex_runtime_error",
-          message: params.willRetry ? `${message}\nCodex will retry.` : message,
+          errorCode: "codex_runtime_error",
+          message,
         });
         break;
       }


### PR DESCRIPTION
## Summary

- log transient Codex retry/reconnect diagnostics server-side instead of adding them to chat
- keep retry attempts from cluttering live and restored transcripts
- preserve non-retryable runtime errors for the user

## Verification

- all 943 Bridge tests passed on current upstream
- Bridge TypeScript checking passed