### PR TITLE
fix(sessions): hide empty recent project groups

### DIFF
--- a/apps/mobile/lib/features/session_list/widgets/home_content.dart
+++ b/apps/mobile/lib/features/session_list/widgets/home_content.dart
@@ -542,7 +542,7 @@ class HomeContentState extends State<HomeContent> {
     final groupedRecentSessions = _groupSessionsByProject(
       projectPaths: allProjectPaths,
       sessions: filteredSessions,
-    );
+    ).where((group) => group.sessions.isNotEmpty).toList();
     final runningSessions = prioritizePinned(
       widget.sessions,
       isPinned: (session) {
@@ -802,7 +802,9 @@ class HomeContentState extends State<HomeContent> {
             )
           else ...[
             if ((!_groupRecentSessions && filteredSessions.isEmpty) ||
-                (_groupRecentSessions && groupedRecentSessions.isEmpty))
+                (_groupRecentSessions &&
+                    groupedRecentSessions.isEmpty &&
+                    !widget.hasMoreSessions))
               _RecentSessionsEmptyResult(
                 title: hasActiveFilter
                     ? l.noSessionsMatchFilters
@@ -867,8 +869,7 @@ class HomeContentState extends State<HomeContent> {
                   onToggleSessionPinned: widget.onToggleRecentSessionPinned,
                   onLongPressRecentSession: widget.onLongPressRecentSession,
                 ),
-            if (widget.currentProjectFilter != null &&
-                widget.hasMoreSessions) ...[
+            if (_groupRecentSessions && widget.hasMoreSessions) ...[
               const SizedBox(height: 8),
               _LoadMoreRecentSessionsButton(
                 isLoadingMore: widget.isLoadingMore,

--- a/apps/mobile/test/home_content_skeleton_test.dart
+++ b/apps/mobile/test/home_content_skeleton_test.dart
@@ -93,6 +93,7 @@ Widget _buildHomeContent({
   List<SessionInfo> sessions = const [],
   List<OfflinePendingAction> offlinePendingActions = const [],
   List<RecentSession> recentSessions = const [],
+  Set<String> accumulatedProjectPaths = const {},
   Set<String> exhaustedProjectPaths = const {},
   Map<String, int> projectSessionDisplayLimits = const {},
   String? currentProjectFilter,
@@ -126,7 +127,7 @@ Widget _buildHomeContent({
             sessions: sessions,
             offlinePendingActions: offlinePendingActions,
             recentSessions: recentSessions,
-            accumulatedProjectPaths: const {},
+            accumulatedProjectPaths: accumulatedProjectPaths,
             exhaustedProjectPaths: exhaustedProjectPaths,
             projectSessionDisplayLimits: projectSessionDisplayLimits,
             searchQuery: '',
@@ -278,6 +279,82 @@ void main() {
       expect(find.text('test prompt for s1'), findsOneWidget);
       expect(find.text('test prompt for s2'), findsOneWidget);
     });
+
+    testWidgets('hides a project after its recent sessions are exhausted', (
+      tester,
+    ) async {
+      const emptyProject = '/home/user/empty-project';
+      const activeProject = '/home/user/active-project';
+      await tester.pumpWidget(
+        _buildHomeContent(
+          recentSessions: [_session(id: 's1', projectPath: activeProject)],
+          accumulatedProjectPaths: const {emptyProject, activeProject},
+          exhaustedProjectPaths: const {emptyProject, activeProject},
+          isInitialLoading: false,
+          cubit: cubit,
+          draftService: draftService,
+          revenueCatService: revenueCatService,
+          supportBannerService: supportBannerService,
+        ),
+      );
+      await tester.pump();
+
+      expect(
+        find.byKey(const ValueKey('project_header_$emptyProject')),
+        findsNothing,
+      );
+      expect(
+        find.byKey(const ValueKey('project_header_$activeProject')),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('hides an unloaded project until it has a session', (
+      tester,
+    ) async {
+      const unloadedProject = '/home/user/unloaded-project';
+      await tester.pumpWidget(
+        _buildHomeContent(
+          accumulatedProjectPaths: const {unloadedProject},
+          isInitialLoading: false,
+          cubit: cubit,
+          draftService: draftService,
+          revenueCatService: revenueCatService,
+          supportBannerService: supportBannerService,
+        ),
+      );
+      await tester.pump();
+
+      expect(
+        find.byKey(const ValueKey('project_header_$unloadedProject')),
+        findsNothing,
+      );
+    });
+
+    testWidgets(
+      'keeps global pagination when empty project headers are hidden',
+      (tester) async {
+        const unloadedProject = '/home/user/unloaded-project';
+        await tester.pumpWidget(
+          _buildHomeContent(
+            accumulatedProjectPaths: const {unloadedProject},
+            hasMoreSessions: true,
+            isInitialLoading: false,
+            cubit: cubit,
+            draftService: draftService,
+            revenueCatService: revenueCatService,
+            supportBannerService: supportBannerService,
+          ),
+        );
+        await tester.pump();
+
+        expect(
+          find.byKey(const ValueKey('project_header_$unloadedProject')),
+          findsNothing,
+        );
+        expect(find.byKey(const ValueKey('load_more_button')), findsOneWidget);
+      },
+    );
 
     testWidgets('shows only five sessions per project by default', (
       tester,


### PR DESCRIPTION
## Summary

- hide Recent project headers until they contain a loaded session
- remove empty expanded groups and meaningless Show more rows
- retain global pagination so older projects can still be discovered
- leave the user's default Recent-session display mode unchanged

## Verification

- all 19 focused HomeContent widget tests passed
- Dart analysis passed for the changed files
- the unrelated default-display change from the original branch was removed