### PR TITLE
fix(chat): page long session history

### DIFF
--- a/apps/mobile/lib/features/chat_session/state/chat_session_cubit.dart
+++ b/apps/mobile/lib/features/chat_session/state/chat_session_cubit.dart
@@ -72,6 +72,10 @@ class ChatSessionCubit extends Cubit<ChatSessionState> {
   Map<String, List<String>> get codexModelServiceTiers =>
       _bridge.codexModelServiceTiers;
 
+  bool get hasOlderHistory => _bridge.hasOlderSessionHistory(sessionId);
+
+  void loadOlderHistory() => _bridge.requestOlderSessionHistory(sessionId);
+
   String _nextOptimisticCodexUserTurnUuid() {
     final userTurnCount = state.entries.whereType<UserChatEntry>().length;
     return 'codex:user-turn:${userTurnCount + 1}';
@@ -309,6 +313,12 @@ class ChatSessionCubit extends Cubit<ChatSessionState> {
     // --- Build new entries list ---
     var entries = current.entries;
     var didModifyEntries = false;
+
+    if (update.resetPrependedEntries && _pastEntryCount > 0) {
+      entries = entries.skip(_pastEntryCount).toList();
+      _pastEntryCount = 0;
+      didModifyEntries = true;
+    }
 
     // When assistant message arrives and streaming was active, reset streaming
     if (originalMsg is AssistantServerMessage &&

--- a/apps/mobile/lib/features/chat_session/widgets/chat_message_list.dart
+++ b/apps/mobile/lib/features/chat_session/widgets/chat_message_list.dart
@@ -12,6 +12,7 @@ import 'package:flutter/rendering.dart'
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:scroll_to_index/scroll_to_index.dart';
 
+import '../../../l10n/app_localizations.dart';
 import '../../../models/messages.dart';
 import '../../../providers/bridge_cubits.dart';
 import '../../../services/bridge_service.dart';
@@ -461,7 +462,8 @@ class _ChatMessageListState extends State<ChatMessageList> {
   Widget build(BuildContext context) {
     chatListPerformanceProbe.recordBuild();
     _notifyScrollMetricsAfterLayout();
-    final chatState = context.watch<ChatSessionCubit>().state;
+    final sessionCubit = context.watch<ChatSessionCubit>();
+    final chatState = sessionCubit.state;
     final hiddenToolUseIds = chatState.hiddenToolUseIds;
     final allEntries = chatState.entries;
     final activePermissionId = switch (chatState.approval) {
@@ -476,11 +478,15 @@ class _ChatMessageListState extends State<ChatMessageList> {
     final hasStreaming = context.select<StreamingStateCubit, bool>(
       (cubit) => cubit.state.isStreaming,
     );
-    final totalCount = allEntries.length + (hasStreaming ? 1 : 0);
+    final hasOlderHistory = sessionCubit.hasOlderHistory;
+    final historyLoaderCount = hasOlderHistory ? 1 : 0;
+    final totalCount =
+        allEntries.length + (hasStreaming ? 1 : 0) + historyLoaderCount;
     final entryKeys = _entryKeys(allEntries);
     final childIndexByEntryKey = <String, int>{
       for (var entryIndex = 0; entryIndex < allEntries.length; entryIndex++)
-        entryKeys[entryIndex]: totalCount - 1 - entryIndex,
+        entryKeys[entryIndex]:
+            totalCount - 1 - (entryIndex + historyLoaderCount),
     };
     final derivedData = _deriveData(
       chatState,
@@ -531,9 +537,27 @@ class _ChatMessageListState extends State<ChatMessageList> {
                 return childIndexByEntryKey[key.value];
               },
               itemBuilder: (context, index) {
-                // index 0 = newest entry (bottom of chat)
-                // Map to actual entry index:
-                final entryIndex = totalCount - 1 - index;
+                // index 0 = newest item (bottom of chat). The optional older
+                // history loader occupies the logical slot before entry 0.
+                final logicalIndex = totalCount - 1 - index;
+
+                if (hasOlderHistory && logicalIndex == 0) {
+                  return Padding(
+                    key: const ValueKey('load-older-history'),
+                    padding: const EdgeInsets.fromLTRB(16, 8, 16, 20),
+                    child: Center(
+                      child: OutlinedButton.icon(
+                        onPressed: sessionCubit.loadOlderHistory,
+                        icon: const Icon(Icons.history, size: 18),
+                        label: Text(
+                          AppLocalizations.of(context).loadEarlierMessages,
+                        ),
+                      ),
+                    ),
+                  );
+                }
+
+                final entryIndex = logicalIndex - historyLoaderCount;
 
                 // Streaming entry is at totalCount - 1 (index 0 in reverse)
                 if (hasStreaming && entryIndex == allEntries.length) {

--- a/apps/mobile/lib/l10n/app_en.arb
+++ b/apps/mobile/lib/l10n/app_en.arb
@@ -1091,5 +1091,6 @@
   "approvalQuestionNotificationTitle": "Question - ccpocket",
   "approvalRequiredNotificationTitle": "Approval Required - ccpocket",
   "exitPlanModeNotificationBody": "The generated plan needs your review",
-  "renderErrorFallback": "This content couldn't be displayed."
+  "renderErrorFallback": "This content couldn't be displayed.",
+  "loadEarlierMessages": "Load earlier messages"
 }

--- a/apps/mobile/lib/l10n/app_ja.arb
+++ b/apps/mobile/lib/l10n/app_ja.arb
@@ -1121,5 +1121,6 @@
   "approvalQuestionNotificationTitle": "質問があります - ccpocket",
   "approvalRequiredNotificationTitle": "承認待ち - ccpocket",
   "exitPlanModeNotificationBody": "作成したプランの確認が必要です",
-  "renderErrorFallback": "このコンテンツを表示できませんでした"
+  "renderErrorFallback": "このコンテンツを表示できませんでした",
+  "loadEarlierMessages": "以前のメッセージを読み込む"
 }

--- a/apps/mobile/lib/l10n/app_ko.arb
+++ b/apps/mobile/lib/l10n/app_ko.arb
@@ -1055,5 +1055,6 @@
   "approvalQuestionNotificationTitle": "질문이 있습니다 - ccpocket",
   "approvalRequiredNotificationTitle": "승인 대기 중 - ccpocket",
   "exitPlanModeNotificationBody": "작성된 계획을 확인해야 합니다",
-  "renderErrorFallback": "이 콘텐츠를 표시할 수 없습니다."
+  "renderErrorFallback": "이 콘텐츠를 표시할 수 없습니다.",
+  "loadEarlierMessages": "이전 메시지 불러오기"
 }

--- a/apps/mobile/lib/l10n/app_localizations.dart
+++ b/apps/mobile/lib/l10n/app_localizations.dart
@@ -4925,6 +4925,12 @@ abstract class AppLocalizations {
   /// In ja, this message translates to:
   /// **'このコンテンツを表示できませんでした'**
   String get renderErrorFallback;
+
+  /// No description provided for @loadEarlierMessages.
+  ///
+  /// In ja, this message translates to:
+  /// **'以前のメッセージを読み込む'**
+  String get loadEarlierMessages;
 }
 
 class _AppLocalizationsDelegate

--- a/apps/mobile/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/lib/l10n/app_localizations_en.dart
@@ -2720,4 +2720,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get renderErrorFallback => 'This content couldn\'t be displayed.';
+
+  @override
+  String get loadEarlierMessages => 'Load earlier messages';
 }

--- a/apps/mobile/lib/l10n/app_localizations_ja.dart
+++ b/apps/mobile/lib/l10n/app_localizations_ja.dart
@@ -2620,4 +2620,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get renderErrorFallback => 'このコンテンツを表示できませんでした';
+
+  @override
+  String get loadEarlierMessages => '以前のメッセージを読み込む';
 }

--- a/apps/mobile/lib/l10n/app_localizations_ko.dart
+++ b/apps/mobile/lib/l10n/app_localizations_ko.dart
@@ -2645,4 +2645,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get renderErrorFallback => '이 콘텐츠를 표시할 수 없습니다.';
+
+  @override
+  String get loadEarlierMessages => '이전 메시지 불러오기';
 }

--- a/apps/mobile/lib/l10n/app_localizations_zh.dart
+++ b/apps/mobile/lib/l10n/app_localizations_zh.dart
@@ -2590,4 +2590,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get renderErrorFallback => '无法显示此内容。';
+
+  @override
+  String get loadEarlierMessages => '加载更早的消息';
 }

--- a/apps/mobile/lib/l10n/app_zh.arb
+++ b/apps/mobile/lib/l10n/app_zh.arb
@@ -1196,5 +1196,6 @@
   "approvalQuestionNotificationTitle": "有一个问题 - ccpocket",
   "approvalRequiredNotificationTitle": "等待审批 - ccpocket",
   "exitPlanModeNotificationBody": "生成的计划需要你确认",
-  "renderErrorFallback": "无法显示此内容。"
+  "renderErrorFallback": "无法显示此内容。",
+  "loadEarlierMessages": "加载更早的消息"
 }

--- a/apps/mobile/lib/models/messages.dart
+++ b/apps/mobile/lib/models/messages.dart
@@ -886,6 +886,19 @@ sealed class ServerMessage {
             .map((m) => ServerMessage.fromJson(m as Map<String, dynamic>))
             .toList(),
       ),
+      'history_page' => HistoryPageMessage(
+        sessionId: json['sessionId'] as String? ?? '',
+        fromSeq: json['fromSeq'] as int? ?? 0,
+        toSeq: json['toSeq'] as int? ?? 0,
+        entries: (json['messages'] as List)
+            .map((m) => HistoryEntry.fromJson(m as Map<String, dynamic>))
+            .toList(),
+        hasOlder: json['hasOlder'] as bool? ?? false,
+        initial: json['initial'] as bool? ?? false,
+        status: json['status'] != null
+            ? ProcessStatus.fromString(json['status'] as String)
+            : null,
+      ),
       'history_delta' => HistoryDeltaMessage(
         sessionId: json['sessionId'] as String?,
         fromSeq: json['fromSeq'] as int? ?? 0,
@@ -1715,7 +1728,42 @@ class StatusMessage implements ServerMessage {
 
 class HistoryMessage implements ServerMessage {
   final List<ServerMessage> messages;
-  const HistoryMessage({required this.messages});
+
+  /// Internal marker for a newly restored bounded window. Older pages that
+  /// were prepended to the previous window must not survive this replacement.
+  final bool resetPrependedEntries;
+
+  const HistoryMessage({
+    required this.messages,
+    this.resetPrependedEntries = false,
+  });
+}
+
+/// A bounded slice of canonical history returned by a paging-capable Bridge.
+class HistoryPageMessage implements ServerMessage {
+  final String sessionId;
+  final int fromSeq;
+  final int toSeq;
+  final List<HistoryEntry> entries;
+  final bool hasOlder;
+  final bool initial;
+  final ProcessStatus? status;
+
+  const HistoryPageMessage({
+    required this.sessionId,
+    required this.fromSeq,
+    required this.toSeq,
+    required this.entries,
+    required this.hasOlder,
+    required this.initial,
+    this.status,
+  });
+}
+
+/// Internal app event used to prepend an older bounded history page.
+class HistoryPrependMessage implements ServerMessage {
+  final List<ServerMessage> messages;
+  const HistoryPrependMessage({required this.messages});
 }
 
 class HistoryEntry {
@@ -3965,6 +4013,7 @@ class ClientMessage {
       'goal_state',
       'guardian_approval',
       'history_delta',
+      'history_page',
       'history_snapshot',
       'git_status_result',
       'prompt_history_status',
@@ -4261,8 +4310,16 @@ class ClientMessage {
     });
   }
 
-  factory ClientMessage.getHistory(String sessionId) =>
-      ClientMessage._({'type': 'get_history', 'sessionId': sessionId});
+  factory ClientMessage.getHistory(
+    String sessionId, {
+    int? limit,
+    int? beforeSeq,
+  }) => ClientMessage._(<String, dynamic>{
+    'type': 'get_history',
+    'sessionId': sessionId,
+    'limit': ?limit,
+    'beforeSeq': ?beforeSeq,
+  });
 
   factory ClientMessage.getHistoryDelta(
     String sessionId, {

--- a/apps/mobile/lib/services/bridge_service.dart
+++ b/apps/mobile/lib/services/bridge_service.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:isolate';
 import 'dart:math';
 
 import 'package:flutter/services.dart';
@@ -16,6 +17,53 @@ import 'bridge_service_base.dart';
 import 'session_runtime_store.dart';
 
 enum SessionLinkResolveSupport { resolved, unsupported, unavailable }
+
+const _largeBridgeFrameDecodeThreshold = 256 * 1024;
+
+class _DecodedBridgeFrame {
+  const _DecodedBridgeFrame.success(this.json, this.message)
+    : error = null,
+      stackTrace = null;
+
+  const _DecodedBridgeFrame.failure(this.error, this.stackTrace)
+    : json = null,
+      message = null;
+
+  final Map<String, dynamic>? json;
+  final ServerMessage? message;
+  final Object? error;
+  final StackTrace? stackTrace;
+}
+
+_DecodedBridgeFrame _parseBridgeFrame(String data) {
+  final json = jsonDecode(data) as Map<String, dynamic>;
+  return _DecodedBridgeFrame.success(json, ServerMessage.fromJson(json));
+}
+
+Future<_DecodedBridgeFrame> _parseLargeBridgeFrame(String data) async {
+  try {
+    return await Isolate.run(() => _parseBridgeFrame(data));
+  } catch (error, stackTrace) {
+    return _DecodedBridgeFrame.failure(error, stackTrace);
+  }
+}
+
+FutureOr<_DecodedBridgeFrame> _decodeBridgeFrame(Object? data) {
+  if (data is! String) {
+    return _DecodedBridgeFrame.failure(
+      FormatException('Expected a text WebSocket frame'),
+      StackTrace.current,
+    );
+  }
+  if (data.length >= _largeBridgeFrameDecodeThreshold) {
+    return _parseLargeBridgeFrame(data);
+  }
+  try {
+    return _parseBridgeFrame(data);
+  } catch (error, stackTrace) {
+    return _DecodedBridgeFrame.failure(error, stackTrace);
+  }
+}
 
 class SessionLinkResolveResult {
   final SessionLinkResolveSupport support;
@@ -137,6 +185,8 @@ class BridgeService implements BridgeServiceBase {
   UsageResultMessage? _lastUsageResult;
   final SessionRuntimeStore _runtimeStore = SessionRuntimeStore();
   final Map<String, int> _pendingHistoryDeltaSinceSeq = {};
+  final Map<String, List<ServerMessage>> _legacyOlderHistory = {};
+  final Map<String, _RemoteHistoryCursor> _remoteHistoryCursors = {};
   final Map<String, ClientMessage> _inFlightPendingMessages = {};
   final Map<String, ClientMessage> _inFlightInputMessages = {};
   final Map<String, Timer> _inFlightPendingVisibilityTimers = {};
@@ -391,13 +441,26 @@ class BridgeService implements BridgeServiceBase {
     try {
       final channel = WebSocketChannel.connect(Uri.parse(url));
       _channel = channel;
-      _channelSub = channel.stream.listen(
-        (data) {
+      final decodedStream = channel.stream.asyncMap(_decodeBridgeFrame);
+      _channelSub = decodedStream.listen(
+        (frame) {
           if (epoch != _connectionEpoch) return;
+          if (frame.error != null) {
+            logger.error('WS parse error', frame.error, frame.stackTrace);
+            final errorMsg = ErrorMessage(
+              message: 'Parse error: ${frame.error}',
+            );
+            _taggedMessageController.add((errorMsg, null));
+            _messageController.add(errorMsg);
+            return;
+          }
           try {
-            final json = jsonDecode(data as String) as Map<String, dynamic>;
+            final json = frame.json!;
             final sessionId = json['sessionId'] as String?;
-            final msg = ServerMessage.fromJson(json);
+            final msg = frame.message!;
+            if (sessionId != null && msg is ErrorMessage) {
+              _remoteHistoryCursors[sessionId]?.loading = false;
+            }
             _clearDeliveredNonReplayableToolAction(msg, sessionId: sessionId);
             if (sessionId != null && msg is HistoryDeltaMessage) {
               _handleHistoryDelta(sessionId, msg);
@@ -405,6 +468,14 @@ class BridgeService implements BridgeServiceBase {
             }
             if (sessionId != null && msg is HistorySnapshotMessage) {
               _handleHistorySnapshot(sessionId, msg);
+              return;
+            }
+            if (sessionId != null && msg is HistoryPageMessage) {
+              _handleHistoryPage(sessionId, msg);
+              return;
+            }
+            if (sessionId != null && msg is HistoryMessage) {
+              _handleLegacyHistory(sessionId, msg);
               return;
             }
             if (sessionId != null) {
@@ -755,6 +826,8 @@ class BridgeService implements BridgeServiceBase {
     _promptHistoryBridgeId = null;
     _lastUsageResult = null;
     _pendingHistoryDeltaSinceSeq.clear();
+    _legacyOlderHistory.clear();
+    _remoteHistoryCursors.clear();
     _inFlightNonReplayableToolActions.clear();
     _respondedToolUseIds.clear();
     _deliveryPendingInputs.clear();
@@ -812,6 +885,30 @@ class BridgeService implements BridgeServiceBase {
     return null;
   }
 
+  static const _restoredHistoryPageSize = 200;
+
+  void _emitSessionMessage(String sessionId, ServerMessage message) {
+    _taggedMessageController.add((message, sessionId));
+    _messageController.add(message);
+  }
+
+  void _handleLegacyHistory(String sessionId, HistoryMessage msg) {
+    _remoteHistoryCursors.remove(sessionId);
+    final split = max(0, msg.messages.length - _restoredHistoryPageSize);
+    final visible = msg.messages.sublist(split);
+    if (split > 0) {
+      _legacyOlderHistory[sessionId] = msg.messages.sublist(0, split);
+    } else {
+      _legacyOlderHistory.remove(sessionId);
+    }
+    final bounded = HistoryMessage(
+      messages: visible,
+      resetPrependedEntries: true,
+    );
+    _runtimeStore.applyServerMessage(sessionId, bounded);
+    _emitSessionMessage(sessionId, bounded);
+  }
+
   void _handleHistoryDelta(String sessionId, HistoryDeltaMessage msg) {
     final previousSnapshot = _runtimeStore.snapshot(sessionId);
     final hadCachedTimeline = previousSnapshot.messages.isNotEmpty;
@@ -851,21 +948,75 @@ class BridgeService implements BridgeServiceBase {
 
   void _handleHistorySnapshot(String sessionId, HistorySnapshotMessage msg) {
     _pendingHistoryDeltaSinceSeq.remove(sessionId);
-    _runtimeStore.applyServerMessage(sessionId, msg);
+    _remoteHistoryCursors.remove(sessionId);
+    final split = max(0, msg.entries.length - _restoredHistoryPageSize);
+    final visibleEntries = msg.entries.sublist(split);
+    if (split > 0) {
+      _legacyOlderHistory[sessionId] = msg.entries
+          .sublist(0, split)
+          .map((entry) => entry.message)
+          .toList();
+    } else {
+      _legacyOlderHistory.remove(sessionId);
+    }
+    final bounded = HistorySnapshotMessage(
+      sessionId: msg.sessionId,
+      fromSeq: visibleEntries.firstOrNull?.seq ?? msg.fromSeq,
+      toSeq: msg.toSeq,
+      entries: visibleEntries,
+      status: msg.status,
+      reason: msg.reason,
+    );
+    _runtimeStore.applyServerMessage(sessionId, bounded);
 
     final history = HistoryMessage(
-      messages: msg.entries.map((entry) => entry.message).toList(),
+      messages: visibleEntries.map((entry) => entry.message).toList(),
+      resetPrependedEntries: true,
     );
-    _taggedMessageController.add((history, sessionId));
-    _messageController.add(history);
+    _emitSessionMessage(sessionId, history);
 
     final status = msg.status;
     if (status != null) {
       _patchSessionStatus(sessionId, status);
       final statusMessage = StatusMessage(status: status);
       _runtimeStore.applyServerMessage(sessionId, statusMessage);
-      _taggedMessageController.add((statusMessage, sessionId));
-      _messageController.add(statusMessage);
+      _emitSessionMessage(sessionId, statusMessage);
+    }
+  }
+
+  void _handleHistoryPage(String sessionId, HistoryPageMessage msg) {
+    final messages = msg.entries.map((entry) => entry.message).toList();
+    _legacyOlderHistory.remove(sessionId);
+    _remoteHistoryCursors[sessionId] = _RemoteHistoryCursor(
+      beforeSeq: msg.fromSeq,
+      hasOlder: msg.hasOlder,
+    );
+
+    if (msg.initial) {
+      _pendingHistoryDeltaSinceSeq.remove(sessionId);
+      final snapshot = HistorySnapshotMessage(
+        sessionId: sessionId,
+        fromSeq: msg.fromSeq,
+        toSeq: msg.toSeq,
+        entries: msg.entries,
+        status: msg.status,
+        reason: 'reset',
+      );
+      _runtimeStore.applyServerMessage(sessionId, snapshot);
+      _emitSessionMessage(
+        sessionId,
+        HistoryMessage(messages: messages, resetPrependedEntries: true),
+      );
+    } else {
+      _emitSessionMessage(sessionId, HistoryPrependMessage(messages: messages));
+    }
+
+    final status = msg.status;
+    if (status != null) {
+      _patchSessionStatus(sessionId, status);
+      final statusMessage = StatusMessage(status: status);
+      _runtimeStore.applyServerMessage(sessionId, statusMessage);
+      _emitSessionMessage(sessionId, statusMessage);
     }
   }
 
@@ -874,7 +1025,9 @@ class BridgeService implements BridgeServiceBase {
     final sessionIds = List<String>.from(_pendingHistoryDeltaSinceSeq.keys);
     _pendingHistoryDeltaSinceSeq.clear();
     for (final sessionId in sessionIds) {
-      send(ClientMessage.getHistory(sessionId));
+      send(
+        ClientMessage.getHistory(sessionId, limit: _restoredHistoryPageSize),
+      );
     }
   }
 
@@ -1922,7 +2075,40 @@ class BridgeService implements BridgeServiceBase {
       );
       return;
     }
-    send(ClientMessage.getHistory(sessionId));
+    _legacyOlderHistory.remove(sessionId);
+    _remoteHistoryCursors.remove(sessionId);
+    send(ClientMessage.getHistory(sessionId, limit: _restoredHistoryPageSize));
+  }
+
+  bool hasOlderSessionHistory(String sessionId) {
+    if (_legacyOlderHistory[sessionId]?.isNotEmpty ?? false) return true;
+    return _remoteHistoryCursors[sessionId]?.hasOlder ?? false;
+  }
+
+  void requestOlderSessionHistory(String sessionId) {
+    final legacy = _legacyOlderHistory[sessionId];
+    if (legacy != null && legacy.isNotEmpty) {
+      final start = max(0, legacy.length - _restoredHistoryPageSize);
+      final page = legacy.sublist(start);
+      if (start == 0) {
+        _legacyOlderHistory.remove(sessionId);
+      } else {
+        _legacyOlderHistory[sessionId] = legacy.sublist(0, start);
+      }
+      _emitSessionMessage(sessionId, HistoryPrependMessage(messages: page));
+      return;
+    }
+
+    final cursor = _remoteHistoryCursors[sessionId];
+    if (cursor == null || !cursor.hasOlder || cursor.loading) return;
+    cursor.loading = true;
+    send(
+      ClientMessage.getHistory(
+        sessionId,
+        limit: _restoredHistoryPageSize,
+        beforeSeq: cursor.beforeSeq,
+      ),
+    );
   }
 
   void refreshBranch(String sessionId) {
@@ -2118,6 +2304,8 @@ class BridgeService implements BridgeServiceBase {
   void clearExplorerHistory(String sessionId) {
     _runtimeStore.clearSession(sessionId);
     _respondedToolUseIds.remove(sessionId);
+    _legacyOlderHistory.remove(sessionId);
+    _remoteHistoryCursors.remove(sessionId);
   }
 
   /// Rename a session. For running sessions, [sessionId] is the bridge id.
@@ -2832,6 +3020,14 @@ class _DeliveryPendingInputState {
 
   final QueuedInputItem item;
   bool visible = false;
+}
+
+class _RemoteHistoryCursor {
+  _RemoteHistoryCursor({required this.beforeSeq, required this.hasOlder});
+
+  final int beforeSeq;
+  final bool hasOlder;
+  bool loading = false;
 }
 
 /// Cached diff image data for a single file.

--- a/apps/mobile/lib/services/chat_message_handler.dart
+++ b/apps/mobile/lib/services/chat_message_handler.dart
@@ -39,6 +39,7 @@ class ChatStateUpdate {
   final bool? planMode;
   final List<ChatEntry> entriesToAdd;
   final List<ChatEntry> entriesToPrepend;
+  final bool resetPrependedEntries;
   final String? pendingToolUseId;
   final PermissionRequestMessage? pendingPermission;
   final String? askToolUseId;
@@ -98,6 +99,7 @@ class ChatStateUpdate {
     this.planMode,
     this.entriesToAdd = const [],
     this.entriesToPrepend = const [],
+    this.resetPrependedEntries = false,
     this.pendingToolUseId,
     this.pendingPermission,
     this.askToolUseId,
@@ -198,8 +200,20 @@ class ChatMessageHandler {
         );
       case PastHistoryMessage(:final claudeSessionId, :final messages):
         return _handlePastHistory(messages, claudeSessionId: claudeSessionId);
-      case HistoryMessage(:final messages):
-        return _handleHistory(messages, ignoredToolUseIds: ignoredToolUseIds);
+      case HistoryMessage(:final messages, :final resetPrependedEntries):
+        return _handleHistory(
+          messages,
+          ignoredToolUseIds: ignoredToolUseIds,
+          resetPrependedEntries: resetPrependedEntries,
+        );
+      case HistoryPrependMessage(:final messages):
+        final history = _handleHistory(
+          messages,
+          ignoredToolUseIds: ignoredToolUseIds,
+        );
+        return ChatStateUpdate(entriesToPrepend: history.entriesToAdd);
+      case HistoryPageMessage():
+        return const ChatStateUpdate();
       case ConversationQueueMessage(:final items):
         return ChatStateUpdate(
           queuedInput: items.isNotEmpty ? items.first : null,
@@ -568,6 +582,7 @@ class ChatMessageHandler {
   ChatStateUpdate _handleHistory(
     List<ServerMessage> messages, {
     Set<String> ignoredToolUseIds = const {},
+    bool resetPrependedEntries = false,
   }) {
     final entries = <ChatEntry>[];
     ProcessStatus? lastStatus;
@@ -745,6 +760,7 @@ class ChatMessageHandler {
       status: lastStatus,
       entriesToAdd: entries,
       replaceEntries: true,
+      resetPrependedEntries: resetPrependedEntries,
       slashCommands: commands,
       pendingToolUseId: isWaiting ? lastPermission?.toolUseId : null,
       pendingPermission: isWaiting ? lastPermission : null,

--- a/apps/mobile/lib/widgets/message_bubble.dart
+++ b/apps/mobile/lib/widgets/message_bubble.dart
@@ -218,6 +218,8 @@ class ServerMessageWidget extends StatelessWidget {
       SessionLinkResolutionMessage() => const SizedBox.shrink(),
       final StatusMessage msg => StatusChip(message: msg),
       HistoryMessage() => const SizedBox.shrink(),
+      HistoryPageMessage() => const SizedBox.shrink(),
+      HistoryPrependMessage() => const SizedBox.shrink(),
       HistoryDeltaMessage() => const SizedBox.shrink(),
       HistorySnapshotMessage() => const SizedBox.shrink(),
       final PermissionRequestMessage msg =>

--- a/apps/mobile/test/chat_message_handler_test.dart
+++ b/apps/mobile/test/chat_message_handler_test.dart
@@ -482,6 +482,30 @@ void main() {
     });
   });
 
+  test('older history pages prepend visible entries', () {
+    final update = handler.handle(
+      const HistoryPrependMessage(
+        messages: [
+          UserInputMessage(text: 'older user message'),
+          AssistantServerMessage(
+            message: AssistantMessage(
+              id: 'older-assistant',
+              role: 'assistant',
+              content: [TextContent(text: 'older assistant message')],
+              model: 'synthetic',
+            ),
+          ),
+        ],
+      ),
+      isBackground: false,
+    );
+
+    expect(update.entriesToAdd, isEmpty);
+    expect(update.entriesToPrepend, hasLength(2));
+    expect(update.entriesToPrepend.first, isA<UserChatEntry>());
+    expect(update.entriesToPrepend.last, isA<ServerChatEntry>());
+  });
+
   group('ResultMessage handling', () {
     test('stopped resets all state', () {
       final update = handler.handle(

--- a/apps/mobile/test/chat_message_list_scroll_anchor_test.dart
+++ b/apps/mobile/test/chat_message_list_scroll_anchor_test.dart
@@ -233,10 +233,62 @@ void main() {
     expect(tester.takeException(), isNull);
     await gesture.up();
   });
+
+  testWidgets('offers older history without building it into the first page', (
+    tester,
+  ) async {
+    final bridge = _ScrollTestBridge()..hasOlder = true;
+    final streamingCubit = StreamingStateCubit();
+    final chatCubit = ChatSessionCubit(
+      sessionId: 'scroll-anchor',
+      bridge: bridge,
+      streamingCubit: streamingCubit,
+    );
+    final controller = AnchorMaintainingAutoScrollController();
+    addTearDown(controller.dispose);
+    addTearDown(chatCubit.close);
+    addTearDown(streamingCubit.close);
+    addTearDown(bridge.dispose);
+
+    await tester.pumpWidget(
+      MultiRepositoryProvider(
+        providers: [RepositoryProvider<BridgeService>.value(value: bridge)],
+        child: MultiBlocProvider(
+          providers: [
+            BlocProvider<ChatSessionCubit>.value(value: chatCubit),
+            BlocProvider<StreamingStateCubit>.value(value: streamingCubit),
+          ],
+          child: MaterialApp(
+            theme: AppTheme.darkTheme,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            locale: const Locale('en'),
+            home: Scaffold(
+              body: ChatMessageList(
+                sessionId: 'scroll-anchor',
+                scrollController: controller,
+                httpBaseUrl: null,
+                onRetryMessage: null,
+                collapseToolResults: null,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    bridge.emit(const StatusMessage(status: ProcessStatus.idle));
+    await tester.pump();
+
+    expect(find.text('Load earlier messages'), findsOneWidget);
+    await tester.tap(find.text('Load earlier messages'));
+    expect(bridge.olderHistoryRequests, 1);
+  });
 }
 
 class _ScrollTestBridge extends BridgeService {
   final _messages = StreamController<(ServerMessage, String?)>.broadcast();
+  bool hasOlder = false;
+  int olderHistoryRequests = 0;
 
   void emit(ServerMessage message) => _messages.add((message, 'scroll-anchor'));
 
@@ -247,6 +299,14 @@ class _ScrollTestBridge extends BridgeService {
 
   @override
   void requestSessionHistory(String sessionId) {}
+
+  @override
+  bool hasOlderSessionHistory(String sessionId) => hasOlder;
+
+  @override
+  void requestOlderSessionHistory(String sessionId) {
+    olderHistoryRequests++;
+  }
 
   @override
   void send(ClientMessage message) {}

--- a/apps/mobile/test/chat_session_cubit_test.dart
+++ b/apps/mobile/test/chat_session_cubit_test.dart
@@ -2187,6 +2187,67 @@ void main() {
       expect(cubit.state.entries.first, isA<UserChatEntry>());
     });
 
+    test('prepends older bounded history before the visible window', () async {
+      final cubit = createCubit('s1');
+      addTearDown(cubit.close);
+      await Future.microtask(() {});
+
+      mockBridge.emitMessage(
+        const HistoryMessage(messages: [UserInputMessage(text: 'newer')]),
+        sessionId: 's1',
+      );
+      await Future.microtask(() {});
+      mockBridge.emitMessage(
+        const HistoryPrependMessage(
+          messages: [UserInputMessage(text: 'older')],
+        ),
+        sessionId: 's1',
+      );
+      await Future.microtask(() {});
+
+      expect(
+        cubit.state.entries.whereType<UserChatEntry>().map(
+          (entry) => entry.text,
+        ),
+        ['older', 'newer'],
+      );
+    });
+
+    test('fresh bounded window discards prepended pages from prior load', () async {
+      final cubit = createCubit('s1');
+      addTearDown(cubit.close);
+      await Future.microtask(() {});
+
+      mockBridge.emitMessage(
+        const HistoryMessage(messages: [UserInputMessage(text: 'newer')]),
+        sessionId: 's1',
+      );
+      await Future.microtask(() {});
+      mockBridge.emitMessage(
+        const HistoryPrependMessage(
+          messages: [UserInputMessage(text: 'stale older')],
+        ),
+        sessionId: 's1',
+      );
+      await Future.microtask(() {});
+
+      mockBridge.emitMessage(
+        const HistoryMessage(
+          messages: [UserInputMessage(text: 'fresh')],
+          resetPrependedEntries: true,
+        ),
+        sessionId: 's1',
+      );
+      await Future.microtask(() {});
+
+      expect(
+        cubit.state.entries.whereType<UserChatEntry>().map(
+          (entry) => entry.text,
+        ),
+        ['fresh', 'newer'],
+      );
+    });
+
     test('refresh replaces the previous past-history snapshot', () async {
       final cubit = createCubit('s1');
       addTearDown(cubit.close);

--- a/apps/mobile/test/messages_test.dart
+++ b/apps/mobile/test/messages_test.dart
@@ -486,6 +486,7 @@ void main() {
         'goal_state',
         'guardian_approval',
         'history_delta',
+        'history_page',
         'history_snapshot',
         'git_status_result',
         'prompt_history_status',
@@ -501,6 +502,43 @@ void main() {
         'sessionId': 's1',
         'sinceSeq': 42,
       });
+    });
+
+    test('ClientMessage.getHistory serializes paging options', () {
+      final msg = ClientMessage.getHistory('s1', limit: 200, beforeSeq: 401);
+
+      expect(jsonDecode(msg.toJson()), {
+        'type': 'get_history',
+        'sessionId': 's1',
+        'limit': 200,
+        'beforeSeq': 401,
+      });
+    });
+
+    test('ServerMessage parses a bounded history page', () {
+      final msg = ServerMessage.fromJson({
+        'type': 'history_page',
+        'sessionId': 's1',
+        'fromSeq': 201,
+        'toSeq': 400,
+        'hasOlder': true,
+        'initial': true,
+        'status': 'idle',
+        'messages': [
+          {
+            'seq': 201,
+            'message': {'type': 'status', 'status': 'running'},
+          },
+        ],
+      });
+
+      expect(msg, isA<HistoryPageMessage>());
+      final page = msg as HistoryPageMessage;
+      expect(page.sessionId, 's1');
+      expect(page.entries.single.seq, 201);
+      expect(page.hasOlder, isTrue);
+      expect(page.initial, isTrue);
+      expect(page.status, ProcessStatus.idle);
     });
 
     test('ClientMessage.input serializes strict ack metadata', () {

--- a/apps/mobile/test/services/bridge_service_usage_test.dart
+++ b/apps/mobile/test/services/bridge_service_usage_test.dart
@@ -415,7 +415,11 @@ void main() {
           ),
           isTrue,
         );
-        expect(requests.last, {'type': 'get_history', 'sessionId': 's1'});
+        expect(requests.last, {
+          'type': 'get_history',
+          'sessionId': 's1',
+          'limit': 200,
+        });
 
         bridge.disconnect();
         await socket.close();
@@ -423,6 +427,150 @@ void main() {
         bridge.dispose();
       },
     );
+
+    test(
+      'large legacy history is decoded without exposing an unbounded list',
+      () async {
+        final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+        final socketReady = Completer<WebSocket>();
+        server.transform(WebSocketTransformer()).listen(socketReady.complete);
+
+        final bridge = BridgeService();
+        final received = <ServerMessage>[];
+        final subscription = bridge
+            .messagesForSession('s1')
+            .listen(received.add);
+        bridge.connect('ws://127.0.0.1:${server.port}');
+        final socket = await socketReady.future;
+        final padding = 'x' * 1024;
+        socket.add(
+          jsonEncode({
+            'type': 'history',
+            'sessionId': 's1',
+            'messages': List.generate(450, (index) {
+              return {
+                'type': 'user_input',
+                'text': 'synthetic-$index-$padding',
+              };
+            }),
+          }),
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 250));
+
+        final initial = received.whereType<HistoryMessage>().single;
+        expect(initial.messages, hasLength(200));
+        expect(
+          (initial.messages.first as UserInputMessage).text,
+          startsWith('synthetic-250-'),
+        );
+        expect(bridge.hasOlderSessionHistory('s1'), isTrue);
+
+        bridge.requestOlderSessionHistory('s1');
+        await Future<void>.delayed(Duration.zero);
+        final firstOlder = received.whereType<HistoryPrependMessage>().single;
+        expect(firstOlder.messages, hasLength(200));
+        expect(
+          (firstOlder.messages.first as UserInputMessage).text,
+          startsWith('synthetic-50-'),
+        );
+        expect(bridge.hasOlderSessionHistory('s1'), isTrue);
+
+        bridge.requestOlderSessionHistory('s1');
+        await Future<void>.delayed(Duration.zero);
+        final olderPages = received.whereType<HistoryPrependMessage>().toList();
+        expect(olderPages.last.messages, hasLength(50));
+        expect(bridge.hasOlderSessionHistory('s1'), isFalse);
+
+        await subscription.cancel();
+        bridge.disconnect();
+        await socket.close();
+        await server.close(force: true);
+        bridge.dispose();
+      },
+    );
+
+    test('history page requests only the next older window', () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      final socketReady = Completer<WebSocket>();
+      final outgoing = <Map<String, dynamic>>[];
+      server.transform(WebSocketTransformer()).listen((socket) {
+        socketReady.complete(socket);
+        socket.listen((data) {
+          outgoing.add(jsonDecode(data as String) as Map<String, dynamic>);
+        });
+      });
+
+      final bridge = BridgeService();
+      final received = <ServerMessage>[];
+      final subscription = bridge.messagesForSession('s1').listen(received.add);
+      bridge.connect('ws://127.0.0.1:${server.port}');
+      final socket = await socketReady.future;
+      socket.add(
+        jsonEncode({
+          'type': 'history_page',
+          'sessionId': 's1',
+          'fromSeq': 201,
+          'toSeq': 400,
+          'initial': true,
+          'hasOlder': true,
+          'status': 'idle',
+          'messages': [
+            {
+              'seq': 400,
+              'message': {'type': 'user_input', 'text': 'latest'},
+            },
+          ],
+        }),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(
+        received.whereType<HistoryMessage>().single.messages,
+        hasLength(1),
+      );
+      bridge.requestOlderSessionHistory('s1');
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      final request = outgoing.lastWhere(
+        (message) => message['type'] == 'get_history',
+      );
+      expect(request, {
+        'type': 'get_history',
+        'sessionId': 's1',
+        'limit': 200,
+        'beforeSeq': 201,
+      });
+
+      socket.add(
+        jsonEncode({
+          'type': 'history_page',
+          'sessionId': 's1',
+          'fromSeq': 1,
+          'toSeq': 200,
+          'initial': false,
+          'hasOlder': false,
+          'status': 'idle',
+          'messages': [
+            {
+              'seq': 1,
+              'message': {'type': 'user_input', 'text': 'older'},
+            },
+          ],
+        }),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(
+        received.whereType<HistoryPrependMessage>().single.messages,
+        hasLength(1),
+      );
+      expect(bridge.hasOlderSessionHistory('s1'), isFalse);
+
+      await subscription.cancel();
+      bridge.disconnect();
+      await socket.close();
+      await server.close(force: true);
+      bridge.dispose();
+    });
 
     test('resolveSessionLink completes with the matching response', () async {
       final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);

--- a/packages/bridge/src/parser.test.ts
+++ b/packages/bridge/src/parser.test.ts
@@ -483,6 +483,31 @@ describe("parseClientMessage", () => {
     expect(msg).toEqual({ type: "get_history", sessionId: "s2" });
   });
 
+  it("parses bounded get_history page options", () => {
+    const msg = parseClientMessage(
+      '{"type":"get_history","sessionId":"s2","limit":200,"beforeSeq":401}',
+    );
+    expect(msg).toEqual({
+      type: "get_history",
+      sessionId: "s2",
+      limit: 200,
+      beforeSeq: 401,
+    });
+  });
+
+  it("rejects invalid get_history page options", () => {
+    expect(
+      parseClientMessage(
+        '{"type":"get_history","sessionId":"s2","limit":0}',
+      ),
+    ).toBeNull();
+    expect(
+      parseClientMessage(
+        '{"type":"get_history","sessionId":"s2","beforeSeq":-1}',
+      ),
+    ).toBeNull();
+  });
+
   it("parses resolve_session_link message", () => {
     const msg = parseClientMessage(
       '{"type":"resolve_session_link","requestId":"req-1","sessionId":"session-1","provider":"claude"}',

--- a/packages/bridge/src/parser.ts
+++ b/packages/bridge/src/parser.ts
@@ -219,7 +219,12 @@ export type ClientMessage =
       providerSessionId?: string;
       projectPath?: string;
     }
-  | { type: "get_history"; sessionId: string }
+  | {
+      type: "get_history";
+      sessionId: string;
+      limit?: number;
+      beforeSeq?: number;
+    }
   | { type: "get_history_delta"; sessionId: string; sinceSeq: number }
   | {
       type: "resolve_session_link";
@@ -572,6 +577,16 @@ export type ServerMessage =
     }
   | { type: "status"; status: ProcessStatus }
   | { type: "history"; messages: ServerMessage[] }
+  | {
+      type: "history_page";
+      sessionId: string;
+      fromSeq: number;
+      toSeq: number;
+      messages: Array<{ seq: number; message: ServerMessage }>;
+      hasOlder: boolean;
+      initial: boolean;
+      status?: ProcessStatus;
+    }
   | {
       type: "history_delta";
       sessionId?: string;
@@ -1275,6 +1290,21 @@ export function parseClientMessage(data: string): ClientMessage | null {
         break;
       case "get_history":
         if (typeof msg.sessionId !== "string") return null;
+        if (
+          msg.limit !== undefined &&
+          (typeof msg.limit !== "number" ||
+            !Number.isInteger(msg.limit) ||
+            msg.limit < 1 ||
+            msg.limit > 500)
+        )
+          return null;
+        if (
+          msg.beforeSeq !== undefined &&
+          (typeof msg.beforeSeq !== "number" ||
+            !Number.isInteger(msg.beforeSeq) ||
+            msg.beforeSeq < 1)
+        )
+          return null;
         break;
       case "get_history_delta":
         if (typeof msg.sessionId !== "string") return null;

--- a/packages/bridge/src/websocket.test.ts
+++ b/packages/bridge/src/websocket.test.ts
@@ -2708,6 +2708,115 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     bridge.close();
   });
 
+  it("shows cached codex history while a canonical refresh is still pending", async () => {
+    codexThreadToSessionHistoryMock.mockReturnValue([
+      {
+        role: "user",
+        uuid: "codex:user-turn:stored",
+        content: [{ type: "text", text: "stored transcript" }],
+      },
+    ]);
+
+    const bridge = new BridgeWebSocketServer({ server: httpServer });
+    const ws = {
+      readyState: OPEN_STATE,
+      send: vi.fn(),
+    } as any;
+
+    await (bridge as any).handleClientMessage(
+      {
+        type: "start",
+        projectPath: "/tmp/project-codex",
+        provider: "codex",
+        model: "gpt-5.3-codex",
+      },
+      ws,
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const created = ws.send.mock.calls
+      .map((c: unknown[]) => JSON.parse(c[0] as string))
+      .find((m: any) => m.type === "system" && m.subtype === "session_created");
+    const sessionId = created.sessionId as string;
+    const manager = (bridge as any).sessionManager;
+    const session = manager.get(sessionId);
+    session.claudeSessionId = "thr_codex_slow_history";
+    session.codexSettings = { model: "gpt-5.3-codex" };
+    manager.appendHistory(sessionId, {
+      type: "assistant",
+      message: {
+        id: "cached-live",
+        role: "assistant",
+        content: [{ type: "text", text: "already visible on the session card" }],
+        model: "gpt-5.3-codex",
+      },
+      messageUuid: "cached-live",
+    });
+
+    let resolveRead!: (thread: unknown) => void;
+    const pendingRead = new Promise((resolve) => {
+      resolveRead = resolve;
+    });
+    session.process.readThread.mockReturnValue(pendingRead);
+
+    ws.send.mockClear();
+    const firstRequest = (bridge as any).handleClientMessage(
+      {
+        type: "get_history_delta",
+        sessionId,
+        sinceSeq: 0,
+      },
+      ws,
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const earlyHistory = ws.send.mock.calls
+      .map((c: unknown[]) => JSON.parse(c[0] as string))
+      .find(
+        (message: any) =>
+          message.type === "history_delta" ||
+          message.type === "history_snapshot",
+      );
+    expect(earlyHistory).toMatchObject({ sessionId });
+    expect(earlyHistory.messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          message: expect.objectContaining({
+            type: "assistant",
+            messageUuid: "cached-live",
+          }),
+        }),
+      ]),
+    );
+
+    const duplicateRequest = (bridge as any).handleClientMessage(
+      {
+        type: "get_history_delta",
+        sessionId,
+        sinceSeq: 0,
+      },
+      ws,
+    );
+    await duplicateRequest;
+    expect(session.process.readThread).toHaveBeenCalledTimes(1);
+
+    resolveRead({ id: "thr_codex_slow_history", turns: [] });
+    await firstRequest;
+
+    const finalHistory = ws.send.mock.calls
+      .map((c: unknown[]) => JSON.parse(c[0] as string))
+      .filter((message: any) => message.type === "history_snapshot")
+      .at(-1);
+    expect(finalHistory).toMatchObject({
+      sessionId,
+      reason: "reset",
+    });
+
+    bridge.close();
+  });
+
   it("serves codex get_history as legacy history from canonical thread/read", async () => {
     codexThreadToSessionHistoryMock.mockReturnValue([
       {
@@ -3192,7 +3301,10 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     const sends = ws.send.mock.calls.map((c: unknown[]) =>
       JSON.parse(c[0] as string),
     );
-    expect(sends[0]).toMatchObject({
+    const snapshot = sends.find(
+      (message: any) => message.type === "history_snapshot",
+    );
+    expect(snapshot).toMatchObject({
       type: "history_snapshot",
       sessionId,
       reason: "reset",
@@ -3218,22 +3330,22 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
         },
       ],
     });
-    expect(sends[0].fromSeq).toBe(sends[0].messages[0].seq);
-    expect(sends[0].toSeq).toBe(sends[0].messages[1].seq);
-    expect(sends[0].fromSeq).toBeGreaterThan(1);
+    expect(snapshot.fromSeq).toBe(snapshot.messages[0].seq);
+    expect(snapshot.toSeq).toBe(snapshot.messages[1].seq);
+    expect(snapshot.fromSeq).toBeGreaterThan(1);
     expect(session.codexCanonicalHistoryRevision).toBe(
-      sends[0].messages[0].seq,
+      snapshot.messages[0].seq,
     );
     expect(session.historyEntries).toMatchObject([
       {
-        seq: sends[0].messages[1].seq,
+        seq: snapshot.messages[1].seq,
         message: {
           type: "assistant",
           messageUuid: "live-assistant-1",
         },
       },
     ]);
-    expect(session.historyRevision).toBe(sends[0].toSeq);
+    expect(session.historyRevision).toBe(snapshot.toSeq);
 
     bridge.close();
   });
@@ -3508,7 +3620,10 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     const sends = ws.send.mock.calls.map((c: unknown[]) =>
       JSON.parse(c[0] as string),
     );
-    expect(sends[0]).toMatchObject({
+    const snapshot = sends.find(
+      (message: any) => message.type === "history_snapshot",
+    );
+    expect(snapshot).toMatchObject({
       type: "history_snapshot",
       sessionId,
       messages: [
@@ -3537,12 +3652,12 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
         },
       ],
     });
-    expect(sends[0].fromSeq).toBe(sends[0].messages[0].seq);
-    expect(sends[0].toSeq).toBe(sends[0].messages[1].seq);
-    expect(sends[0].fromSeq).toBeGreaterThan(1);
+    expect(snapshot.fromSeq).toBe(snapshot.messages[0].seq);
+    expect(snapshot.toSeq).toBe(snapshot.messages[1].seq);
+    expect(snapshot.fromSeq).toBeGreaterThan(1);
     expect(session.historyEntries).toMatchObject([
       {
-        seq: sends[0].messages[1].seq,
+        seq: snapshot.messages[1].seq,
         message: {
           type: "assistant",
           message: {
@@ -3771,7 +3886,10 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     const sends = ws.send.mock.calls.map((c: unknown[]) =>
       JSON.parse(c[0] as string),
     );
-    expect(sends[0]).toMatchObject({
+    const snapshot = sends.find(
+      (message: any) => message.type === "history_snapshot",
+    );
+    expect(snapshot).toMatchObject({
       type: "history_snapshot",
       sessionId,
       messages: [
@@ -3792,11 +3910,11 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
         },
       ],
     });
-    expect(sends[0].fromSeq).toBe(sends[0].toSeq);
-    expect(sends[0].messages[0].seq).toBe(sends[0].toSeq);
-    expect(sends[0].toSeq).toBeGreaterThan(1);
+    expect(snapshot.fromSeq).toBe(snapshot.toSeq);
+    expect(snapshot.messages[0].seq).toBe(snapshot.toSeq);
+    expect(snapshot.toSeq).toBeGreaterThan(1);
     expect(session.historyEntries).toEqual([]);
-    expect(session.historyRevision).toBe(sends[0].toSeq);
+    expect(session.historyRevision).toBe(snapshot.toSeq);
 
     bridge.close();
   });
@@ -3861,7 +3979,10 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     const sends = ws.send.mock.calls.map((c: unknown[]) =>
       JSON.parse(c[0] as string),
     );
-    expect(sends[0]).toMatchObject({
+    const snapshot = sends.find(
+      (message: any) => message.type === "history_snapshot",
+    );
+    expect(snapshot).toMatchObject({
       type: "history_snapshot",
       sessionId,
       messages: [
@@ -3875,11 +3996,11 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
         },
       ],
     });
-    expect(sends[0].fromSeq).toBe(sends[0].toSeq);
-    expect(sends[0].messages[0].seq).toBe(sends[0].toSeq);
-    expect(sends[0].toSeq).toBeGreaterThan(1);
+    expect(snapshot.fromSeq).toBe(snapshot.toSeq);
+    expect(snapshot.messages[0].seq).toBe(snapshot.toSeq);
+    expect(snapshot.toSeq).toBeGreaterThan(1);
     expect(session.historyEntries).toEqual([]);
-    expect(session.historyRevision).toBe(sends[0].toSeq);
+    expect(session.historyRevision).toBe(snapshot.toSeq);
 
     bridge.close();
   });

--- a/packages/bridge/src/websocket.test.ts
+++ b/packages/bridge/src/websocket.test.ts
@@ -2813,6 +2813,87 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     bridge.close();
   });
 
+  it("pages long Codex history for capable clients", async () => {
+    codexThreadToSessionHistoryMock.mockReturnValue(
+      Array.from({ length: 6 }, (_, index) => ({
+        role: index.isEven ? "user" : "assistant",
+        uuid: `history-${index + 1}`,
+        content: [{ type: "text", text: `synthetic-${index + 1}` }],
+      })),
+    );
+
+    const bridge = new BridgeWebSocketServer({ server: httpServer });
+    const ws = { readyState: OPEN_STATE, send: vi.fn() } as any;
+    await (bridge as any).handleClientMessage(
+      {
+        type: "client_capabilities",
+        supportedServerMessages: ["history_page"],
+      },
+      ws,
+    );
+    await (bridge as any).handleClientMessage(
+      {
+        type: "start",
+        projectPath: "/tmp/project-codex",
+        provider: "codex",
+      },
+      ws,
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const created = ws.send.mock.calls
+      .map((call: unknown[]) => JSON.parse(call[0] as string))
+      .find((message: any) => message.subtype === "session_created");
+    const sessionId = created.sessionId as string;
+    const session = (bridge as any).sessionManager.get(sessionId);
+    session.claudeSessionId = "thr_paged";
+    session.process.readThread.mockResolvedValue({
+      id: "thr_paged",
+      turns: [],
+    });
+
+    ws.send.mockClear();
+    await (bridge as any).handleClientMessage(
+      { type: "get_history", sessionId, limit: 2 },
+      ws,
+    );
+    const initial = ws.send.mock.calls
+      .map((call: unknown[]) => JSON.parse(call[0] as string))
+      .find((message: any) => message.type === "history_page");
+    expect(initial).toMatchObject({
+      type: "history_page",
+      sessionId,
+      initial: true,
+      hasOlder: true,
+    });
+    expect(initial.messages).toHaveLength(2);
+
+    ws.send.mockClear();
+    await (bridge as any).handleClientMessage(
+      {
+        type: "get_history",
+        sessionId,
+        limit: 2,
+        beforeSeq: initial.fromSeq,
+      },
+      ws,
+    );
+    const older = ws.send.mock.calls
+      .map((call: unknown[]) => JSON.parse(call[0] as string))
+      .find((message: any) => message.type === "history_page");
+    expect(older).toMatchObject({
+      type: "history_page",
+      sessionId,
+      initial: false,
+    });
+    expect(older.messages).toHaveLength(2);
+    expect(older.toSeq).toBeLessThan(initial.fromSeq);
+    expect(session.process.readThread).toHaveBeenCalledTimes(1);
+
+    bridge.close();
+  });
+
   it("replays cached Codex goal state with history responses", async () => {
     const bridge = new BridgeWebSocketServer({ server: httpServer });
     const ws = {

--- a/packages/bridge/src/websocket.ts
+++ b/packages/bridge/src/websocket.ts
@@ -753,6 +753,11 @@ export class BridgeWebSocketServer {
   private deltaBatches = new Map<WebSocket, Map<string, DeltaBatch>>();
   private platform: NodeJS.Platform;
   private clientSupportedServerMessages = new WeakMap<WebSocket, Set<string>>();
+  private codexHistoryResponsesInFlight = new WeakMap<WebSocket, Set<string>>();
+  private codexCanonicalHistoryInFlight = new Map<
+    string,
+    Promise<HistoryEntry[] | null>
+  >();
   private codexHistoryPageCache = new Map<string, HistoryEntry[]>();
   private pendingClaudeResumeInputs = new WeakMap<
     WebSocket,
@@ -1454,7 +1459,44 @@ export class BridgeWebSocketServer {
     return undefined;
   }
 
+  private beginCodexHistoryResponse(ws: WebSocket, sessionId: string): boolean {
+    let sessionIds = this.codexHistoryResponsesInFlight.get(ws);
+    if (!sessionIds) {
+      sessionIds = new Set<string>();
+      this.codexHistoryResponsesInFlight.set(ws, sessionIds);
+    }
+    if (sessionIds.has(sessionId)) return false;
+    sessionIds.add(sessionId);
+    return true;
+  }
+
+  private endCodexHistoryResponse(ws: WebSocket, sessionId: string): void {
+    const sessionIds = this.codexHistoryResponsesInFlight.get(ws);
+    if (!sessionIds) return;
+    sessionIds.delete(sessionId);
+    if (sessionIds.size === 0) {
+      this.codexHistoryResponsesInFlight.delete(ws);
+    }
+  }
+
   private async codexCanonicalHistoryEntries(
+    session: SessionInfo,
+  ): Promise<HistoryEntry[] | null> {
+    const existing = this.codexCanonicalHistoryInFlight.get(session.id);
+    if (existing) return existing;
+
+    const request = this.loadCodexCanonicalHistoryEntries(session);
+    this.codexCanonicalHistoryInFlight.set(session.id, request);
+    try {
+      return await request;
+    } finally {
+      if (this.codexCanonicalHistoryInFlight.get(session.id) === request) {
+        this.codexCanonicalHistoryInFlight.delete(session.id);
+      }
+    }
+  }
+
+  private async loadCodexCanonicalHistoryEntries(
     session: SessionInfo,
   ): Promise<HistoryEntry[] | null> {
     const threadId = this.codexThreadIdForSession(session);
@@ -4321,28 +4363,33 @@ export class BridgeWebSocketServer {
         const session = this.sessionManager.get(msg.sessionId);
         if (session) {
           if (session.provider === "codex") {
-            const supportsPages =
-              this.clientSupportedServerMessages
-                .get(ws)
-                ?.has("history_page") ?? false;
-            if (supportsPages) {
-              const handled = await this.sendCodexCanonicalHistoryPage(
+            if (!this.beginCodexHistoryResponse(ws, msg.sessionId)) break;
+            try {
+              const supportsPages =
+                this.clientSupportedServerMessages
+                  .get(ws)
+                  ?.has("history_page") ?? false;
+              if (supportsPages) {
+                const handled = await this.sendCodexCanonicalHistoryPage(
+                  ws,
+                  msg.sessionId,
+                  session,
+                  { beforeSeq: msg.beforeSeq, limit: msg.limit },
+                );
+                if (handled) {
+                  break;
+                }
+              }
+              const handled = await this.sendCodexCanonicalLegacyHistory(
                 ws,
                 msg.sessionId,
                 session,
-                { beforeSeq: msg.beforeSeq, limit: msg.limit },
               );
               if (handled) {
                 break;
               }
-            }
-            const handled = await this.sendCodexCanonicalLegacyHistory(
-              ws,
-              msg.sessionId,
-              session,
-            );
-            if (handled) {
-              break;
+            } finally {
+              this.endCodexHistoryResponse(ws, msg.sessionId);
             }
           }
 
@@ -4462,11 +4509,39 @@ export class BridgeWebSocketServer {
               result.kind,
             )
           ) {
-            await this.sendCodexCanonicalHistorySnapshot(
-              ws,
-              msg.sessionId,
-              session,
-            );
+            if (!this.beginCodexHistoryResponse(ws, msg.sessionId)) break;
+            try {
+              // The canonical thread/read can take several seconds while a
+              // turn is active. Show the Bridge's sequenced live cache first
+              // so reopening a working session never presents a blank chat.
+              // The canonical snapshot below then reconciles the full thread.
+              const hasCachedConversation = result.entries.some(
+                ({ message }) => message.type !== "system",
+              );
+              if (hasCachedConversation) {
+                this.send(ws, {
+                  type:
+                    result.kind === "snapshot"
+                      ? "history_snapshot"
+                      : "history_delta",
+                  sessionId: msg.sessionId,
+                  fromSeq: result.fromSeq,
+                  toSeq: result.toSeq,
+                  messages: result.entries,
+                  status: session.status,
+                  ...(result.kind === "snapshot"
+                    ? { reason: result.reason }
+                    : {}),
+                } as ServerMessage);
+              }
+              await this.sendCodexCanonicalHistorySnapshot(
+                ws,
+                msg.sessionId,
+                session,
+              );
+            } finally {
+              this.endCodexHistoryResponse(ws, msg.sessionId);
+            }
             break;
           }
 

--- a/packages/bridge/src/websocket.ts
+++ b/packages/bridge/src/websocket.ts
@@ -218,6 +218,7 @@ const OPT_IN_SERVER_MESSAGES = new Set<string>([
   "conversation_queue",
   "goal_state",
   "guardian_approval",
+  "history_page",
   "prompt_history_status",
   "push_registration_result",
 ]);
@@ -752,6 +753,7 @@ export class BridgeWebSocketServer {
   private deltaBatches = new Map<WebSocket, Map<string, DeltaBatch>>();
   private platform: NodeJS.Platform;
   private clientSupportedServerMessages = new WeakMap<WebSocket, Set<string>>();
+  private codexHistoryPageCache = new Map<string, HistoryEntry[]>();
   private pendingClaudeResumeInputs = new WeakMap<
     WebSocket,
     Map<string, InputClientMessage[]>
@@ -1836,6 +1838,61 @@ export class BridgeWebSocketServer {
         message: `Failed to read Codex thread history: ${
           err instanceof Error ? err.message : String(err)
         }`,
+      });
+      return true;
+    }
+  }
+
+  private async sendCodexCanonicalHistoryPage(
+    ws: WebSocket,
+    sessionId: string,
+    session: SessionInfo,
+    options: { beforeSeq?: number; limit?: number } = {},
+  ): Promise<boolean> {
+    try {
+      const initial = options.beforeSeq === undefined;
+      let entries = initial
+        ? await this.codexCanonicalHistoryEntries(session)
+        : this.codexHistoryPageCache.get(sessionId);
+      if (!entries) {
+        entries = await this.codexCanonicalHistoryEntries(session);
+      }
+      if (!entries) return false;
+      this.codexHistoryPageCache.set(sessionId, entries);
+
+      const limit = Math.min(Math.max(options.limit ?? 200, 1), 500);
+      let end = entries.length;
+      if (options.beforeSeq !== undefined) {
+        end = entries.findIndex((entry) => entry.seq >= options.beforeSeq!);
+        if (end === -1) end = entries.length;
+      }
+      const start = Math.max(0, end - limit);
+      const page = entries.slice(start, end);
+      this.send(ws, {
+        type: "history_page",
+        sessionId,
+        fromSeq: page[0]?.seq ?? options.beforeSeq ?? 0,
+        toSeq: page.at(-1)?.seq ?? Math.max((options.beforeSeq ?? 1) - 1, 0),
+        messages: page,
+        hasOlder: start > 0,
+        initial,
+        status: session.status,
+      } satisfies Extract<ServerMessage, { type: "history_page" }>);
+
+      if (initial) {
+        this.sendCodexCurrentSettings(ws, sessionId, session);
+        this.sendCodexQueueState(ws, sessionId, session);
+        this.sendCodexGoalState(ws, sessionId, session);
+        this.sendCachedCommands(ws, sessionId, session);
+      }
+      return true;
+    } catch (err) {
+      this.send(ws, {
+        type: "error",
+        message: `Failed to read Codex thread history: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+        sessionId,
       });
       return true;
     }
@@ -4264,6 +4321,21 @@ export class BridgeWebSocketServer {
         const session = this.sessionManager.get(msg.sessionId);
         if (session) {
           if (session.provider === "codex") {
+            const supportsPages =
+              this.clientSupportedServerMessages
+                .get(ws)
+                ?.has("history_page") ?? false;
+            if (supportsPages) {
+              const handled = await this.sendCodexCanonicalHistoryPage(
+                ws,
+                msg.sessionId,
+                session,
+                { beforeSeq: msg.beforeSeq, limit: msg.limit },
+              );
+              if (handled) {
+                break;
+              }
+            }
             const handled = await this.sendCodexCanonicalLegacyHistory(
               ws,
               msg.sessionId,
@@ -7148,6 +7220,7 @@ export class BridgeWebSocketServer {
 
   private destroySession(sessionId: string): void {
     this.flushSessionDeltaBatches(sessionId);
+    this.codexHistoryPageCache.delete(sessionId);
     this.sessionManager.destroy(sessionId);
   }
 
@@ -7899,7 +7972,11 @@ export class BridgeWebSocketServer {
         ),
       };
     }
-    if (msg.type === "history_delta" || msg.type === "history_snapshot") {
+    if (
+      msg.type === "history_delta" ||
+      msg.type === "history_snapshot" ||
+      msg.type === "history_page"
+    ) {
       return {
         ...(msg as unknown as Record<string, unknown>),
         messages: messages.filter((entry) => {


### PR DESCRIPTION
## Summary

- load long transcripts in bounded history pages
- immediately return cached sequenced history when a session is reopened, while canonical Codex history continues loading
- coalesce duplicate canonical reads and suppress duplicate per-socket history requests
- keep older-history loading retryable after failures

## Verification

- all 153 Bridge websocket tests passed
- all 919 Bridge tests passed
- Bridge TypeScript checking passed
- the original focused chat-history tests and Android release build passed