### PR TITLE
feat(bridge): support Claude Code with Amazon Bedrock

### DIFF
--- a/packages/bridge/CHANGELOG.md
+++ b/packages/bridge/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `@ccpocket/bridge` will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- Support Claude Code sessions on Amazon Bedrock. When `CLAUDE_CODE_USE_BEDROCK` is enabled in the Bridge environment or in the Claude Code user settings `env` block, session startup and model listing no longer require an Anthropic API credential or the subscription opt-in. AWS credentials stay on the Bridge host and are resolved through the normal AWS credential provider chain.
+
+### Changed
+- Report Amazon Bedrock in `doctor` as `Amazon Bedrock configured; AWS credentials not verified` instead of warning that Anthropic authentication is missing, and print each provider's authentication detail instead of a generic authenticated label.
+
 ## [1.73.1] - 2026-08-28
 
 ### Fixed

--- a/packages/bridge/README.md
+++ b/packages/bridge/README.md
@@ -16,6 +16,8 @@ Claude sessions use `ANTHROPIC_API_KEY` by default. Subscription authentication
 through the Bridge machine's Claude Code login is available only after explicit
 opt-in with `BRIDGE_ALLOW_CLAUDE_OAUTH=1`; see
 [Claude Subscription Authentication](#claude-subscription-authentication-explicit-opt-in).
+Hosts that run Claude Code on Amazon Bedrock need neither of those; see
+[Claude on Amazon Bedrock](#claude-on-amazon-bedrock).
 
 ## Installation
 
@@ -59,6 +61,8 @@ ccpocket-bridge --version
 | `DIFF_IMAGE_MAX_SIZE_MB` | `5` (5 MB) | Maximum diff image size available for on-demand loading, in MB |
 | `ANTHROPIC_API_KEY` | (none) | Claude Agent SDK API key; recommended for predictable third-party product usage |
 | `ANTHROPIC_AUTH_TOKEN` | (none) | Advanced Claude SDK auth token; prefer `ANTHROPIC_API_KEY` |
+| `CLAUDE_CODE_USE_BEDROCK` | (none) | Claude Code setting; when enabled, Claude sessions run on Amazon Bedrock and no Anthropic credential is required |
+| `AWS_REGION` / `AWS_PROFILE` | (none) | Standard AWS variables read by Claude Code when Amazon Bedrock is enabled |
 | `OPENAI_API_KEY` | (none) | Codex API key; Codex can also use `~/.codex/auth.json` |
 | `HTTPS_PROXY` / `HTTP_PROXY` / `ALL_PROXY` | (none) | Proxy for outgoing fetch requests (`http://`, `https://`, `socks4://`, `socks5://`) |
 
@@ -133,6 +137,64 @@ is reachable through a reverse proxy, tunnel, or public domain.
 
 Without it, the printed QR code is LAN-oriented by default and typically encodes
 something like `ws://192.168.x.x:8765`.
+
+## Claude on Amazon Bedrock
+
+Claude Code and the Claude Agent SDK can run against
+[Amazon Bedrock](https://code.claude.com/docs/en/amazon-bedrock) instead of the
+first-party Anthropic API. Bedrock requests are signed with AWS credentials, so
+the Bridge requires neither `ANTHROPIC_API_KEY` nor the subscription opt-in:
+
+```bash
+CLAUDE_CODE_USE_BEDROCK=1 \
+AWS_REGION=us-west-2 \
+npx @ccpocket/bridge@latest
+
+# AWS_REGION is optional when your AWS profile already sets a region,
+# and AWS_PROFILE selects a specific profile:
+CLAUDE_CODE_USE_BEDROCK=1 AWS_PROFILE=my-profile npx @ccpocket/bridge@latest
+```
+
+AWS credentials remain on the Bridge host and are resolved through the normal
+AWS credential provider chain — environment credentials, `AWS_PROFILE`,
+`~/.aws/credentials`, `~/.aws/config`, IAM roles, SSO, and EC2/ECS credentials.
+CC Pocket has no AWS credential store of its own: it never reads, copies, logs,
+or forwards AWS credentials, and nothing AWS-related is sent to the mobile app.
+
+The Bridge also recognizes Bedrock when Claude Code's `/setup-bedrock` wizard
+wrote `CLAUDE_CODE_USE_BEDROCK` into the `env` block of the Claude Code user
+settings file (`~/.claude/settings.json`, or `$CLAUDE_CONFIG_DIR/settings.json`).
+Only that one flag is read from the file.
+
+Model IDs, region resolution, and IAM permissions follow the Claude Code
+documentation. CC Pocket adds no Bedrock-specific configuration of its own.
+
+Verify the result with the doctor command:
+
+```bash
+npx @ccpocket/bridge@latest doctor
+```
+
+The Claude Code CLI line then reads
+`Amazon Bedrock configured; AWS credentials not verified`. Doctor reports the
+configuration only — it does not call AWS, so it never claims that credentials
+work.
+
+### Amazon Bedrock with the background service
+
+`ccpocket-bridge setup` persists only the `BRIDGE_*` settings listed below, so
+make the Bedrock configuration reachable from the service environment:
+
+- macOS launchd: the generated plist starts the Bridge through a login shell
+  (`zsh -li`), so `export CLAUDE_CODE_USE_BEDROCK=1` and any `AWS_*` variables in
+  `~/.zprofile` / `~/.zshrc` are inherited.
+- Linux systemd: the generated unit starts the Bridge through a login shell
+  (`bash -lc`), so exports in `~/.profile` / `~/.bash_profile` are inherited.
+  `Environment=` lines added to
+  `~/.config/systemd/user/ccpocket-bridge.service` also work, but re-running
+  setup rewrites that file.
+- Either platform: keeping the configuration in the Claude Code user settings
+  `env` block works too, and survives re-running setup.
 
 ## Persistent service setup
 

--- a/packages/bridge/src/claude-provider.test.ts
+++ b/packages/bridge/src/claude-provider.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { isClaudeBedrockModeEnabled } from "./claude-provider.js";
+
+describe("isClaudeBedrockModeEnabled", () => {
+  let configDir: string;
+
+  // Every case points CLAUDE_CONFIG_DIR at a temporary directory so the result
+  // never depends on the developer's real Claude Code settings.
+  beforeEach(() => {
+    configDir = mkdtempSync(join(tmpdir(), "ccpocket-claude-provider-"));
+  });
+
+  afterEach(() => {
+    rmSync(configDir, { recursive: true, force: true });
+  });
+
+  function writeUserSettings(settings: unknown): void {
+    writeFileSync(join(configDir, "settings.json"), JSON.stringify(settings));
+  }
+
+  it("is disabled when nothing is configured", () => {
+    expect(isClaudeBedrockModeEnabled({ CLAUDE_CONFIG_DIR: configDir })).toBe(false);
+  });
+
+  it("accepts the environment values Claude Code treats as enabled", () => {
+    for (const value of ["1", "true", "TRUE", "yes", "on", " 1 "]) {
+      expect(
+        isClaudeBedrockModeEnabled({
+          CLAUDE_CONFIG_DIR: configDir,
+          CLAUDE_CODE_USE_BEDROCK: value,
+        }),
+      ).toBe(true);
+    }
+  });
+
+  it("rejects environment values Claude Code treats as disabled", () => {
+    for (const value of ["", "0", "false", "no", "off", "bedrock"]) {
+      expect(
+        isClaudeBedrockModeEnabled({
+          CLAUDE_CONFIG_DIR: configDir,
+          CLAUDE_CODE_USE_BEDROCK: value,
+        }),
+      ).toBe(false);
+    }
+  });
+
+  it("reads the flag from the Claude Code user settings env block", () => {
+    writeUserSettings({ env: { CLAUDE_CODE_USE_BEDROCK: "1" } });
+    expect(isClaudeBedrockModeEnabled({ CLAUDE_CONFIG_DIR: configDir })).toBe(true);
+  });
+
+  it("stays enabled when the settings file opts in and the environment does not", () => {
+    writeUserSettings({ env: { CLAUDE_CODE_USE_BEDROCK: "1" } });
+    expect(
+      isClaudeBedrockModeEnabled({
+        CLAUDE_CONFIG_DIR: configDir,
+        CLAUDE_CODE_USE_BEDROCK: "0",
+      }),
+    ).toBe(true);
+  });
+
+  it("ignores settings without an enabled Bedrock flag", () => {
+    writeUserSettings({ env: { AWS_REGION: "us-west-2" }, model: "opus" });
+    expect(isClaudeBedrockModeEnabled({ CLAUDE_CONFIG_DIR: configDir })).toBe(false);
+
+    writeUserSettings({ env: { CLAUDE_CODE_USE_BEDROCK: "0" } });
+    expect(isClaudeBedrockModeEnabled({ CLAUDE_CONFIG_DIR: configDir })).toBe(false);
+  });
+
+  it("ignores unreadable or malformed settings files", () => {
+    expect(
+      isClaudeBedrockModeEnabled({ CLAUDE_CONFIG_DIR: join(configDir, "missing") }),
+    ).toBe(false);
+
+    writeFileSync(join(configDir, "settings.json"), "{ not json");
+    expect(isClaudeBedrockModeEnabled({ CLAUDE_CONFIG_DIR: configDir })).toBe(false);
+  });
+});

--- a/packages/bridge/src/claude-provider.ts
+++ b/packages/bridge/src/claude-provider.ts
@@ -1,0 +1,64 @@
+/**
+ * Detection for third-party Claude API backends on the Bridge host.
+ *
+ * Claude Code and the Claude Agent SDK can run against Amazon Bedrock instead
+ * of the first-party Anthropic API. In that mode there is no Anthropic API key
+ * and no Claude.ai login: requests are signed with AWS credentials that the
+ * Claude Code process resolves through the AWS default credential provider
+ * chain on the Bridge machine.
+ *
+ * The Bridge only needs to know whether that mode is active so it does not ask
+ * for Anthropic credentials the setup never uses. It never reads, stores, logs,
+ * or forwards AWS credentials.
+ *
+ * https://code.claude.com/docs/en/amazon-bedrock
+ */
+
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const BEDROCK_ENV_VAR = "CLAUDE_CODE_USE_BEDROCK";
+
+/** Values Claude Code accepts for its own boolean environment variables. */
+const TRUTHY_VALUES = new Set(["1", "true", "yes", "on"]);
+
+function isTruthy(value: unknown): boolean {
+  if (typeof value !== "string") return false;
+  return TRUTHY_VALUES.has(value.trim().toLowerCase());
+}
+
+/**
+ * Read only `env.CLAUDE_CODE_USE_BEDROCK` from the Claude Code user settings.
+ *
+ * `claude`'s Amazon Bedrock login wizard writes its result to the `env` block
+ * of the user settings file instead of exporting shell variables, and the
+ * Bridge starts SDK queries with the `user` setting source enabled. No other
+ * value from that file is inspected, returned, or logged.
+ */
+function bedrockFlagFromUserSettings(env: NodeJS.ProcessEnv): unknown {
+  const configDir = env.CLAUDE_CONFIG_DIR?.trim();
+  const settingsPath = join(configDir || join(homedir(), ".claude"), "settings.json");
+  try {
+    const settings: unknown = JSON.parse(readFileSync(settingsPath, "utf-8"));
+    if (!settings || typeof settings !== "object") return undefined;
+    const settingsEnv = (settings as { env?: unknown }).env;
+    if (!settingsEnv || typeof settingsEnv !== "object") return undefined;
+    return (settingsEnv as Record<string, unknown>)[BEDROCK_ENV_VAR];
+  } catch {
+    // Missing, unreadable, or invalid settings mean "not configured".
+    return undefined;
+  }
+}
+
+/**
+ * Whether Claude Code on this host is configured to use Amazon Bedrock.
+ *
+ * Either source enables it, matching how Claude Code resolves the flag from the
+ * process environment and from its settings files.
+ */
+export function isClaudeBedrockModeEnabled(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return isTruthy(env[BEDROCK_ENV_VAR]) || isTruthy(bedrockFlagFromUserSettings(env));
+}

--- a/packages/bridge/src/doctor.test.ts
+++ b/packages/bridge/src/doctor.test.ts
@@ -12,9 +12,13 @@ vi.mock("node:child_process", () => ({
 // Mock node:fs
 const mockExistsSync = vi.fn();
 const mockAccessSync = vi.fn();
+// Claude Code settings are read when checking for Amazon Bedrock mode; return
+// an empty settings object so the checks never see the host's real setup.
+const mockReadFileSync = vi.fn(() => "{}");
 vi.mock("node:fs", () => ({
   existsSync: (...args: unknown[]) => mockExistsSync(...args),
   accessSync: (...args: unknown[]) => mockAccessSync(...args),
+  readFileSync: (...args: unknown[]) => mockReadFileSync(...args),
   constants: { R_OK: 4, W_OK: 2 },
 }));
 
@@ -70,6 +74,7 @@ describe("doctor checks", () => {
       vi.stubEnv("BRIDGE_ALLOW_CLAUDE_OAUTH", "1");
       vi.stubEnv("ANTHROPIC_API_KEY", "");
       vi.stubEnv("ANTHROPIC_AUTH_TOKEN", "");
+      vi.stubEnv("CLAUDE_CODE_USE_BEDROCK", "");
     });
 
     afterEach(() => {
@@ -162,6 +167,49 @@ describe("doctor checks", () => {
       const claude = result.providers.find((p: ProviderResult) => p.name === "Claude Code CLI");
       expect(claude?.installed).toBe(true);
       expect(claude?.authenticated).toBe(false);
+    });
+
+    it("reports Amazon Bedrock mode without asking for Anthropic credentials", async () => {
+      vi.stubEnv("BRIDGE_ALLOW_CLAUDE_OAUTH", "");
+      vi.stubEnv("CLAUDE_CODE_USE_BEDROCK", "1");
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (cmd === "claude --version") return "2.1.250";
+        throw new Error("command not found");
+      });
+
+      const result = await checkCliProviders();
+      const claude = result.providers.find(
+        (provider: ProviderResult) => provider.name === "Claude Code CLI",
+      );
+
+      expect(result.status).toBe("pass");
+      expect(claude?.authenticated).toBe(true);
+      expect(claude?.authMessage).toContain("Amazon Bedrock");
+      expect(claude?.authMessage).toContain("not verified");
+      expect(claude?.remediation).toBeUndefined();
+      // Bedrock authenticates through AWS, so doctor must not probe Claude
+      // Code's Anthropic login or call AWS to verify credentials.
+      expect(mockExecSync).not.toHaveBeenCalledWith(
+        "claude auth status",
+        expect.anything(),
+      );
+    });
+
+    it("prefers Bedrock mode over an Anthropic API key, matching Claude Code", async () => {
+      vi.stubEnv("BRIDGE_ALLOW_CLAUDE_OAUTH", "");
+      vi.stubEnv("ANTHROPIC_API_KEY", "sk-ant-test");
+      vi.stubEnv("CLAUDE_CODE_USE_BEDROCK", "1");
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (cmd === "claude --version") return "2.1.250";
+        throw new Error("command not found");
+      });
+
+      const result = await checkCliProviders();
+      const claude = result.providers.find(
+        (provider: ProviderResult) => provider.name === "Claude Code CLI",
+      );
+
+      expect(claude?.authMessage).toContain("Amazon Bedrock");
     });
 
     it("warns when subscription login is detected without explicit opt-in", async () => {
@@ -355,6 +403,43 @@ describe("doctor checks", () => {
         allRequiredPassed: true,
       };
       expect(() => printReport(report)).not.toThrow();
+    });
+
+    it("prints a provider auth message instead of the generic authenticated label", () => {
+      const logs: string[] = [];
+      const spy = vi
+        .spyOn(console, "log")
+        .mockImplementation((...args: unknown[]) => {
+          logs.push(args.map((arg) => String(arg)).join(" "));
+        });
+      try {
+        printReport({
+          results: [
+            {
+              name: "CLI providers",
+              status: "pass",
+              message: "1 of 2 available",
+              category: "required",
+              providers: [
+                {
+                  name: "Claude Code CLI",
+                  installed: true,
+                  version: "2.1.250",
+                  authenticated: true,
+                  authMessage: "Amazon Bedrock configured; AWS credentials not verified",
+                },
+              ],
+            },
+          ],
+          allRequiredPassed: true,
+        });
+      } finally {
+        spy.mockRestore();
+      }
+
+      const output = logs.join("\n");
+      expect(output).toContain("Amazon Bedrock configured");
+      expect(output).not.toContain("(authenticated)");
     });
   });
 });

--- a/packages/bridge/src/doctor.ts
+++ b/packages/bridge/src/doctor.ts
@@ -15,6 +15,7 @@ import net from "node:net";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { isClaudeBedrockModeEnabled } from "./claude-provider.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -118,7 +119,13 @@ export async function checkCliProviders(): Promise<
       const out = execQuiet("claude --version");
       installed = true;
       version = out.trim().split("\n")[0];
-      if (process.env.ANTHROPIC_API_KEY || process.env.ANTHROPIC_AUTH_TOKEN) {
+      if (isClaudeBedrockModeEnabled()) {
+        // Claude Code signs Amazon Bedrock requests with AWS credentials from
+        // this host's provider chain. Report the configuration without calling
+        // AWS, so doctor never claims credentials it has not verified.
+        authenticated = true;
+        authMessage = "Amazon Bedrock configured; AWS credentials not verified";
+      } else if (process.env.ANTHROPIC_API_KEY || process.env.ANTHROPIC_AUTH_TOKEN) {
         authenticated = true;
         authMessage = "API credential configured";
       } else {
@@ -694,7 +701,7 @@ function providerStatusMessage(p: ProviderResult): string {
   const parts: string[] = [];
   if (p.version) parts.push(p.version);
   if (p.authenticated) {
-    parts.push("(authenticated)");
+    parts.push(p.authMessage ? `(${p.authMessage})` : "(authenticated)");
   } else if (p.authMessage) {
     parts.push(`(${p.authMessage})`);
   }

--- a/packages/bridge/src/sdk-process.test.ts
+++ b/packages/bridge/src/sdk-process.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -1005,25 +1006,24 @@ describe("SdkProcess input dispatch", () => {
 
 });
 
-// Points Bedrock detection at a directory that has no Claude Code settings
-// file, so these tests never depend on the host's real Claude configuration.
-const CLAUDE_CONFIG_DIR_WITHOUT_SETTINGS = join(
-  tmpdir(),
-  "ccpocket-bridge-tests-no-claude-settings",
-);
-
 describe("SdkProcess Claude authentication", () => {
+  // A fresh empty directory per test points Bedrock detection away from the
+  // host's real Claude Code settings and from anything another run left behind.
+  let claudeConfigDir: string;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    claudeConfigDir = mkdtempSync(join(tmpdir(), "ccpocket-bridge-claude-auth-"));
     vi.stubEnv("ANTHROPIC_API_KEY", "");
     vi.stubEnv("ANTHROPIC_AUTH_TOKEN", "");
     vi.stubEnv("BRIDGE_ALLOW_CLAUDE_OAUTH", "");
     vi.stubEnv("CLAUDE_CODE_USE_BEDROCK", "");
-    vi.stubEnv("CLAUDE_CONFIG_DIR", CLAUDE_CONFIG_DIR_WITHOUT_SETTINGS);
+    vi.stubEnv("CLAUDE_CONFIG_DIR", claudeConfigDir);
   });
 
   afterEach(() => {
     vi.unstubAllEnvs();
+    rmSync(claudeConfigDir, { recursive: true, force: true });
   });
 
   async function runSdkMessages(

--- a/packages/bridge/src/sdk-process.test.ts
+++ b/packages/bridge/src/sdk-process.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   parseRule,
   matchesSessionRule,
@@ -1003,12 +1005,21 @@ describe("SdkProcess input dispatch", () => {
 
 });
 
+// Points Bedrock detection at a directory that has no Claude Code settings
+// file, so these tests never depend on the host's real Claude configuration.
+const CLAUDE_CONFIG_DIR_WITHOUT_SETTINGS = join(
+  tmpdir(),
+  "ccpocket-bridge-tests-no-claude-settings",
+);
+
 describe("SdkProcess Claude authentication", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.stubEnv("ANTHROPIC_API_KEY", "");
     vi.stubEnv("ANTHROPIC_AUTH_TOKEN", "");
     vi.stubEnv("BRIDGE_ALLOW_CLAUDE_OAUTH", "");
+    vi.stubEnv("CLAUDE_CODE_USE_BEDROCK", "");
+    vi.stubEnv("CLAUDE_CONFIG_DIR", CLAUDE_CONFIG_DIR_WITHOUT_SETTINGS);
   });
 
   afterEach(() => {
@@ -1107,6 +1118,120 @@ describe("SdkProcess Claude authentication", () => {
       "BRIDGE_ALLOW_CLAUDE_OAUTH=1",
     );
     expect(mockSdkQuery).not.toHaveBeenCalled();
+  });
+
+  it("keeps Bedrock mode separate from Anthropic credentials and the OAuth opt-in", () => {
+    expect(hasExplicitClaudeCredential({ CLAUDE_CODE_USE_BEDROCK: "1" })).toBe(false);
+    expect(isClaudeOAuthOptInEnabled({ CLAUDE_CODE_USE_BEDROCK: "1" })).toBe(false);
+  });
+
+  it("starts a session in Amazon Bedrock mode without Anthropic credentials", async () => {
+    vi.stubEnv("CLAUDE_CODE_USE_BEDROCK", "1");
+    const proc = new SdkProcess();
+    const messages: ServerMessage[] = [];
+    const exits: Array<number | null> = [];
+    proc.on("message", (message) => messages.push(message));
+    proc.on("exit", (code) => exits.push(code));
+
+    mockSdkQuery.mockReturnValueOnce({
+      async *[Symbol.asyncIterator]() {
+        yield {
+          type: "system",
+          subtype: "init",
+          session_id: "bedrock-session",
+          model: "us.anthropic.claude-sonnet-4-6",
+          // Claude Code reports "none" on Amazon Bedrock; requests are signed
+          // with AWS credentials instead of an Anthropic credential.
+          apiKeySource: "none",
+        };
+        yield {
+          type: "result",
+          subtype: "success",
+          result: "Done",
+          duration_ms: 100,
+          session_id: "bedrock-session",
+        };
+      },
+      close: vi.fn(),
+      supportedCommands: vi.fn().mockResolvedValue([]),
+      initializationResult: vi.fn().mockResolvedValue({
+        account: { apiProvider: "bedrock" },
+        models: [],
+      }),
+    });
+
+    proc.start(process.cwd());
+    await vi.waitFor(() => expect(exits).toEqual([0]));
+
+    expect(mockSdkQuery).toHaveBeenCalledOnce();
+    expect(proc.sessionId).toBe("bedrock-session");
+    expect(messages).toContainEqual(expect.objectContaining({
+      type: "system",
+      subtype: "init",
+      sessionId: "bedrock-session",
+    }));
+    expect(messages).not.toContainEqual(expect.objectContaining({
+      type: "error",
+    }));
+  });
+
+  it("lists models in Amazon Bedrock mode without Anthropic credentials", async () => {
+    vi.stubEnv("CLAUDE_CODE_USE_BEDROCK", "1");
+    const close = vi.fn();
+    mockSdkQuery.mockReturnValueOnce({
+      async *[Symbol.asyncIterator]() {
+        yield { type: "system", subtype: "init", apiKeySource: "none" };
+      },
+      close,
+      initializationResult: vi.fn().mockResolvedValue({
+        account: { apiProvider: "bedrock" },
+        models: [
+          { value: "us.anthropic.claude-sonnet-4-6", displayName: "Sonnet 4.6" },
+        ],
+      }),
+    });
+
+    await expect(listAvailableClaudeModels()).resolves.toEqual([
+      expect.objectContaining({
+        model: "us.anthropic.claude-sonnet-4-6",
+        displayName: "Sonnet 4.6",
+      }),
+    ]);
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("still requires the OAuth opt-in when Bedrock mode resolves to a subscription", async () => {
+    vi.stubEnv("CLAUDE_CODE_USE_BEDROCK", "1");
+    const proc = new SdkProcess();
+    const messages: ServerMessage[] = [];
+    const exits: Array<number | null> = [];
+    proc.on("message", (message) => messages.push(message));
+    proc.on("exit", (code) => exits.push(code));
+
+    mockSdkQuery.mockReturnValueOnce({
+      async *[Symbol.asyncIterator]() {
+        yield {
+          type: "system",
+          subtype: "init",
+          session_id: "oauth-session",
+          apiKeySource: "oauth",
+        };
+      },
+      close: vi.fn(),
+      supportedCommands: vi.fn().mockResolvedValue([]),
+      initializationResult: vi.fn().mockResolvedValue({
+        account: { apiKeySource: "oauth" },
+        models: [],
+      }),
+    });
+
+    proc.start(process.cwd());
+    await vi.waitFor(() => expect(exits).toEqual([1]));
+
+    expect(messages).toContainEqual(expect.objectContaining({
+      type: "error",
+      errorCode: "claude_oauth_opt_in_required",
+    }));
   });
 
   it("rejects model listing when the SDK unexpectedly selects OAuth", async () => {

--- a/packages/bridge/src/sdk-process.ts
+++ b/packages/bridge/src/sdk-process.ts
@@ -11,6 +11,7 @@ import {
   type PermissionResult,
   type ModelInfo,
 } from "@anthropic-ai/claude-agent-sdk";
+import { isClaudeBedrockModeEnabled } from "./claude-provider.js";
 import {
   normalizeToolResultContent,
   type ServerMessage,
@@ -142,7 +143,13 @@ export function hasExplicitClaudeCredential(
 }
 
 function canStartClaudeSdk(env: NodeJS.ProcessEnv = process.env): boolean {
-  return hasExplicitClaudeCredential(env) || isClaudeOAuthOptInEnabled(env);
+  return (
+    hasExplicitClaudeCredential(env)
+    // Amazon Bedrock authenticates with AWS credentials on the Bridge host, so
+    // neither an Anthropic API credential nor the subscription opt-in applies.
+    || isClaudeBedrockModeEnabled(env)
+    || isClaudeOAuthOptInEnabled(env)
+  );
 }
 
 type ClaudeAuthClassification = "unknown" | "api_key" | "subscription";


### PR DESCRIPTION
## Summary

Lets the Bridge run Claude sessions on a host where Claude Code is configured for
Amazon Bedrock. Previously the Bridge refused to start a Claude session on such a
host, because its pre-flight check only accepted `ANTHROPIC_API_KEY`,
`ANTHROPIC_AUTH_TOKEN`, or the `BRIDGE_ALLOW_CLAUDE_OAUTH=1` subscription opt-in.

## Why This Is A PR

<!-- Small, Bridge-only change. -->

- Related Issue / Prompt Request: None — small self-contained Bridge-only change with tests (adjacent third-party-backend context: #124)
- Why this is ready for PR review: One goal, 8 files, no mobile or protocol changes. Scoped to the Claude provider gate plus doctor reporting, covered by unit tests, and validated end to end against real Amazon Bedrock on macOS.

## Changes

- Add `packages/bridge/src/claude-provider.ts` with `isClaudeBedrockModeEnabled()`. It detects `CLAUDE_CODE_USE_BEDROCK` in the Bridge process environment, and — because Claude Code's `/setup-bedrock` wizard writes the flag there instead of exporting it — in the `env` block of the Claude Code user settings file (`~/.claude/settings.json`, or `$CLAUDE_CONFIG_DIR/settings.json`). Only that one flag is read from the file. It accepts the same values Claude Code accepts (`1`, `true`, `yes`, `on`), so the Bridge does not reject a configuration the CLI itself honors.
- `sdk-process.ts`: `canStartClaudeSdk()` also allows Bedrock mode, which unblocks both session startup and model listing. No other auth logic changes.
- `doctor.ts`: when Bedrock mode is detected, the Claude Code CLI provider reports `Amazon Bedrock configured; AWS credentials not verified` instead of probing `claude auth status` and warning that the subscription opt-in is missing.
- `doctor.ts`: `providerStatusMessage()` now prints a provider's `authMessage` when one is set instead of the generic `(authenticated)` label. Without this the new Bedrock wording would never be shown; as a side effect the existing API-key and subscription-opt-in cases now print their already-populated messages too. This changes terminal `doctor` output only.
- Tests: new `claude-provider.test.ts`, plus Bedrock and regression cases in `sdk-process.test.ts` and `doctor.test.ts`.
- `packages/bridge/README.md`: Amazon Bedrock section with a startup example, the credential-handling statement, doctor output, and launchd/systemd notes; plus `CLAUDE_CODE_USE_BEDROCK` / `AWS_REGION` / `AWS_PROFILE` rows in the configuration table.
- `packages/bridge/CHANGELOG.md`: entry under `## [Unreleased]` rather than a version section, since the release flow generates the versioned section.

## Authentication and security model

- Amazon Bedrock support uses Claude Code's own supported provider mechanism (`CLAUDE_CODE_USE_BEDROCK`); the Bridge adds no provider plumbing, no model mapping, and no request signing of its own.
- AWS credentials remain on the Bridge host and are resolved through the normal AWS credential provider chain (environment credentials, `AWS_PROFILE`, `~/.aws/credentials`, `~/.aws/config`, IAM roles, SSO, EC2/ECS credentials).
- CC Pocket does not store AWS credentials. Nothing in this change reads, copies, caches, logs, or sends any AWS credential; no AWS value is exposed to the mobile app or to diagnostics. Doctor makes no AWS call, which is why it reports the configuration rather than claiming that credentials work.
- Existing Anthropic API key, auth token, and Claude subscription behavior is unchanged. Bedrock is not a bypass for the subscription policy: if the SDK reports an OAuth auth source, the runtime check still fails with `claude_oauth_opt_in_required` even in Bedrock mode, and there is a test for that.

## Scope Check

- Single primary goal: allow and correctly report Claude sessions when the Bridge host runs Claude Code on Amazon Bedrock.
- Intentionally out of scope: Google Vertex AI, Mantle, and other third-party backends; Bedrock model pinning or region defaults; reading the Bedrock flag from project or local settings files; persisting `CLAUDE_CODE_USE_BEDROCK` / `AWS_*` through `ccpocket-bridge setup` (documented instead); any mobile app, protocol, or UI change.
- Split plan or why this cannot be split: Not split. The provider gate, the doctor message, the tests, and the docs are the minimum needed for the feature to work and to be reported honestly.

## Test Evidence

- Automated tests (command and result): all PASS — `npm run test:bridge` (Test Files 40 passed, Tests 1006 passed), `npx tsc --noEmit -p packages/bridge/tsconfig.json` (no output), `npm run bridge:build`, `npm run test:pr-readiness` (10/10), `git diff --check` (no output).

  New coverage: Bedrock environment values Claude Code accepts and rejects; the settings-file `env` block path; malformed or missing settings files; session start and model listing in Bedrock mode with no Anthropic credential and no OAuth opt-in; Bedrock mode kept separate from `hasExplicitClaudeCredential` and `isClaudeOAuthOptInEnabled`; the OAuth opt-in still enforced in Bedrock mode; doctor reporting Bedrock without probing Claude Code's Anthropic login; Bedrock preferred over `ANTHROPIC_API_KEY`, matching Claude Code precedence. Bedrock-related tests create a fresh empty `CLAUDE_CONFIG_DIR` per test and remove it afterwards, so results never depend on the developer's own Claude configuration or on leftovers from another run.
- Manual validation: On a Mac whose Claude Code is configured for Amazon Bedrock through `~/.claude/settings.json`, with `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, `BRIDGE_ALLOW_CLAUDE_OAUTH`, and `CLAUDE_CODE_USE_BEDROCK` all unset in the Bridge environment: before the change, `SdkProcess.start()` emitted `claude_oauth_opt_in_required` and exited 1; after the change the same run completed a real Bedrock turn (`init` with `apiKeySource: "none"`, assistant message id `msg_bdrk_…`, model `global.anthropic.claude-opus-5[1m]`, `result: success`). `ccpocket-bridge doctor` reports `Claude Code CLI 2.1.250 (Claude Code) (Amazon Bedrock configured; AWS credentials not verified)` with all required checks passing. Regression spot-check: with `ANTHROPIC_API_KEY` set and Bedrock disabled, doctor still reports `API credential configured`.
- Target platform and version: macOS 15 (Darwin 25.6.0, arm64), Node.js v22.22.2, Claude Code 2.1.250, `@anthropic-ai/claude-agent-sdk` 0.3.148, Bridge 1.73.1. Not validated on Linux or Windows; the change is platform-independent env and JSON reading.

## Risk and Rollback

- [x] Low
- [ ] Medium
- [ ] High
- Main risks: (1) The gate now accepts one more configuration, so a host that sets `CLAUDE_CODE_USE_BEDROCK` while Claude Code actually resolves a subscription login reaches the SDK instead of failing early — the runtime OAuth check still rejects that case with the same error code. (2) `doctor` output wording changed for authenticated providers. (3) Bedrock sessions report Claude Code's own estimated cost, the same as API-key sessions; this PR does not change cost handling.
- Rollback plan: Revert this branch's commits. They touch no protocol, no persisted state, and no mobile code, so no migration or client update is involved.

## UI Evidence

- [x] No user-visible UI change
- [ ] User-visible UI change
- No-visual-change reason: Bridge-only change. No files under `apps/mobile/` are touched; the only user-facing text change is terminal `ccpocket-bridge doctor` output.
- Before: N/A — no mobile UI change
- After: N/A — no mobile UI change
- Device / platform: N/A — no mobile UI change

## Author Checklist

- [x] I reviewed the complete diff and can explain and maintain this change.
- [x] This PR contains no unrelated changes.
- [x] User-facing or breaking changes are documented, or documentation is not applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for running Claude Code through Amazon Bedrock.
  * Bedrock mode can be configured through environment variables or Claude settings.
  * The Bridge can start and list models using AWS authentication without Anthropic credentials.
  * Added Bedrock-specific authentication guidance and configuration details.

* **Bug Fixes**
  * Doctor checks now accurately report Bedrock configuration and avoid irrelevant credential checks.
  * Improved provider-specific authentication messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->