### PR TITLE
fix(sessions): recover stalled recent session lists

### DIFF
--- a/apps/mobile/lib/features/session_list/session_list_screen.dart
+++ b/apps/mobile/lib/features/session_list/session_list_screen.dart
@@ -1789,6 +1789,7 @@ class _SessionListScreenState extends State<SessionListScreen>
               searchQuery: slState.searchQuery,
               isLoadingMore: slState.isLoadingMore,
               isInitialLoading: slState.isInitialLoading,
+              recentSessionsLoadFailed: slState.recentSessionsLoadFailed,
               hasMoreSessions: slState.hasMore,
               archivingSessionIds: _archivingSessionIds,
               unseenSessionIds: unseenSessionIds,
@@ -1873,6 +1874,8 @@ class _SessionListScreenState extends State<SessionListScreen>
               onSelectProject: (path) =>
                   context.read<SessionListCubit>().selectProject(path),
               onLoadMore: () => context.read<SessionListCubit>().loadMore(),
+              onRetryRecentSessions: () =>
+                  context.read<SessionListCubit>().retryRecentSessions(),
               onLoadMoreProject: (path) =>
                   context.read<SessionListCubit>().loadMoreProject(path),
               onToggleProjectCollapsed: (path) =>

--- a/apps/mobile/lib/features/session_list/state/session_list_cubit.dart
+++ b/apps/mobile/lib/features/session_list/state/session_list_cubit.dart
@@ -66,6 +66,7 @@ class SessionListCubit extends Cubit<SessionListState> {
   final BridgeService _bridge;
   StreamSubscription<List<RecentSession>>? _recentSub;
   StreamSubscription<List<String>>? _projectHistorySub;
+  StreamSubscription<ServerMessage>? _messageSub;
   Timer? _searchDebounce;
   late final Future<void> _preferencesLoaded;
 
@@ -76,6 +77,7 @@ class SessionListCubit extends Cubit<SessionListState> {
     _projectHistorySub = _bridge.projectHistoryStream.listen(
       _onProjectHistoryUpdate,
     );
+    _messageSub = _bridge.messages.listen(_onBridgeMessage);
     _preferencesLoaded = _loadPreferences();
   }
 
@@ -151,6 +153,7 @@ class SessionListCubit extends Cubit<SessionListState> {
         hasMore: hasMore,
         isLoadingMore: false,
         isInitialLoading: false,
+        recentSessionsLoadFailed: false,
         accumulatedProjectPaths: merged,
         loadingProjectPaths: const {},
         exhaustedProjectPaths: hasMore ? const {} : merged,
@@ -170,12 +173,40 @@ class SessionListCubit extends Cubit<SessionListState> {
     }
   }
 
+  void _onBridgeMessage(ServerMessage message) {
+    if (message is! ErrorMessage ||
+        message.errorCode != 'recent_sessions_failed') {
+      return;
+    }
+    final projectPath = message.path;
+    if (message.requestScope == 'project' &&
+        projectPath != null &&
+        projectPath.isNotEmpty) {
+      emit(
+        state.copyWith(
+          loadingProjectPaths: {...state.loadingProjectPaths}
+            ..remove(projectPath),
+        ),
+      );
+      return;
+    }
+    emit(
+      state.copyWith(
+        isInitialLoading: false,
+        isLoadingMore: false,
+        recentSessionsLoadFailed: true,
+      ),
+    );
+  }
+
   // ---- Filter commands (all trigger server re-fetch) ----
 
   /// Switch project filter. Resets sessions on the server side and fetches
   /// from offset 0 for the selected project.
   void selectProject(String? projectPath) {
-    emit(state.copyWith(isInitialLoading: true));
+    emit(
+      state.copyWith(isInitialLoading: true, recentSessionsLoadFailed: false),
+    );
     _bridge.switchFilter(
       projectPath: projectPath,
       provider: _providerToString(state.providerFilter),
@@ -190,7 +221,9 @@ class SessionListCubit extends Cubit<SessionListState> {
     _searchDebounce?.cancel();
     _searchDebounce = Timer(const Duration(milliseconds: 300), () {
       if (isClosed) return;
-      emit(state.copyWith(isInitialLoading: true));
+      emit(
+        state.copyWith(isInitialLoading: true, recentSessionsLoadFailed: false),
+      );
       _requestWithCurrentFilters();
     });
   }
@@ -211,7 +244,13 @@ class SessionListCubit extends Cubit<SessionListState> {
 
   void setProviderFilter(ProviderFilter next) {
     if (state.providerFilter == next) return;
-    emit(state.copyWith(providerFilter: next, isInitialLoading: true));
+    emit(
+      state.copyWith(
+        providerFilter: next,
+        isInitialLoading: true,
+        recentSessionsLoadFailed: false,
+      ),
+    );
     _requestWithCurrentFilters();
     // Persist preference in background (fire-and-forget).
     SharedPreferences.getInstance().then(
@@ -228,7 +267,13 @@ class SessionListCubit extends Cubit<SessionListState> {
   /// Toggle named-only filter on/off.
   void toggleNamedOnly() async {
     final next = !state.namedOnly;
-    emit(state.copyWith(namedOnly: next, isInitialLoading: true));
+    emit(
+      state.copyWith(
+        namedOnly: next,
+        isInitialLoading: true,
+        recentSessionsLoadFailed: false,
+      ),
+    );
     _requestWithCurrentFilters();
     // Persist preference in background (fire-and-forget).
     SharedPreferences.getInstance().then(
@@ -238,7 +283,7 @@ class SessionListCubit extends Cubit<SessionListState> {
 
   /// Load more sessions (pagination).
   void loadMore() {
-    emit(state.copyWith(isLoadingMore: true));
+    emit(state.copyWith(isLoadingMore: true, recentSessionsLoadFailed: false));
     _bridge.loadMoreRecentSessions();
   }
 
@@ -340,9 +385,25 @@ class SessionListCubit extends Cubit<SessionListState> {
 
   /// Request fresh data from the server.
   void refresh() {
+    emit(
+      state.copyWith(
+        isInitialLoading: state.sessions.isEmpty,
+        recentSessionsLoadFailed: false,
+      ),
+    );
     _bridge.requestSessionList();
     _requestWithCurrentFilters();
     _bridge.requestProjectHistory();
+  }
+
+  void retryRecentSessions() {
+    emit(
+      state.copyWith(
+        isInitialLoading: state.sessions.isEmpty,
+        recentSessionsLoadFailed: false,
+      ),
+    );
+    _requestWithCurrentFilters();
   }
 
   /// Reset all filter state (used on disconnect).
@@ -358,6 +419,7 @@ class SessionListCubit extends Cubit<SessionListState> {
         projectSessionDisplayLimits: const {},
         isLoadingMore: false,
         isInitialLoading: true,
+        recentSessionsLoadFailed: false,
         providerFilter: ProviderFilter.all,
         namedOnly: false,
       ),
@@ -401,6 +463,7 @@ class SessionListCubit extends Cubit<SessionListState> {
     _searchDebounce?.cancel();
     _recentSub?.cancel();
     _projectHistorySub?.cancel();
+    _messageSub?.cancel();
     return super.close();
   }
 }

--- a/apps/mobile/lib/features/session_list/state/session_list_state.dart
+++ b/apps/mobile/lib/features/session_list/state/session_list_state.dart
@@ -23,6 +23,9 @@ abstract class SessionListState with _$SessionListState {
     /// Initial loading (true until the first recent sessions response arrives).
     @Default(true) bool isInitialLoading,
 
+    /// The latest non-project recent-sessions request failed.
+    @Default(false) bool recentSessionsLoadFailed,
+
     /// Client-side text search query (bound to the TextField, sent to server
     /// after debounce).
     @Default('') String searchQuery,

--- a/apps/mobile/lib/features/session_list/state/session_list_state.freezed.dart
+++ b/apps/mobile/lib/features/session_list/state/session_list_state.freezed.dart
@@ -19,7 +19,8 @@ mixin _$SessionListState {
  List<RecentSession> get sessions;/// Whether there are more sessions available on the server.
  bool get hasMore;/// Loading more sessions (pagination).
  bool get isLoadingMore;/// Initial loading (true until the first recent sessions response arrives).
- bool get isInitialLoading;/// Client-side text search query (bound to the TextField, sent to server
+ bool get isInitialLoading;/// The latest non-project recent-sessions request failed.
+ bool get recentSessionsLoadFailed;/// Client-side text search query (bound to the TextField, sent to server
 /// after debounce).
  String get searchQuery;/// Accumulated project paths from all loaded sessions + project history.
 /// Used for the "New Session" project picker.
@@ -43,16 +44,16 @@ $SessionListStateCopyWith<SessionListState> get copyWith => _$SessionListStateCo
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is SessionListState&&const DeepCollectionEquality().equals(other.sessions, sessions)&&(identical(other.hasMore, hasMore) || other.hasMore == hasMore)&&(identical(other.isLoadingMore, isLoadingMore) || other.isLoadingMore == isLoadingMore)&&(identical(other.isInitialLoading, isInitialLoading) || other.isInitialLoading == isInitialLoading)&&(identical(other.searchQuery, searchQuery) || other.searchQuery == searchQuery)&&const DeepCollectionEquality().equals(other.accumulatedProjectPaths, accumulatedProjectPaths)&&const DeepCollectionEquality().equals(other.collapsedProjectPaths, collapsedProjectPaths)&&const DeepCollectionEquality().equals(other.loadingProjectPaths, loadingProjectPaths)&&const DeepCollectionEquality().equals(other.exhaustedProjectPaths, exhaustedProjectPaths)&&const DeepCollectionEquality().equals(other.projectSessionDisplayLimits, projectSessionDisplayLimits)&&const DeepCollectionEquality().equals(other.pinnedSessionKeys, pinnedSessionKeys)&&const DeepCollectionEquality().equals(other.pinnedProjectPaths, pinnedProjectPaths)&&(identical(other.providerFilter, providerFilter) || other.providerFilter == providerFilter)&&(identical(other.namedOnly, namedOnly) || other.namedOnly == namedOnly));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SessionListState&&const DeepCollectionEquality().equals(other.sessions, sessions)&&(identical(other.hasMore, hasMore) || other.hasMore == hasMore)&&(identical(other.isLoadingMore, isLoadingMore) || other.isLoadingMore == isLoadingMore)&&(identical(other.isInitialLoading, isInitialLoading) || other.isInitialLoading == isInitialLoading)&&(identical(other.recentSessionsLoadFailed, recentSessionsLoadFailed) || other.recentSessionsLoadFailed == recentSessionsLoadFailed)&&(identical(other.searchQuery, searchQuery) || other.searchQuery == searchQuery)&&const DeepCollectionEquality().equals(other.accumulatedProjectPaths, accumulatedProjectPaths)&&const DeepCollectionEquality().equals(other.collapsedProjectPaths, collapsedProjectPaths)&&const DeepCollectionEquality().equals(other.loadingProjectPaths, loadingProjectPaths)&&const DeepCollectionEquality().equals(other.exhaustedProjectPaths, exhaustedProjectPaths)&&const DeepCollectionEquality().equals(other.projectSessionDisplayLimits, projectSessionDisplayLimits)&&const DeepCollectionEquality().equals(other.pinnedSessionKeys, pinnedSessionKeys)&&const DeepCollectionEquality().equals(other.pinnedProjectPaths, pinnedProjectPaths)&&(identical(other.providerFilter, providerFilter) || other.providerFilter == providerFilter)&&(identical(other.namedOnly, namedOnly) || other.namedOnly == namedOnly));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(sessions),hasMore,isLoadingMore,isInitialLoading,searchQuery,const DeepCollectionEquality().hash(accumulatedProjectPaths),const DeepCollectionEquality().hash(collapsedProjectPaths),const DeepCollectionEquality().hash(loadingProjectPaths),const DeepCollectionEquality().hash(exhaustedProjectPaths),const DeepCollectionEquality().hash(projectSessionDisplayLimits),const DeepCollectionEquality().hash(pinnedSessionKeys),const DeepCollectionEquality().hash(pinnedProjectPaths),providerFilter,namedOnly);
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(sessions),hasMore,isLoadingMore,isInitialLoading,recentSessionsLoadFailed,searchQuery,const DeepCollectionEquality().hash(accumulatedProjectPaths),const DeepCollectionEquality().hash(collapsedProjectPaths),const DeepCollectionEquality().hash(loadingProjectPaths),const DeepCollectionEquality().hash(exhaustedProjectPaths),const DeepCollectionEquality().hash(projectSessionDisplayLimits),const DeepCollectionEquality().hash(pinnedSessionKeys),const DeepCollectionEquality().hash(pinnedProjectPaths),providerFilter,namedOnly);
 
 @override
 String toString() {
-  return 'SessionListState(sessions: $sessions, hasMore: $hasMore, isLoadingMore: $isLoadingMore, isInitialLoading: $isInitialLoading, searchQuery: $searchQuery, accumulatedProjectPaths: $accumulatedProjectPaths, collapsedProjectPaths: $collapsedProjectPaths, loadingProjectPaths: $loadingProjectPaths, exhaustedProjectPaths: $exhaustedProjectPaths, projectSessionDisplayLimits: $projectSessionDisplayLimits, pinnedSessionKeys: $pinnedSessionKeys, pinnedProjectPaths: $pinnedProjectPaths, providerFilter: $providerFilter, namedOnly: $namedOnly)';
+  return 'SessionListState(sessions: $sessions, hasMore: $hasMore, isLoadingMore: $isLoadingMore, isInitialLoading: $isInitialLoading, recentSessionsLoadFailed: $recentSessionsLoadFailed, searchQuery: $searchQuery, accumulatedProjectPaths: $accumulatedProjectPaths, collapsedProjectPaths: $collapsedProjectPaths, loadingProjectPaths: $loadingProjectPaths, exhaustedProjectPaths: $exhaustedProjectPaths, projectSessionDisplayLimits: $projectSessionDisplayLimits, pinnedSessionKeys: $pinnedSessionKeys, pinnedProjectPaths: $pinnedProjectPaths, providerFilter: $providerFilter, namedOnly: $namedOnly)';
 }
 
 
@@ -63,7 +64,7 @@ abstract mixin class $SessionListStateCopyWith<$Res>  {
   factory $SessionListStateCopyWith(SessionListState value, $Res Function(SessionListState) _then) = _$SessionListStateCopyWithImpl;
 @useResult
 $Res call({
- List<RecentSession> sessions, bool hasMore, bool isLoadingMore, bool isInitialLoading, String searchQuery, Set<String> accumulatedProjectPaths, Set<String> collapsedProjectPaths, Set<String> loadingProjectPaths, Set<String> exhaustedProjectPaths, Map<String, int> projectSessionDisplayLimits, Set<String> pinnedSessionKeys, Set<String> pinnedProjectPaths, ProviderFilter providerFilter, bool namedOnly
+ List<RecentSession> sessions, bool hasMore, bool isLoadingMore, bool isInitialLoading, bool recentSessionsLoadFailed, String searchQuery, Set<String> accumulatedProjectPaths, Set<String> collapsedProjectPaths, Set<String> loadingProjectPaths, Set<String> exhaustedProjectPaths, Map<String, int> projectSessionDisplayLimits, Set<String> pinnedSessionKeys, Set<String> pinnedProjectPaths, ProviderFilter providerFilter, bool namedOnly
 });
 
 
@@ -80,12 +81,13 @@ class _$SessionListStateCopyWithImpl<$Res>
 
 /// Create a copy of SessionListState
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? sessions = null,Object? hasMore = null,Object? isLoadingMore = null,Object? isInitialLoading = null,Object? searchQuery = null,Object? accumulatedProjectPaths = null,Object? collapsedProjectPaths = null,Object? loadingProjectPaths = null,Object? exhaustedProjectPaths = null,Object? projectSessionDisplayLimits = null,Object? pinnedSessionKeys = null,Object? pinnedProjectPaths = null,Object? providerFilter = null,Object? namedOnly = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? sessions = null,Object? hasMore = null,Object? isLoadingMore = null,Object? isInitialLoading = null,Object? recentSessionsLoadFailed = null,Object? searchQuery = null,Object? accumulatedProjectPaths = null,Object? collapsedProjectPaths = null,Object? loadingProjectPaths = null,Object? exhaustedProjectPaths = null,Object? projectSessionDisplayLimits = null,Object? pinnedSessionKeys = null,Object? pinnedProjectPaths = null,Object? providerFilter = null,Object? namedOnly = null,}) {
   return _then(SessionListState(
 sessions: null == sessions ? _self.sessions : sessions // ignore: cast_nullable_to_non_nullable
 as List<RecentSession>,hasMore: null == hasMore ? _self.hasMore : hasMore // ignore: cast_nullable_to_non_nullable
 as bool,isLoadingMore: null == isLoadingMore ? _self.isLoadingMore : isLoadingMore // ignore: cast_nullable_to_non_nullable
 as bool,isInitialLoading: null == isInitialLoading ? _self.isInitialLoading : isInitialLoading // ignore: cast_nullable_to_non_nullable
+as bool,recentSessionsLoadFailed: null == recentSessionsLoadFailed ? _self.recentSessionsLoadFailed : recentSessionsLoadFailed // ignore: cast_nullable_to_non_nullable
 as bool,searchQuery: null == searchQuery ? _self.searchQuery : searchQuery // ignore: cast_nullable_to_non_nullable
 as String,accumulatedProjectPaths: null == accumulatedProjectPaths ? _self.accumulatedProjectPaths : accumulatedProjectPaths // ignore: cast_nullable_to_non_nullable
 as Set<String>,collapsedProjectPaths: null == collapsedProjectPaths ? _self.collapsedProjectPaths : collapsedProjectPaths // ignore: cast_nullable_to_non_nullable
@@ -181,10 +183,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( List<RecentSession> sessions,  bool hasMore,  bool isLoadingMore,  bool isInitialLoading,  String searchQuery,  Set<String> accumulatedProjectPaths,  Set<String> collapsedProjectPaths,  Set<String> loadingProjectPaths,  Set<String> exhaustedProjectPaths,  Map<String, int> projectSessionDisplayLimits,  Set<String> pinnedSessionKeys,  Set<String> pinnedProjectPaths,  ProviderFilter providerFilter,  bool namedOnly)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( List<RecentSession> sessions,  bool hasMore,  bool isLoadingMore,  bool isInitialLoading,  bool recentSessionsLoadFailed,  String searchQuery,  Set<String> accumulatedProjectPaths,  Set<String> collapsedProjectPaths,  Set<String> loadingProjectPaths,  Set<String> exhaustedProjectPaths,  Map<String, int> projectSessionDisplayLimits,  Set<String> pinnedSessionKeys,  Set<String> pinnedProjectPaths,  ProviderFilter providerFilter,  bool namedOnly)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _SessionListState() when $default != null:
-return $default(_that.sessions,_that.hasMore,_that.isLoadingMore,_that.isInitialLoading,_that.searchQuery,_that.accumulatedProjectPaths,_that.collapsedProjectPaths,_that.loadingProjectPaths,_that.exhaustedProjectPaths,_that.projectSessionDisplayLimits,_that.pinnedSessionKeys,_that.pinnedProjectPaths,_that.providerFilter,_that.namedOnly);case _:
+return $default(_that.sessions,_that.hasMore,_that.isLoadingMore,_that.isInitialLoading,_that.recentSessionsLoadFailed,_that.searchQuery,_that.accumulatedProjectPaths,_that.collapsedProjectPaths,_that.loadingProjectPaths,_that.exhaustedProjectPaths,_that.projectSessionDisplayLimits,_that.pinnedSessionKeys,_that.pinnedProjectPaths,_that.providerFilter,_that.namedOnly);case _:
   return orElse();
 
 }
@@ -202,10 +204,10 @@ return $default(_that.sessions,_that.hasMore,_that.isLoadingMore,_that.isInitial
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( List<RecentSession> sessions,  bool hasMore,  bool isLoadingMore,  bool isInitialLoading,  String searchQuery,  Set<String> accumulatedProjectPaths,  Set<String> collapsedProjectPaths,  Set<String> loadingProjectPaths,  Set<String> exhaustedProjectPaths,  Map<String, int> projectSessionDisplayLimits,  Set<String> pinnedSessionKeys,  Set<String> pinnedProjectPaths,  ProviderFilter providerFilter,  bool namedOnly)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( List<RecentSession> sessions,  bool hasMore,  bool isLoadingMore,  bool isInitialLoading,  bool recentSessionsLoadFailed,  String searchQuery,  Set<String> accumulatedProjectPaths,  Set<String> collapsedProjectPaths,  Set<String> loadingProjectPaths,  Set<String> exhaustedProjectPaths,  Map<String, int> projectSessionDisplayLimits,  Set<String> pinnedSessionKeys,  Set<String> pinnedProjectPaths,  ProviderFilter providerFilter,  bool namedOnly)  $default,) {final _that = this;
 switch (_that) {
 case _SessionListState():
-return $default(_that.sessions,_that.hasMore,_that.isLoadingMore,_that.isInitialLoading,_that.searchQuery,_that.accumulatedProjectPaths,_that.collapsedProjectPaths,_that.loadingProjectPaths,_that.exhaustedProjectPaths,_that.projectSessionDisplayLimits,_that.pinnedSessionKeys,_that.pinnedProjectPaths,_that.providerFilter,_that.namedOnly);case _:
+return $default(_that.sessions,_that.hasMore,_that.isLoadingMore,_that.isInitialLoading,_that.recentSessionsLoadFailed,_that.searchQuery,_that.accumulatedProjectPaths,_that.collapsedProjectPaths,_that.loadingProjectPaths,_that.exhaustedProjectPaths,_that.projectSessionDisplayLimits,_that.pinnedSessionKeys,_that.pinnedProjectPaths,_that.providerFilter,_that.namedOnly);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -222,10 +224,10 @@ return $default(_that.sessions,_that.hasMore,_that.isLoadingMore,_that.isInitial
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( List<RecentSession> sessions,  bool hasMore,  bool isLoadingMore,  bool isInitialLoading,  String searchQuery,  Set<String> accumulatedProjectPaths,  Set<String> collapsedProjectPaths,  Set<String> loadingProjectPaths,  Set<String> exhaustedProjectPaths,  Map<String, int> projectSessionDisplayLimits,  Set<String> pinnedSessionKeys,  Set<String> pinnedProjectPaths,  ProviderFilter providerFilter,  bool namedOnly)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( List<RecentSession> sessions,  bool hasMore,  bool isLoadingMore,  bool isInitialLoading,  bool recentSessionsLoadFailed,  String searchQuery,  Set<String> accumulatedProjectPaths,  Set<String> collapsedProjectPaths,  Set<String> loadingProjectPaths,  Set<String> exhaustedProjectPaths,  Map<String, int> projectSessionDisplayLimits,  Set<String> pinnedSessionKeys,  Set<String> pinnedProjectPaths,  ProviderFilter providerFilter,  bool namedOnly)?  $default,) {final _that = this;
 switch (_that) {
 case _SessionListState() when $default != null:
-return $default(_that.sessions,_that.hasMore,_that.isLoadingMore,_that.isInitialLoading,_that.searchQuery,_that.accumulatedProjectPaths,_that.collapsedProjectPaths,_that.loadingProjectPaths,_that.exhaustedProjectPaths,_that.projectSessionDisplayLimits,_that.pinnedSessionKeys,_that.pinnedProjectPaths,_that.providerFilter,_that.namedOnly);case _:
+return $default(_that.sessions,_that.hasMore,_that.isLoadingMore,_that.isInitialLoading,_that.recentSessionsLoadFailed,_that.searchQuery,_that.accumulatedProjectPaths,_that.collapsedProjectPaths,_that.loadingProjectPaths,_that.exhaustedProjectPaths,_that.projectSessionDisplayLimits,_that.pinnedSessionKeys,_that.pinnedProjectPaths,_that.providerFilter,_that.namedOnly);case _:
   return null;
 
 }
@@ -237,7 +239,7 @@ return $default(_that.sessions,_that.hasMore,_that.isLoadingMore,_that.isInitial
 
 
 class _SessionListState implements SessionListState {
-  const _SessionListState({ List<RecentSession> sessions = const [], this.hasMore = false, this.isLoadingMore = false, this.isInitialLoading = true, this.searchQuery = '',  Set<String> accumulatedProjectPaths = const {},  Set<String> collapsedProjectPaths = const {},  Set<String> loadingProjectPaths = const {},  Set<String> exhaustedProjectPaths = const {},  Map<String, int> projectSessionDisplayLimits = const {},  Set<String> pinnedSessionKeys = const {},  Set<String> pinnedProjectPaths = const {}, this.providerFilter = ProviderFilter.all, this.namedOnly = false}): _sessions = sessions,_accumulatedProjectPaths = accumulatedProjectPaths,_collapsedProjectPaths = collapsedProjectPaths,_loadingProjectPaths = loadingProjectPaths,_exhaustedProjectPaths = exhaustedProjectPaths,_projectSessionDisplayLimits = projectSessionDisplayLimits,_pinnedSessionKeys = pinnedSessionKeys,_pinnedProjectPaths = pinnedProjectPaths;
+  const _SessionListState({ List<RecentSession> sessions = const [], this.hasMore = false, this.isLoadingMore = false, this.isInitialLoading = true, this.recentSessionsLoadFailed = false, this.searchQuery = '',  Set<String> accumulatedProjectPaths = const {},  Set<String> collapsedProjectPaths = const {},  Set<String> loadingProjectPaths = const {},  Set<String> exhaustedProjectPaths = const {},  Map<String, int> projectSessionDisplayLimits = const {},  Set<String> pinnedSessionKeys = const {},  Set<String> pinnedProjectPaths = const {}, this.providerFilter = ProviderFilter.all, this.namedOnly = false}): _sessions = sessions,_accumulatedProjectPaths = accumulatedProjectPaths,_collapsedProjectPaths = collapsedProjectPaths,_loadingProjectPaths = loadingProjectPaths,_exhaustedProjectPaths = exhaustedProjectPaths,_projectSessionDisplayLimits = projectSessionDisplayLimits,_pinnedSessionKeys = pinnedSessionKeys,_pinnedProjectPaths = pinnedProjectPaths;
   
 
 /// All sessions loaded from the server (including paginated results).
@@ -255,6 +257,8 @@ class _SessionListState implements SessionListState {
 @override@JsonKey() final  bool isLoadingMore;
 /// Initial loading (true until the first recent sessions response arrives).
 @override@JsonKey() final  bool isInitialLoading;
+/// The latest non-project recent-sessions request failed.
+@override@JsonKey() final  bool recentSessionsLoadFailed;
 /// Client-side text search query (bound to the TextField, sent to server
 /// after debounce).
 @override@JsonKey() final  String searchQuery;
@@ -340,16 +344,16 @@ _$SessionListStateCopyWith<_SessionListState> get copyWith => __$SessionListStat
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SessionListState&&const DeepCollectionEquality().equals(other._sessions, _sessions)&&(identical(other.hasMore, hasMore) || other.hasMore == hasMore)&&(identical(other.isLoadingMore, isLoadingMore) || other.isLoadingMore == isLoadingMore)&&(identical(other.isInitialLoading, isInitialLoading) || other.isInitialLoading == isInitialLoading)&&(identical(other.searchQuery, searchQuery) || other.searchQuery == searchQuery)&&const DeepCollectionEquality().equals(other._accumulatedProjectPaths, _accumulatedProjectPaths)&&const DeepCollectionEquality().equals(other._collapsedProjectPaths, _collapsedProjectPaths)&&const DeepCollectionEquality().equals(other._loadingProjectPaths, _loadingProjectPaths)&&const DeepCollectionEquality().equals(other._exhaustedProjectPaths, _exhaustedProjectPaths)&&const DeepCollectionEquality().equals(other._projectSessionDisplayLimits, _projectSessionDisplayLimits)&&const DeepCollectionEquality().equals(other._pinnedSessionKeys, _pinnedSessionKeys)&&const DeepCollectionEquality().equals(other._pinnedProjectPaths, _pinnedProjectPaths)&&(identical(other.providerFilter, providerFilter) || other.providerFilter == providerFilter)&&(identical(other.namedOnly, namedOnly) || other.namedOnly == namedOnly));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SessionListState&&const DeepCollectionEquality().equals(other._sessions, _sessions)&&(identical(other.hasMore, hasMore) || other.hasMore == hasMore)&&(identical(other.isLoadingMore, isLoadingMore) || other.isLoadingMore == isLoadingMore)&&(identical(other.isInitialLoading, isInitialLoading) || other.isInitialLoading == isInitialLoading)&&(identical(other.recentSessionsLoadFailed, recentSessionsLoadFailed) || other.recentSessionsLoadFailed == recentSessionsLoadFailed)&&(identical(other.searchQuery, searchQuery) || other.searchQuery == searchQuery)&&const DeepCollectionEquality().equals(other._accumulatedProjectPaths, _accumulatedProjectPaths)&&const DeepCollectionEquality().equals(other._collapsedProjectPaths, _collapsedProjectPaths)&&const DeepCollectionEquality().equals(other._loadingProjectPaths, _loadingProjectPaths)&&const DeepCollectionEquality().equals(other._exhaustedProjectPaths, _exhaustedProjectPaths)&&const DeepCollectionEquality().equals(other._projectSessionDisplayLimits, _projectSessionDisplayLimits)&&const DeepCollectionEquality().equals(other._pinnedSessionKeys, _pinnedSessionKeys)&&const DeepCollectionEquality().equals(other._pinnedProjectPaths, _pinnedProjectPaths)&&(identical(other.providerFilter, providerFilter) || other.providerFilter == providerFilter)&&(identical(other.namedOnly, namedOnly) || other.namedOnly == namedOnly));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_sessions),hasMore,isLoadingMore,isInitialLoading,searchQuery,const DeepCollectionEquality().hash(_accumulatedProjectPaths),const DeepCollectionEquality().hash(_collapsedProjectPaths),const DeepCollectionEquality().hash(_loadingProjectPaths),const DeepCollectionEquality().hash(_exhaustedProjectPaths),const DeepCollectionEquality().hash(_projectSessionDisplayLimits),const DeepCollectionEquality().hash(_pinnedSessionKeys),const DeepCollectionEquality().hash(_pinnedProjectPaths),providerFilter,namedOnly);
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_sessions),hasMore,isLoadingMore,isInitialLoading,recentSessionsLoadFailed,searchQuery,const DeepCollectionEquality().hash(_accumulatedProjectPaths),const DeepCollectionEquality().hash(_collapsedProjectPaths),const DeepCollectionEquality().hash(_loadingProjectPaths),const DeepCollectionEquality().hash(_exhaustedProjectPaths),const DeepCollectionEquality().hash(_projectSessionDisplayLimits),const DeepCollectionEquality().hash(_pinnedSessionKeys),const DeepCollectionEquality().hash(_pinnedProjectPaths),providerFilter,namedOnly);
 
 @override
 String toString() {
-  return 'SessionListState(sessions: $sessions, hasMore: $hasMore, isLoadingMore: $isLoadingMore, isInitialLoading: $isInitialLoading, searchQuery: $searchQuery, accumulatedProjectPaths: $accumulatedProjectPaths, collapsedProjectPaths: $collapsedProjectPaths, loadingProjectPaths: $loadingProjectPaths, exhaustedProjectPaths: $exhaustedProjectPaths, projectSessionDisplayLimits: $projectSessionDisplayLimits, pinnedSessionKeys: $pinnedSessionKeys, pinnedProjectPaths: $pinnedProjectPaths, providerFilter: $providerFilter, namedOnly: $namedOnly)';
+  return 'SessionListState(sessions: $sessions, hasMore: $hasMore, isLoadingMore: $isLoadingMore, isInitialLoading: $isInitialLoading, recentSessionsLoadFailed: $recentSessionsLoadFailed, searchQuery: $searchQuery, accumulatedProjectPaths: $accumulatedProjectPaths, collapsedProjectPaths: $collapsedProjectPaths, loadingProjectPaths: $loadingProjectPaths, exhaustedProjectPaths: $exhaustedProjectPaths, projectSessionDisplayLimits: $projectSessionDisplayLimits, pinnedSessionKeys: $pinnedSessionKeys, pinnedProjectPaths: $pinnedProjectPaths, providerFilter: $providerFilter, namedOnly: $namedOnly)';
 }
 
 
@@ -360,7 +364,7 @@ abstract mixin class _$SessionListStateCopyWith<$Res> implements $SessionListSta
   factory _$SessionListStateCopyWith(_SessionListState value, $Res Function(_SessionListState) _then) = __$SessionListStateCopyWithImpl;
 @override @useResult
 $Res call({
- List<RecentSession> sessions, bool hasMore, bool isLoadingMore, bool isInitialLoading, String searchQuery, Set<String> accumulatedProjectPaths, Set<String> collapsedProjectPaths, Set<String> loadingProjectPaths, Set<String> exhaustedProjectPaths, Map<String, int> projectSessionDisplayLimits, Set<String> pinnedSessionKeys, Set<String> pinnedProjectPaths, ProviderFilter providerFilter, bool namedOnly
+ List<RecentSession> sessions, bool hasMore, bool isLoadingMore, bool isInitialLoading, bool recentSessionsLoadFailed, String searchQuery, Set<String> accumulatedProjectPaths, Set<String> collapsedProjectPaths, Set<String> loadingProjectPaths, Set<String> exhaustedProjectPaths, Map<String, int> projectSessionDisplayLimits, Set<String> pinnedSessionKeys, Set<String> pinnedProjectPaths, ProviderFilter providerFilter, bool namedOnly
 });
 
 
@@ -377,12 +381,13 @@ class __$SessionListStateCopyWithImpl<$Res>
 
 /// Create a copy of SessionListState
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? sessions = null,Object? hasMore = null,Object? isLoadingMore = null,Object? isInitialLoading = null,Object? searchQuery = null,Object? accumulatedProjectPaths = null,Object? collapsedProjectPaths = null,Object? loadingProjectPaths = null,Object? exhaustedProjectPaths = null,Object? projectSessionDisplayLimits = null,Object? pinnedSessionKeys = null,Object? pinnedProjectPaths = null,Object? providerFilter = null,Object? namedOnly = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? sessions = null,Object? hasMore = null,Object? isLoadingMore = null,Object? isInitialLoading = null,Object? recentSessionsLoadFailed = null,Object? searchQuery = null,Object? accumulatedProjectPaths = null,Object? collapsedProjectPaths = null,Object? loadingProjectPaths = null,Object? exhaustedProjectPaths = null,Object? projectSessionDisplayLimits = null,Object? pinnedSessionKeys = null,Object? pinnedProjectPaths = null,Object? providerFilter = null,Object? namedOnly = null,}) {
   return _then(_SessionListState(
 sessions: null == sessions ? _self._sessions : sessions // ignore: cast_nullable_to_non_nullable
 as List<RecentSession>,hasMore: null == hasMore ? _self.hasMore : hasMore // ignore: cast_nullable_to_non_nullable
 as bool,isLoadingMore: null == isLoadingMore ? _self.isLoadingMore : isLoadingMore // ignore: cast_nullable_to_non_nullable
 as bool,isInitialLoading: null == isInitialLoading ? _self.isInitialLoading : isInitialLoading // ignore: cast_nullable_to_non_nullable
+as bool,recentSessionsLoadFailed: null == recentSessionsLoadFailed ? _self.recentSessionsLoadFailed : recentSessionsLoadFailed // ignore: cast_nullable_to_non_nullable
 as bool,searchQuery: null == searchQuery ? _self.searchQuery : searchQuery // ignore: cast_nullable_to_non_nullable
 as String,accumulatedProjectPaths: null == accumulatedProjectPaths ? _self._accumulatedProjectPaths : accumulatedProjectPaths // ignore: cast_nullable_to_non_nullable
 as Set<String>,collapsedProjectPaths: null == collapsedProjectPaths ? _self._collapsedProjectPaths : collapsedProjectPaths // ignore: cast_nullable_to_non_nullable

--- a/apps/mobile/lib/features/session_list/widgets/home_content.dart
+++ b/apps/mobile/lib/features/session_list/widgets/home_content.dart
@@ -83,6 +83,7 @@ class HomeContent extends StatefulWidget {
   final String searchQuery;
   final bool isLoadingMore;
   final bool isInitialLoading;
+  final bool recentSessionsLoadFailed;
   final bool hasMoreSessions;
   final Set<String> archivingSessionIds;
   final Set<String> unseenSessionIds;
@@ -119,6 +120,7 @@ class HomeContent extends StatefulWidget {
   final ValueChanged<SessionInfo>? onToggleRunningSessionPinned;
   final ValueChanged<String?> onSelectProject;
   final VoidCallback onLoadMore;
+  final VoidCallback? onRetryRecentSessions;
   final ValueChanged<String>? onLoadMoreProject;
   final ValueChanged<String>? onToggleProjectCollapsed;
   final ValueChanged<String>? onToggleProjectPinned;
@@ -154,6 +156,7 @@ class HomeContent extends StatefulWidget {
     required this.searchQuery,
     required this.isLoadingMore,
     required this.isInitialLoading,
+    this.recentSessionsLoadFailed = false,
     required this.hasMoreSessions,
     this.archivingSessionIds = const {},
     this.unseenSessionIds = const {},
@@ -174,6 +177,7 @@ class HomeContent extends StatefulWidget {
     this.onToggleRunningSessionPinned,
     required this.onSelectProject,
     required this.onLoadMore,
+    this.onRetryRecentSessions,
     this.onLoadMoreProject,
     this.onToggleProjectCollapsed,
     this.onToggleProjectPinned,
@@ -589,6 +593,29 @@ class HomeContentState extends State<HomeContent> {
         );
       }
 
+      if (widget.recentSessionsLoadFailed) {
+        return ListView(
+          keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+          physics: const AlwaysScrollableScrollPhysics(),
+          padding: const EdgeInsets.all(12),
+          children: [
+            if (isReconnecting) const SessionReconnectBanner(),
+            ?connectedBridgeBanner,
+            ?updateBanner,
+            ?supportBanner,
+            ?appUpdateBanner,
+            ?macOSNativeAppBanner,
+            SectionHeader(
+              icon: Icons.history,
+              label: l.recentSessions,
+              color: appColors.subtleText,
+            ),
+            const SizedBox(height: 8),
+            _RecentSessionsLoadError(onRetry: widget.onRetryRecentSessions),
+          ],
+        );
+      }
+
       return ListView(
         keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
         physics: const AlwaysScrollableScrollPhysics(),
@@ -801,8 +828,11 @@ class HomeContentState extends State<HomeContent> {
               ],
             )
           else ...[
-            if ((!_groupRecentSessions && filteredSessions.isEmpty) ||
-                (_groupRecentSessions && groupedRecentSessions.isEmpty))
+            if (widget.recentSessionsLoadFailed)
+              _RecentSessionsLoadError(onRetry: widget.onRetryRecentSessions),
+            if (((!_groupRecentSessions && filteredSessions.isEmpty) ||
+                    (_groupRecentSessions && groupedRecentSessions.isEmpty)) &&
+                !widget.recentSessionsLoadFailed)
               _RecentSessionsEmptyResult(
                 title: hasActiveFilter
                     ? l.noSessionsMatchFilters
@@ -879,6 +909,46 @@ class HomeContentState extends State<HomeContent> {
           ],
         ],
       ],
+    );
+  }
+}
+
+class _RecentSessionsLoadError extends StatelessWidget {
+  final VoidCallback? onRetry;
+
+  const _RecentSessionsLoadError({this.onRetry});
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    final cs = Theme.of(context).colorScheme;
+    return Container(
+      key: const ValueKey('recent_sessions_load_error'),
+      width: double.infinity,
+      margin: const EdgeInsets.only(bottom: 8),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: BoxDecoration(
+        color: cs.errorContainer.withValues(alpha: 0.35),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: [
+          Icon(Icons.error_outline, size: 18, color: cs.error),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              l.recentSessionsLoadFailed,
+              style: TextStyle(fontSize: 13, color: cs.onSurface),
+            ),
+          ),
+          if (onRetry != null)
+            TextButton(
+              key: const ValueKey('retry_recent_sessions_button'),
+              onPressed: onRetry,
+              child: Text(l.retry),
+            ),
+        ],
+      ),
     );
   }
 }

--- a/apps/mobile/lib/l10n/app_en.arb
+++ b/apps/mobile/lib/l10n/app_en.arb
@@ -847,6 +847,7 @@
     }
   },
   "retry": "Retry",
+  "recentSessionsLoadFailed": "Recent sessions didn’t load. Check the connection and try again.",
 
   "clipboardNotAvailable": "Cannot access clipboard",
   "failedToLoadImage": "Failed to load image",

--- a/apps/mobile/lib/l10n/app_ja.arb
+++ b/apps/mobile/lib/l10n/app_ja.arb
@@ -877,6 +877,7 @@
     }
   },
   "retry": "リトライ",
+  "recentSessionsLoadFailed": "最近のセッションを読み込めませんでした。接続を確認して再試行してください。",
 
   "clipboardNotAvailable": "クリップボードにアクセスできません",
   "failedToLoadImage": "画像の読み込みに失敗しました",

--- a/apps/mobile/lib/l10n/app_ko.arb
+++ b/apps/mobile/lib/l10n/app_ko.arb
@@ -790,6 +790,7 @@
     }
   },
   "retry": "재시도",
+  "recentSessionsLoadFailed": "최근 세션을 불러오지 못했습니다. 연결을 확인하고 다시 시도하세요.",
   "clipboardNotAvailable": "클립보드를 사용할 수 없습니다",
   "failedToLoadImage": "이미지 로드 실패",
   "generatedImagePromptLabel": "프롬프트",

--- a/apps/mobile/lib/l10n/app_localizations.dart
+++ b/apps/mobile/lib/l10n/app_localizations.dart
@@ -3972,6 +3972,12 @@ abstract class AppLocalizations {
   /// **'リトライ'**
   String get retry;
 
+  /// No description provided for @recentSessionsLoadFailed.
+  ///
+  /// In ja, this message translates to:
+  /// **'最近のセッションを読み込めませんでした。接続を確認して再試行してください。'**
+  String get recentSessionsLoadFailed;
+
   /// No description provided for @clipboardNotAvailable.
   ///
   /// In ja, this message translates to:

--- a/apps/mobile/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/lib/l10n/app_localizations_en.dart
@@ -2179,6 +2179,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get retry => 'Retry';
 
   @override
+  String get recentSessionsLoadFailed =>
+      'Recent sessions didn’t load. Check the connection and try again.';
+
+  @override
   String get clipboardNotAvailable => 'Cannot access clipboard';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_ja.dart
+++ b/apps/mobile/lib/l10n/app_localizations_ja.dart
@@ -2103,6 +2103,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get retry => 'リトライ';
 
   @override
+  String get recentSessionsLoadFailed =>
+      '最近のセッションを読み込めませんでした。接続を確認して再試行してください。';
+
+  @override
   String get clipboardNotAvailable => 'クリップボードにアクセスできません';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_ko.dart
+++ b/apps/mobile/lib/l10n/app_localizations_ko.dart
@@ -2117,6 +2117,10 @@ class AppLocalizationsKo extends AppLocalizations {
   String get retry => '재시도';
 
   @override
+  String get recentSessionsLoadFailed =>
+      '최근 세션을 불러오지 못했습니다. 연결을 확인하고 다시 시도하세요.';
+
+  @override
   String get clipboardNotAvailable => '클립보드를 사용할 수 없습니다';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_zh.dart
+++ b/apps/mobile/lib/l10n/app_localizations_zh.dart
@@ -2078,6 +2078,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get retry => '重试';
 
   @override
+  String get recentSessionsLoadFailed => '无法加载最近的会话。请检查连接后重试。';
+
+  @override
   String get clipboardNotAvailable => '无法访问剪贴板';
 
   @override

--- a/apps/mobile/lib/l10n/app_zh.arb
+++ b/apps/mobile/lib/l10n/app_zh.arb
@@ -917,6 +917,7 @@
     }
   },
   "retry": "重试",
+  "recentSessionsLoadFailed": "无法加载最近的会话。请检查连接后重试。",
 
   "clipboardNotAvailable": "无法访问剪贴板",
   "failedToLoadImage": "加载图片失败",

--- a/apps/mobile/lib/models/messages.dart
+++ b/apps/mobile/lib/models/messages.dart
@@ -858,6 +858,8 @@ sealed class ServerMessage {
         toolUseId: json['toolUseId'] as String?,
         path: json['path'] as String?,
         requestId: json['requestId'] as String?,
+        requestScope: json['requestScope'] as String?,
+        offset: json['offset'] as int?,
       ),
       'push_registration_result' => PushRegistrationResultMessage(
         token: json['token'] as String,
@@ -993,6 +995,7 @@ sealed class ServerMessage {
         offset: json['offset'] as int?,
         projectPath: json['projectPath'] as String?,
         requestScope: json['requestScope'] as String?,
+        requestId: json['requestId'] as String?,
       ),
       'past_history' => PastHistoryMessage(
         claudeSessionId: json['claudeSessionId'] as String? ?? '',
@@ -1630,6 +1633,8 @@ class ErrorMessage implements ServerMessage {
   final String? toolUseId;
   final String? path;
   final String? requestId;
+  final String? requestScope;
+  final int? offset;
 
   const ErrorMessage({
     required this.message,
@@ -1638,6 +1643,8 @@ class ErrorMessage implements ServerMessage {
     this.toolUseId,
     this.path,
     this.requestId,
+    this.requestScope,
+    this.offset,
   });
 }
 
@@ -2445,6 +2452,7 @@ class RecentSessionsMessage implements ServerMessage {
   final int? offset;
   final String? projectPath;
   final String? requestScope;
+  final String? requestId;
   const RecentSessionsMessage({
     required this.sessions,
     this.hasMore = false,
@@ -2452,6 +2460,7 @@ class RecentSessionsMessage implements ServerMessage {
     this.offset,
     this.projectPath,
     this.requestScope,
+    this.requestId,
   });
 }
 
@@ -4328,6 +4337,7 @@ class ClientMessage {
     int? offset,
     String? projectPath,
     String? requestScope,
+    String? requestId,
     String? provider,
     bool? namedOnly,
     String? searchQuery,
@@ -4338,6 +4348,7 @@ class ClientMessage {
       'offset': ?offset,
       'projectPath': ?projectPath,
       'requestScope': ?requestScope,
+      'requestId': ?requestId,
       'provider': ?provider,
       'namedOnly': ?namedOnly,
       'searchQuery': ?searchQuery,

--- a/apps/mobile/lib/services/bridge_service.dart
+++ b/apps/mobile/lib/services/bridge_service.dart
@@ -148,6 +148,9 @@ class BridgeService implements BridgeServiceBase {
   final Set<({String? sessionId, String toolUseId})>
   _inFlightNonReplayableToolActions = {};
   int _nextSessionLinkRequestId = 0;
+  int _nextRecentSessionsRequestId = 0;
+  final Map<String, _PendingRecentSessionsRequest>
+  _pendingRecentSessionsRequests = {};
   final Map<String, Set<String>> _respondedToolUseIds = {};
   List<OfflinePendingAction> _offlinePendingActions = const [];
 
@@ -277,7 +280,9 @@ class BridgeService implements BridgeServiceBase {
   List<OfflinePendingAction> get offlinePendingActions =>
       _offlinePendingActions;
 
-  BridgeService() {
+  BridgeService({
+    this.recentSessionsRequestTimeout = const Duration(seconds: 10),
+  }) {
     unawaited(_ensureOfflineQueueRestored());
   }
 
@@ -358,6 +363,7 @@ class BridgeService implements BridgeServiceBase {
   static const _prefKeyOfflinePendingMessages =
       'bridge_offline_pending_messages_v1';
   static const _inFlightPendingVisibilityDelay = Duration(milliseconds: 600);
+  final Duration recentSessionsRequestTimeout;
 
   Future<void>? _offlineQueueRestore;
   int _offlineQueueGeneration = 0;
@@ -419,6 +425,11 @@ class BridgeService implements BridgeServiceBase {
             }
             _clearDeliveredDeliveryPendingInput(msg, sessionId: sessionId);
             _clearDeliveredInFlightInput(msg, sessionId: sessionId);
+            if (msg is ErrorMessage &&
+                msg.errorCode == 'recent_sessions_failed' &&
+                !_acceptRecentSessionsFailure(msg)) {
+              return;
+            }
             switch (msg) {
               case SessionListMessage(
                 :final sessions,
@@ -448,6 +459,7 @@ class BridgeService implements BridgeServiceBase {
                 _codexAutoReviewPolicyController.add(codexAutoReviewDisabled);
                 _bridgeVersion = bridgeVersion;
               case RecentSessionsMessage(:final sessions, :final hasMore):
+                if (!_acceptRecentSessionsResponse(msg)) return;
                 _lastRecentSessionsMessage = msg;
                 final isProjectMerge =
                     msg.requestScope == 'project' &&
@@ -460,7 +472,8 @@ class BridgeService implements BridgeServiceBase {
                   );
                 } else {
                   _recentSessionsHasMore = hasMore;
-                  if (_appendMode) {
+                  final shouldAppend = (msg.offset ?? 0) > 0 || _appendMode;
+                  if (shouldAppend) {
                     _recentSessions = _mergeRecentSessions(
                       _recentSessions,
                       sessions,
@@ -739,6 +752,10 @@ class BridgeService implements BridgeServiceBase {
     _lastRecentSessionsMessage = null;
     _recentSessionsHasMore = false;
     _appendMode = false;
+    for (final pending in _pendingRecentSessionsRequests.values) {
+      pending.timeoutTimer?.cancel();
+    }
+    _pendingRecentSessionsRequests.clear();
     _currentProjectFilter = null;
     _galleryImages = const [];
     _projectHistory = const [];
@@ -1829,19 +1846,120 @@ class BridgeService implements BridgeServiceBase {
     }
   }
 
-  void requestRecentSessions({int? limit, int? offset, String? projectPath}) {
-    if (offset == null || offset == 0) {
-      _appendMode = false;
-    }
+  String _recentSessionsScopeKey({
+    required String requestScope,
+    String? projectPath,
+  }) => requestScope == 'project' ? 'project:${projectPath ?? ''}' : 'list';
+
+  bool _acceptRecentSessionsResponse(RecentSessionsMessage message) {
+    return _acceptRecentSessionsResult(
+      requestScope: message.requestScope ?? 'list',
+      projectPath: message.projectPath,
+      requestId: message.requestId,
+    );
+  }
+
+  bool _acceptRecentSessionsFailure(ErrorMessage message) {
+    return _acceptRecentSessionsResult(
+      requestScope: message.requestScope ?? 'list',
+      projectPath: message.path,
+      requestId: message.requestId,
+    );
+  }
+
+  bool _acceptRecentSessionsResult({
+    required String requestScope,
+    required String? projectPath,
+    required String? requestId,
+  }) {
+    final scopeKey = _recentSessionsScopeKey(
+      requestScope: requestScope,
+      projectPath: projectPath,
+    );
+    final pending = _pendingRecentSessionsRequests[scopeKey];
+    if (pending == null) return true;
+    if (requestId != null && requestId != pending.requestId) return false;
+    pending.timeoutTimer?.cancel();
+    _pendingRecentSessionsRequests.remove(scopeKey);
+    return true;
+  }
+
+  void _sendRecentSessionsRequest({
+    required int? limit,
+    required int? offset,
+    required String? projectPath,
+    required String requestScope,
+    required String? provider,
+    required bool? namedOnly,
+    required String? searchQuery,
+  }) {
+    final scopeKey = _recentSessionsScopeKey(
+      requestScope: requestScope,
+      projectPath: projectPath,
+    );
+    final queryKey = jsonEncode([
+      limit,
+      offset,
+      projectPath,
+      requestScope,
+      provider,
+      namedOnly,
+      searchQuery,
+    ]);
+    final existing = _pendingRecentSessionsRequests[scopeKey];
+    if (existing?.queryKey == queryKey) return;
+    existing?.timeoutTimer?.cancel();
+
+    final requestId = 'recent-${++_nextRecentSessionsRequestId}';
+    final pending = _PendingRecentSessionsRequest(
+      requestId: requestId,
+      queryKey: queryKey,
+    );
+    _pendingRecentSessionsRequests[scopeKey] = pending;
+    pending.timeoutTimer = Timer(recentSessionsRequestTimeout, () {
+      if (!identical(_pendingRecentSessionsRequests[scopeKey], pending)) {
+        return;
+      }
+      _pendingRecentSessionsRequests.remove(scopeKey);
+      if (requestScope != 'project') _appendMode = false;
+      final error = ErrorMessage(
+        message: 'Recent sessions did not load in time',
+        errorCode: 'recent_sessions_failed',
+        path: projectPath,
+        requestId: requestId,
+        requestScope: requestScope,
+        offset: offset,
+      );
+      _taggedMessageController.add((error, null));
+      _messageController.add(error);
+    });
+
     send(
       ClientMessage.listRecentSessions(
         limit: limit,
         offset: offset,
         projectPath: projectPath,
-        provider: _currentProvider,
-        namedOnly: _currentNamedOnly,
-        searchQuery: _currentSearchQuery,
+        requestScope: requestScope,
+        requestId: requestId,
+        provider: provider,
+        namedOnly: namedOnly,
+        searchQuery: searchQuery,
       ),
+    );
+  }
+
+  void requestRecentSessions({int? limit, int? offset, String? projectPath}) {
+    if (offset == null || offset == 0) {
+      _appendMode = false;
+    }
+    _sendRecentSessionsRequest(
+      limit: limit,
+      offset: offset,
+      projectPath: projectPath,
+      requestScope: 'list',
+      provider: _currentProvider,
+      namedOnly: _currentNamedOnly,
+      searchQuery: _currentSearchQuery,
     );
   }
 
@@ -1854,16 +1972,14 @@ class BridgeService implements BridgeServiceBase {
   }) {
     final requestedProjectPath = projectPath ?? _currentProjectFilter;
     _appendMode = true;
-    send(
-      ClientMessage.listRecentSessions(
-        limit: pageSize,
-        offset: offset ?? _recentSessions.length,
-        projectPath: requestedProjectPath,
-        requestScope: requestScope,
-        provider: _currentProvider,
-        namedOnly: _currentNamedOnly,
-        searchQuery: _currentSearchQuery,
-      ),
+    _sendRecentSessionsRequest(
+      limit: pageSize,
+      offset: offset ?? _recentSessions.length,
+      projectPath: requestedProjectPath,
+      requestScope: requestScope,
+      provider: _currentProvider,
+      namedOnly: _currentNamedOnly,
+      searchQuery: _currentSearchQuery,
     );
   }
 
@@ -1872,15 +1988,14 @@ class BridgeService implements BridgeServiceBase {
   void switchProjectFilter(String? projectPath, {int pageSize = 20}) {
     _currentProjectFilter = projectPath;
     _appendMode = false;
-    send(
-      ClientMessage.listRecentSessions(
-        limit: pageSize,
-        offset: 0,
-        projectPath: projectPath,
-        provider: _currentProvider,
-        namedOnly: _currentNamedOnly,
-        searchQuery: _currentSearchQuery,
-      ),
+    _sendRecentSessionsRequest(
+      limit: pageSize,
+      offset: 0,
+      projectPath: projectPath,
+      requestScope: 'list',
+      provider: _currentProvider,
+      namedOnly: _currentNamedOnly,
+      searchQuery: _currentSearchQuery,
     );
   }
 
@@ -1897,15 +2012,14 @@ class BridgeService implements BridgeServiceBase {
     _currentNamedOnly = namedOnly;
     _currentSearchQuery = searchQuery;
     _appendMode = false;
-    send(
-      ClientMessage.listRecentSessions(
-        limit: pageSize,
-        offset: 0,
-        projectPath: projectPath,
-        provider: provider,
-        namedOnly: namedOnly,
-        searchQuery: searchQuery,
-      ),
+    _sendRecentSessionsRequest(
+      limit: pageSize,
+      offset: 0,
+      projectPath: projectPath,
+      requestScope: 'list',
+      provider: provider,
+      namedOnly: namedOnly,
+      searchQuery: searchQuery,
     );
   }
 
@@ -2769,6 +2883,10 @@ class BridgeService implements BridgeServiceBase {
       const SessionLinkResolveResult.unavailable(),
     );
     _reconnectTimer?.cancel();
+    for (final pending in _pendingRecentSessionsRequests.values) {
+      pending.timeoutTimer?.cancel();
+    }
+    _pendingRecentSessionsRequests.clear();
     for (final timer in _inFlightPendingVisibilityTimers.values) {
       timer.cancel();
     }
@@ -2832,6 +2950,17 @@ class _DeliveryPendingInputState {
 
   final QueuedInputItem item;
   bool visible = false;
+}
+
+class _PendingRecentSessionsRequest {
+  _PendingRecentSessionsRequest({
+    required this.requestId,
+    required this.queryKey,
+  });
+
+  final String requestId;
+  final String queryKey;
+  Timer? timeoutTimer;
 }
 
 /// Cached diff image data for a single file.

--- a/apps/mobile/test/home_content_skeleton_test.dart
+++ b/apps/mobile/test/home_content_skeleton_test.dart
@@ -98,6 +98,8 @@ Widget _buildHomeContent({
   String? currentProjectFilter,
   bool hasMoreSessions = false,
   bool isInitialLoading = false,
+  bool recentSessionsLoadFailed = false,
+  VoidCallback? onRetryRecentSessions,
   bool showMacOSNativeAppBanner = false,
   VoidCallback? onDismissMacOSNativeAppBanner,
   required SessionListCubit cubit,
@@ -132,6 +134,7 @@ Widget _buildHomeContent({
             searchQuery: '',
             isLoadingMore: false,
             isInitialLoading: isInitialLoading,
+            recentSessionsLoadFailed: recentSessionsLoadFailed,
             hasMoreSessions: hasMoreSessions,
             currentProjectFilter: currentProjectFilter,
             onNewSession: () {},
@@ -153,6 +156,7 @@ Widget _buildHomeContent({
             onLongPressRunningSession: (_, _) {},
             onSelectProject: (_) {},
             onLoadMore: () {},
+            onRetryRecentSessions: onRetryRecentSessions,
             onLoadMoreProject: (_) {},
             providerFilter: ProviderFilter.all,
             namedOnly: false,
@@ -253,6 +257,35 @@ void main() {
       expect(find.byType(SkeletonizerScope), findsNothing);
       // Empty state should show the "New Session" button
       expect(find.text('New Session'), findsOneWidget);
+    });
+
+    testWidgets('replaces a timed-out skeleton with a retry action', (
+      tester,
+    ) async {
+      var retried = false;
+      await tester.pumpWidget(
+        _buildHomeContent(
+          recentSessions: const [],
+          isInitialLoading: false,
+          recentSessionsLoadFailed: true,
+          onRetryRecentSessions: () => retried = true,
+          cubit: cubit,
+          draftService: draftService,
+          revenueCatService: revenueCatService,
+          supportBannerService: supportBannerService,
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byType(SkeletonizerScope), findsNothing);
+      expect(
+        find.byKey(const ValueKey('recent_sessions_load_error')),
+        findsOneWidget,
+      );
+      await tester.tap(
+        find.byKey(const ValueKey('retry_recent_sessions_button')),
+      );
+      expect(retried, isTrue);
     });
 
     testWidgets('shows real session cards (not skeleton) when sessions exist '

--- a/apps/mobile/test/services/bridge_service_usage_test.dart
+++ b/apps/mobile/test/services/bridge_service_usage_test.dart
@@ -86,6 +86,59 @@ void main() {
       },
     );
 
+    test('duplicate recent-session requests share one request and time out visibly', () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      final socketReady = Completer<WebSocket>();
+      final requests = <Map<String, dynamic>>[];
+      server.transform(WebSocketTransformer()).listen((socket) {
+        socketReady.complete(socket);
+        socket.listen((data) {
+          final message = jsonDecode(data as String) as Map<String, dynamic>;
+          if (message['type'] == 'list_recent_sessions') {
+            requests.add(message);
+          }
+        });
+      });
+
+      final bridge = BridgeService(
+        recentSessionsRequestTimeout: const Duration(milliseconds: 80),
+      );
+      final timeoutError = bridge.messages
+          .where((message) => message is ErrorMessage)
+          .cast<ErrorMessage>()
+          .firstWhere(
+            (message) => message.errorCode == 'recent_sessions_failed',
+          );
+      final connected = bridge.connectionStatus.firstWhere(
+        (state) => state == BridgeConnectionState.connected,
+      );
+      bridge.connect('ws://127.0.0.1:${server.port}');
+      final socket = await socketReady.future;
+      await connected.timeout(const Duration(seconds: 2));
+
+      bridge.requestRecentSessions(limit: 20, offset: 0);
+      bridge.requestRecentSessions(limit: 20, offset: 0);
+      for (var i = 0; i < 50 && requests.isEmpty; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }
+      expect(requests, hasLength(1));
+      expect(requests.single['requestId'], isA<String>());
+
+      final error = await timeoutError.timeout(const Duration(seconds: 2));
+      expect(error.requestId, requests.single['requestId']);
+
+      bridge.requestRecentSessions(limit: 20, offset: 0);
+      for (var i = 0; i < 50 && requests.length < 2; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }
+      expect(requests, hasLength(2));
+
+      bridge.disconnect();
+      await socket.close();
+      await server.close(force: true);
+      bridge.dispose();
+    });
+
     test('disconnect clears last usage result cache', () async {
       final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
       final sockets = <WebSocket>[];

--- a/apps/mobile/test/session_list_cubit_test.dart
+++ b/apps/mobile/test/session_list_cubit_test.dart
@@ -13,6 +13,7 @@ class MockBridgeService extends BridgeService {
   final _recentSessionsController =
       StreamController<List<RecentSession>>.broadcast();
   final _projectHistoryController = StreamController<List<String>>.broadcast();
+  final _messagesController = StreamController<ServerMessage>.broadcast();
   final sentMessages = <ClientMessage>[];
 
   bool _hasMore = false;
@@ -26,6 +27,9 @@ class MockBridgeService extends BridgeService {
   @override
   Stream<List<String>> get projectHistoryStream =>
       _projectHistoryController.stream;
+
+  @override
+  Stream<ServerMessage> get messages => _messagesController.stream;
 
   @override
   bool get recentSessionsHasMore => _hasMore;
@@ -63,6 +67,17 @@ class MockBridgeService extends BridgeService {
 
   void emitProjectHistory(List<String> paths) {
     _projectHistoryController.add(paths);
+  }
+
+  void emitRecentSessionsError({String? projectPath, String? requestScope}) {
+    _messagesController.add(
+      ErrorMessage(
+        message: 'Failed to list recent sessions',
+        errorCode: 'recent_sessions_failed',
+        path: projectPath,
+        requestScope: requestScope,
+      ),
+    );
   }
 
   @override
@@ -134,6 +149,7 @@ class MockBridgeService extends BridgeService {
   void dispose() {
     _recentSessionsController.close();
     _projectHistoryController.close();
+    _messagesController.close();
   }
 }
 
@@ -439,6 +455,41 @@ void main() {
     });
 
     test(
+      'initial recent-session failure exits the skeleton with retry state',
+      () async {
+        expect(cubit.state.isInitialLoading, isTrue);
+
+        mockBridge.emitRecentSessionsError();
+        await Future.microtask(() {});
+
+        expect(cubit.state.isInitialLoading, isFalse);
+        expect(cubit.state.recentSessionsLoadFailed, isTrue);
+
+        mockBridge.sentMessages.clear();
+        cubit.retryRecentSessions();
+
+        expect(cubit.state.isInitialLoading, isTrue);
+        expect(cubit.state.recentSessionsLoadFailed, isFalse);
+        expect(mockBridge.sentMessages, hasLength(1));
+      },
+    );
+
+    test('pagination failure preserves rows and restores load more', () async {
+      mockBridge.emitSessions([_session(id: 's1')], hasMore: true);
+      await Future.microtask(() {});
+      cubit.loadMore();
+      expect(cubit.state.isLoadingMore, isTrue);
+
+      mockBridge.emitRecentSessionsError();
+      await Future.microtask(() {});
+
+      expect(cubit.state.sessions.single.sessionId, 's1');
+      expect(cubit.state.hasMore, isTrue);
+      expect(cubit.state.isLoadingMore, isFalse);
+      expect(cubit.state.recentSessionsLoadFailed, isTrue);
+    });
+
+    test(
       'loadMoreProject requests project-scoped page from current count',
       () async {
         mockBridge.emitSessions([
@@ -490,6 +541,25 @@ void main() {
         expect(cubit.state.exhaustedProjectPaths, contains('/a/proj1'));
       },
     );
+
+    test('project failure clears only that project loading state', () async {
+      mockBridge.emitSessions([
+        _session(id: 's1', projectPath: '/a/proj1'),
+      ], hasMore: true);
+      await Future.microtask(() {});
+      cubit.loadMoreProject('/a/proj1');
+      expect(cubit.state.loadingProjectPaths, contains('/a/proj1'));
+
+      mockBridge.emitRecentSessionsError(
+        projectPath: '/a/proj1',
+        requestScope: 'project',
+      );
+      await Future.microtask(() {});
+
+      expect(cubit.state.sessions.single.sessionId, 's1');
+      expect(cubit.state.loadingProjectPaths, isNot(contains('/a/proj1')));
+      expect(cubit.state.recentSessionsLoadFailed, isFalse);
+    });
 
     test('toggleProjectCollapsed persists collapsed project path', () async {
       cubit.toggleProjectCollapsed('/a/proj1');

--- a/packages/bridge/src/parser.ts
+++ b/packages/bridge/src/parser.ts
@@ -233,6 +233,7 @@ export type ClientMessage =
       offset?: number;
       projectPath?: string;
       requestScope?: "list" | "project";
+      requestId?: string;
       provider?: "claude" | "codex";
       namedOnly?: boolean;
       searchQuery?: string;
@@ -553,6 +554,8 @@ export type ServerMessage =
       toolUseId?: string;
       path?: string;
       requestId?: string;
+      requestScope?: "list" | "project";
+      offset?: number;
     }
   | {
       type: "push_registration_result";

--- a/packages/bridge/src/websocket.test.ts
+++ b/packages/bridge/src/websocket.test.ts
@@ -1094,6 +1094,104 @@ describe("BridgeWebSocketServer resume/get_history flow", () => {
     bridge.close();
   });
 
+  it("shares identical recent-session scans without clients cancelling each other", async () => {
+    const bridge = new BridgeWebSocketServer({ server: httpServer });
+    const firstClient = {
+      readyState: OPEN_STATE,
+      send: vi.fn(),
+    } as any;
+    const secondClient = {
+      readyState: OPEN_STATE,
+      send: vi.fn(),
+    } as any;
+    let resolveScan!: (value: {
+      sessions: any[];
+      hasMore: boolean;
+    }) => void;
+    const scan = new Promise<{ sessions: any[]; hasMore: boolean }>(
+      (resolve) => {
+        resolveScan = resolve;
+      },
+    );
+    getAllRecentSessionsMock.mockReturnValue(scan);
+
+    const request = {
+      type: "list_recent_sessions",
+      limit: 20,
+      offset: 0,
+      provider: "claude",
+    };
+    void (bridge as any).handleClientMessage(request, firstClient);
+    void (bridge as any).handleClientMessage(request, secondClient);
+    await Promise.resolve();
+
+    expect(getAllRecentSessionsMock).toHaveBeenCalledTimes(1);
+
+    resolveScan({
+      sessions: [{ sessionId: "shared-result", projectPath: "/tmp/project" }],
+      hasMore: false,
+    });
+    await vi.waitFor(() => {
+      expect(
+        firstClient.send.mock.calls
+          .map((call: unknown[]) => JSON.parse(call[0] as string))
+          .some((message: any) => message.type === "recent_sessions"),
+      ).toBe(true);
+      expect(
+        secondClient.send.mock.calls
+          .map((call: unknown[]) => JSON.parse(call[0] as string))
+          .some((message: any) => message.type === "recent_sessions"),
+      ).toBe(true);
+    });
+
+    bridge.close();
+  });
+
+  it("returns correlated recent-session failures so loading UI can recover", async () => {
+    const bridge = new BridgeWebSocketServer({ server: httpServer });
+    const ws = {
+      readyState: OPEN_STATE,
+      send: vi.fn(),
+    } as any;
+    getAllRecentSessionsMock.mockRejectedValueOnce(new Error("scan failed"));
+
+    void (bridge as any).handleClientMessage(
+      {
+        type: "list_recent_sessions",
+        limit: 20,
+        offset: 40,
+        projectPath: "/tmp/project",
+        requestScope: "project",
+        requestId: "recent-failure-1",
+        provider: "claude",
+      },
+      ws,
+    );
+
+    await vi.waitFor(() => {
+      expect(
+        ws.send.mock.calls
+          .map((call: unknown[]) => JSON.parse(call[0] as string))
+          .some((message: any) =>
+            message.errorCode === "recent_sessions_failed"
+          ),
+      ).toBe(true);
+    });
+    const error = ws.send.mock.calls
+      .map((call: unknown[]) => JSON.parse(call[0] as string))
+      .find((message: any) => message.errorCode === "recent_sessions_failed");
+    expect(error).toMatchObject({
+      type: "error",
+      errorCode: "recent_sessions_failed",
+      path: "/tmp/project",
+      requestScope: "project",
+      offset: 40,
+      requestId: "recent-failure-1",
+    });
+
+    bridge.close();
+  });
+
   it("sends codex model list without deprecated models", () => {
     const bridge = new BridgeWebSocketServer({ server: httpServer });
     const ws = {

--- a/packages/bridge/src/websocket.ts
+++ b/packages/bridge/src/websocket.ts
@@ -706,7 +706,11 @@ export class BridgeWebSocketServer {
   private promptHistoryBackup: PromptHistoryBackupStore | null;
   private promptHistoryStore: PromptHistoryStore | null;
 
-  private recentSessionsRequestId = 0;
+  private recentSessionsRequestIds = new WeakMap<WebSocket, number>();
+  private recentSessionsInFlight = new Map<
+    string,
+    Promise<{ sessions: unknown[]; hasMore: boolean }>
+  >();
   private debugEvents = new Map<string, DebugTraceEvent[]>();
   private notifiedPermissionToolUses = new Map<string, Set<string>>();
   private archiveStore: ArchiveStore;
@@ -4576,13 +4580,17 @@ export class BridgeWebSocketServer {
 
       case "list_recent_sessions": {
         const isProjectScopedRequest = msg.requestScope === "project";
+        const currentRequestId = this.recentSessionsRequestIds.get(ws) ?? 0;
         const requestId = isProjectScopedRequest
-          ? this.recentSessionsRequestId
-          : ++this.recentSessionsRequestId;
-        this.listRecentSessions(msg)
+          ? currentRequestId
+          : currentRequestId + 1;
+        if (!isProjectScopedRequest) {
+          this.recentSessionsRequestIds.set(ws, requestId);
+        }
+        this.listRecentSessionsCoalesced(msg)
           .then(({ sessions, hasMore }) => {
             // Drop stale responses when rapid filter switches cause out-of-order completion
-            if (requestId !== this.recentSessionsRequestId) {
+            if (requestId !== (this.recentSessionsRequestIds.get(ws) ?? 0)) {
               return;
             }
             this.send(ws, {
@@ -4593,15 +4601,21 @@ export class BridgeWebSocketServer {
               offset: msg.offset,
               projectPath: msg.projectPath,
               requestScope: msg.requestScope,
+              requestId: msg.requestId,
             } as Record<string, unknown>);
           })
           .catch((err) => {
-            if (requestId !== this.recentSessionsRequestId) {
+            if (requestId !== (this.recentSessionsRequestIds.get(ws) ?? 0)) {
               return;
             }
             this.send(ws, {
               type: "error",
               message: `Failed to list recent sessions: ${err}`,
+              errorCode: "recent_sessions_failed",
+              path: msg.projectPath,
+              requestId: msg.requestId,
+              requestScope: msg.requestScope,
+              offset: msg.offset,
             });
           });
         break;
@@ -7221,6 +7235,37 @@ export class BridgeWebSocketServer {
       searchQuery: msg.searchQuery,
       archivedSessionIds: this.archiveStore.archivedIds(),
     });
+  }
+
+  private listRecentSessionsCoalesced(
+    msg: Extract<ClientMessage, { type: "list_recent_sessions" }>,
+  ): Promise<{ sessions: unknown[]; hasMore: boolean }> {
+    const key = JSON.stringify({
+      limit: msg.limit ?? null,
+      offset: msg.offset ?? null,
+      projectPath: msg.projectPath ?? null,
+      provider: msg.provider ?? null,
+      namedOnly: msg.namedOnly ?? null,
+      searchQuery: msg.searchQuery ?? null,
+    });
+    const existing = this.recentSessionsInFlight.get(key);
+    if (existing) return existing;
+
+    const request = this.listRecentSessions(msg);
+    this.recentSessionsInFlight.set(key, request);
+    request.then(
+      () => {
+        if (this.recentSessionsInFlight.get(key) === request) {
+          this.recentSessionsInFlight.delete(key);
+        }
+      },
+      () => {
+        if (this.recentSessionsInFlight.get(key) === request) {
+          this.recentSessionsInFlight.delete(key);
+        }
+      },
+    );
+    return request;
   }
 
   private async listRecentAllProviderSessions(


### PR DESCRIPTION
## Summary

- keep one client's Recent Sessions refresh from cancelling another client's scan
- share identical in-flight Bridge scans instead of repeating the same expensive work
- correlate list responses and failures so stale results cannot replace a newer request
- stop the Android loading skeleton after 10 seconds and show a clear Retry action
- preserve existing rows when pagination fails

## Scope note

The repeated full Bridge reconnects seen after reinstall were traced to Android battery optimization being reset. That setup issue is intentionally not addressed with a risky socket-policy change in this PR.

## Verification

- 7 focused Bridge recent-session tests passed
- 93 focused Flutter service, state, and widget tests passed
- full Bridge test suite and TypeScript checking passed
- full Flutter suite passed
- Dart analysis completed with no errors