### PR TITLE
fix(settings): resolve active machine on default WSS port

### DIFF
--- a/apps/mobile/lib/features/settings/state/settings_cubit.dart
+++ b/apps/mobile/lib/features/settings/state/settings_cubit.dart
@@ -148,7 +148,7 @@ class SettingsCubit extends Cubit<SettingsState> {
 
     final machine = manager.findByHostPort(
       uri.host,
-      uri.hasPort ? uri.port : 8765,
+      uri.port != 0 ? uri.port : 8765,
     );
     if (machine != null) {
       emit(state.copyWith(activeMachineId: machine.id));

--- a/apps/mobile/test/settings_cubit_push_test.dart
+++ b/apps/mobile/test/settings_cubit_push_test.dart
@@ -187,6 +187,34 @@ class FakeSecureStorage extends Fake implements FlutterSecureStorage {
 
 void main() {
   group('SettingsCubit push sync', () {
+    test('resolves active machine for WSS on the default HTTPS port', () async {
+      SharedPreferences.setMockInitialValues({
+        'machines_v2':
+            '[{"id":"$_testMachineId","host":"$_testHost","port":443}]',
+      });
+      final prefs = await SharedPreferences.getInstance();
+      final manager = await _createMachineManager(prefs);
+      await manager.init();
+      final bridge = FakeBridgeService()
+        ..emitConnection(
+          BridgeConnectionState.connected,
+          url: 'wss://$_testHost:443',
+        );
+      final fcm = FakeFcmService(available: false);
+      final cubit = SettingsCubit(
+        prefs,
+        bridgeService: bridge,
+        machineManager: manager,
+        fcmService: fcm,
+      );
+
+      expect(cubit.state.activeMachineId, _testMachineId);
+
+      await cubit.close();
+      await fcm.disposeFake();
+      bridge.dispose();
+    });
+
     test('auto registers token on init when machine is enabled', () async {
       SharedPreferences.setMockInitialValues({
         'settings_fcm_machines': '["$_testMachineId"]',


### PR DESCRIPTION
## Summary

Fix notification settings machine lookup when the connected Bridge uses the default WSS/HTTPS port (443). The app now matches the saved host:443 machine instead of falling back to port 8765, so the existing notification settings and FCM registration path remain available.

## Why This Is A PR

- Related Issue / Prompt Request: None — this is a small, self-contained port-normalization bug found in a real WSS deployment.
- Why this is ready for PR review: The implementation change is one line, includes an exact regression test, and was rebased and validated against the latest main.

## Changes

- Resolve the active machine with the URI's normalized port, including default HTTPS/WSS port 443.
- Add a regression test for a saved machine on port 443 connected through wss://host:443.

## Scope Check

- Single primary goal: Restore active-machine matching for default-port WSS connections.
- Intentionally out of scope: Bridge token persistence, relay behavior, and notification UI changes.
- Split plan or why this cannot be split: The implementation and its regression test form one atomic fix.

## Test Evidence

- Automated tests (command and result):
  - flutter test test/settings_cubit_push_test.dart — 12 tests passed.
  - dart analyze . — exit code 0; 45 existing info-level lints, no warnings or errors.
  - dart format --output=none --set-exit-if-changed apps/mobile/lib/features/settings/state/settings_cubit.dart apps/mobile/test/settings_cubit_push_test.dart — 0 files changed.
- Manual validation: Reproduced with an Android client whose saved machine uses port 443 and whose Bridge URL uses WSS on the default HTTPS port; before this fix, activeMachineId remained null and notification settings were unavailable.
- Target platform and version: Android client with a WSS reverse proxy on port 443; validation toolchain was macOS, Flutter 3.47.1, Dart 3.13.1.

## Risk and Rollback

- [x] Low
- [ ] Medium
- [ ] High
- Main risks: Connections without an explicit port now use the URI scheme's actual normalized default (80/443), matching the port the WebSocket connection uses.
- Rollback plan: Revert the two commits.

## UI Evidence

- [x] No user-visible UI change
- [ ] User-visible UI change
- No-visual-change reason: This changes machine resolution only; it restores access to the existing notification settings without adding or redesigning UI.
- Before: N/A
- After: N/A
- Device / platform: Android

## Author Checklist

- [x] I reviewed the complete diff and can explain and maintain this change.
- [x] This PR contains no unrelated changes.
- [x] User-facing or breaking changes are documented, or documentation is not applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection handling for secure bridge connections using the default HTTPS port.
  * Active machine settings now resolve correctly when connecting over WSS without an explicitly specified non-default port.

* **Tests**
  * Added coverage to verify active machine resolution for secure connections on port 443.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->