### PR TITLE
fix(markdown): add code block copy control

### DIFF
--- a/apps/mobile/lib/theme/markdown_style.dart
+++ b/apps/mobile/lib/theme/markdown_style.dart
@@ -251,43 +251,76 @@ class FencedCodeBlockBuilder extends MarkdownElementBuilder {
         borderRadius: BorderRadius.circular(8),
         border: Border.all(color: appColors.codeBorder),
       ),
-      child: GestureDetector(
-        key: ValueKey('code_block_copy_target_$displayLanguage'),
-        behavior: HitTestBehavior.opaque,
-        onLongPress: () => _copyCodeBlock(context, source),
-        child: Stack(
-          children: [
-            SingleChildScrollView(
-              scrollDirection: Axis.horizontal,
-              padding: EdgeInsets.fromLTRB(
-                12,
-                hasExplicitLanguage ? 20 : 12,
-                12,
-                12,
-              ),
-              child: SelectableText.rich(
-                TextSpan(style: baseStyle, children: highlightedSpans),
-                contextMenuBuilder:
-                    googleSearchSelectableTextContextMenuBuilder,
-              ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          _CodeBlockToolbar(
+            displayLanguage: displayLanguage,
+            hasExplicitLanguage: hasExplicitLanguage,
+            baseStyle: baseStyle,
+            source: source,
+          ),
+          SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
+            child: SelectableText.rich(
+              TextSpan(style: baseStyle, children: highlightedSpans),
+              contextMenuBuilder: googleSearchSelectableTextContextMenuBuilder,
             ),
-            if (hasExplicitLanguage)
-              Positioned(
-                top: 6,
-                right: 8,
-                child: Text(
-                  displayLanguage,
-                  key: ValueKey('code_block_language_$displayLanguage'),
-                  style: baseStyle.copyWith(
-                    fontSize: 10,
-                    letterSpacing: 0.2,
-                    color: Theme.of(context).colorScheme.onSurface
-                        .withValues(alpha: 0.52),
-                  ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CodeBlockToolbar extends StatelessWidget {
+  const _CodeBlockToolbar({
+    required this.displayLanguage,
+    required this.hasExplicitLanguage,
+    required this.baseStyle,
+    required this.source,
+  });
+
+  final String displayLanguage;
+  final bool hasExplicitLanguage;
+  final TextStyle baseStyle;
+  final String source;
+
+  @override
+  Widget build(BuildContext context) {
+    final subtleColor = Theme.of(context).colorScheme.onSurface
+        .withValues(alpha: 0.52);
+    return SizedBox(
+      height: 44,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.end,
+        children: [
+          if (hasExplicitLanguage)
+            Padding(
+              padding: const EdgeInsets.only(right: 4),
+              child: Text(
+                displayLanguage,
+                key: ValueKey('code_block_language_$displayLanguage'),
+                style: baseStyle.copyWith(
+                  fontSize: 10,
+                  letterSpacing: 0.2,
+                  color: subtleColor,
                 ),
               ),
-          ],
-        ),
+            ),
+          IconButton(
+            key: ValueKey('code_block_copy_button_$displayLanguage'),
+            tooltip: AppLocalizations.of(context).copy,
+            onPressed: () => _copyCodeBlock(context, source),
+            visualDensity: VisualDensity.compact,
+            constraints: const BoxConstraints.tightFor(width: 44, height: 44),
+            padding: EdgeInsets.zero,
+            iconSize: 18,
+            color: subtleColor,
+            icon: const Icon(Icons.content_copy_rounded),
+          ),
+        ],
       ),
     );
   }

--- a/apps/mobile/test/markdown_code_block_test.dart
+++ b/apps/mobile/test/markdown_code_block_test.dart
@@ -167,9 +167,7 @@ void main() {
   });
 
   group('AssistantBubble copy behavior with code blocks', () {
-    testWidgets('long press on code block copies only fenced code content', (
-      tester,
-    ) async {
+    testWidgets('copy button copies only fenced code content', (tester) async {
       String? clipboardContent;
       tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
         SystemChannels.platform,
@@ -187,8 +185,8 @@ void main() {
         _wrap(AssistantBubble(message: _messageWithText(markdown))),
       );
 
-      await tester.longPress(
-        find.byKey(const ValueKey('code_block_copy_target_bash')),
+      await tester.tap(
+        find.byKey(const ValueKey('code_block_copy_button_bash')),
       );
       await tester.pumpAndSettle();
 
@@ -197,7 +195,7 @@ void main() {
     });
 
     testWidgets(
-      'long press copies only tapped code block when multiple exist',
+      'copy buttons target their own code block when multiple exist',
       (tester) async {
         String? clipboardContent;
         tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
@@ -217,8 +215,8 @@ void main() {
           _wrap(AssistantBubble(message: _messageWithText(markdown))),
         );
 
-        await tester.longPress(
-          find.byKey(const ValueKey('code_block_copy_target_bash')),
+        await tester.tap(
+          find.byKey(const ValueKey('code_block_copy_button_bash')),
         );
         await tester.pumpAndSettle();
 
@@ -226,6 +224,38 @@ void main() {
         expect(find.text('Copied'), findsOneWidget);
       },
     );
+
+    testWidgets('selectable code has no competing long-press ancestor', (
+      tester,
+    ) async {
+      const markdown = '```bash\necho selectable text\n```';
+      await tester.pumpWidget(
+        _wrap(AssistantBubble(message: _messageWithText(markdown))),
+      );
+
+      final codeBlock = find.byWidgetPredicate(
+        (widget) =>
+            widget.key is ValueKey<String> &&
+            (widget.key! as ValueKey<String>).value.startsWith(
+              'code_block_container_bash_',
+            ),
+      );
+      final selectable = find.descendant(
+        of: codeBlock,
+        matching: find.byType(SelectableText),
+      );
+      expect(selectable, findsOneWidget);
+      final longPressAncestors = tester
+          .widgetList<GestureDetector>(
+            find.ancestor(
+              of: selectable,
+              matching: find.byType(GestureDetector),
+            ),
+          )
+          .where((gesture) => gesture.onLongPress != null);
+
+      expect(longPressAncestors, isEmpty);
+    });
 
     testWidgets('copy button copies entire assistant text content', (
       tester,


### PR DESCRIPTION
## Summary

- add a visible Copy button to every fenced code block, including Bash commands
- remove the whole-block long-press handler that competed with Android text selection
- keep horizontal scrolling and SelectableText behavior for copying only part of a command
- retain language labels and localized copy feedback

## Verification

- regression tests failed before the fix because the button was absent and a long-press ancestor owned the selectable text
- all 12 focused Markdown code-block tests passed
- full Flutter test suite passed
- Dart analysis completed with no errors
- final selection-handle acceptance is deferred to the combined Android device test