### PR TITLE
fix(ci): relax readiness checks for small PRs

### DIFF
--- a/scripts/pr-readiness.mjs
+++ b/scripts/pr-readiness.mjs
@@ -502,6 +502,15 @@ export function deferredCodeRabbitGate({ draft, oversized, intakePassed, overrid
   return { state: 'pending', detail: 'Not requested.' };
 }
 
+export function isCodeRabbitReviewEligible({
+  draft,
+  oversized,
+  intakePassed,
+  override,
+}) {
+  return !draft && !override && !oversized && intakePassed;
+}
+
 function readinessComment({ intake, ci, coderabbit, draft, override, fileCount }) {
   const intakeState = intake.errors.length === 0 ? 'success' : 'failure';
   const actionItems = [...intake.errors];
@@ -639,7 +648,12 @@ async function evaluatePullRequest({ repo, number, maintainer }) {
 
   const reviews = await paginate(`/repos/${repo}/pulls/${number}/reviews`);
   const intakePassed = intake.errors.length === 0;
-  const reviewEligible = !pr.draft && !intake.oversized && intakePassed;
+  const reviewEligible = isCodeRabbitReviewEligible({
+    draft: pr.draft,
+    oversized: intake.oversized,
+    intakePassed,
+    override,
+  });
   const ci = shouldEvaluateCi({ oversized: intake.oversized, override })
     ? await ciGate(repo, pr.merge_commit_sha)
     : { state: 'skipped', detail: 'Not run for an oversized PR.' };

--- a/scripts/pr-readiness.mjs
+++ b/scripts/pr-readiness.mjs
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url';
 
 export const MAX_REVIEW_FILES = 150;
 export const LARGE_PR_FILES = 50;
+export const SMALL_PR_FILES = 10;
 
 const MANAGED_LABELS = [
   'size:S',
@@ -103,6 +104,7 @@ function isMeaningful(value) {
 }
 
 export function getSection(body, title) {
+  body = body.replace(/\r\n?/g, '\n');
   const heading = new RegExp(`^##\\s+${escapeRegExp(title)}\\s*$`, 'im');
   const match = heading.exec(body);
   if (!match) return '';
@@ -169,7 +171,7 @@ function hasCheckedItem(section, text) {
 }
 
 export function sizeLabel(fileCount) {
-  if (fileCount <= 10) return 'size:S';
+  if (fileCount <= SMALL_PR_FILES) return 'size:S';
   if (fileCount <= 50) return 'size:M';
   if (fileCount <= MAX_REVIEW_FILES) return 'size:L';
   return 'size:XL';
@@ -198,7 +200,7 @@ export function evaluateIntake({ body, files, fileCount, draft = false }) {
   const oversized = fileCount > MAX_REVIEW_FILES;
   const large = fileCount > LARGE_PR_FILES && !oversized;
   const uiRelated = files.some(isUiRelatedPath);
-  const highRisk = files.some(isHighRiskPath);
+  const pathHighRisk = files.some(isHighRiskPath);
 
   if (oversized) {
     errors.push(
@@ -210,7 +212,8 @@ export function evaluateIntake({ body, files, fileCount, draft = false }) {
       oversized,
       large,
       uiRelated,
-      highRisk,
+      highRisk: pathHighRisk,
+      lightweight: false,
       size: sizeLabel(fileCount),
     };
   }
@@ -234,6 +237,12 @@ export function evaluateIntake({ body, files, fileCount, draft = false }) {
     errors.push('PRs changing more than 50 files must link a prior Issue or Prompt Request.');
   }
 
+  const riskSelections = ['Low', 'Medium', 'High'].filter((risk) =>
+    hasCheckedItem(sections['Risk and Rollback'], risk),
+  );
+  const highRisk = pathHighRisk || riskSelections.includes('High');
+  const lightweight = fileCount <= SMALL_PR_FILES && !highRisk;
+
   const requiredFields = [
     ['Why This Is A PR', 'Why this is ready for PR review'],
     ['Scope Check', 'Single primary goal'],
@@ -245,15 +254,24 @@ export function evaluateIntake({ body, files, fileCount, draft = false }) {
     ['Risk and Rollback', 'Main risks'],
     ['Risk and Rollback', 'Rollback plan'],
   ];
+  const lightweightAdvisoryFields = new Set([
+    'Why this is ready for PR review',
+    'Intentionally out of scope',
+    'Split plan or why this cannot be split',
+    'Manual validation',
+    'Target platform and version',
+  ]);
   for (const [sectionName, fieldName] of requiredFields) {
     if (!isCompletedField(getField(sections[sectionName], fieldName))) {
-      errors.push(`Complete “${fieldName}” in the ${sectionName} section.`);
+      const message = `Complete “${fieldName}” in the ${sectionName} section.`;
+      if (lightweight && lightweightAdvisoryFields.has(fieldName)) {
+        warnings.push(`Small low-risk PR: ${message}`);
+      } else {
+        errors.push(message);
+      }
     }
   }
 
-  const riskSelections = ['Low', 'Medium', 'High'].filter((risk) =>
-    hasCheckedItem(sections['Risk and Rollback'], risk),
-  );
   if (riskSelections.length !== 1) {
     errors.push('Select exactly one risk level: Low, Medium, or High.');
   }
@@ -324,6 +342,7 @@ export function evaluateIntake({ body, files, fileCount, draft = false }) {
     large,
     uiRelated,
     highRisk,
+    lightweight,
     size: sizeLabel(fileCount),
   };
 }
@@ -459,7 +478,28 @@ async function ciGate(repo, mergeCommitSha) {
 function gateIcon(state) {
   if (state === 'success') return '✅';
   if (state === 'failure') return '❌';
+  if (state === 'skipped') return '➖';
   return '⏳';
+}
+
+export function shouldEvaluateCi({ oversized, override }) {
+  return !oversized || override;
+}
+
+export function deferredCodeRabbitGate({ draft, oversized, intakePassed, override }) {
+  if (draft) {
+    return { state: 'pending', detail: 'Not requested while the PR is a draft.' };
+  }
+  if (override) {
+    return { state: 'skipped', detail: 'Skipped by maintainer override.' };
+  }
+  if (oversized) {
+    return { state: 'skipped', detail: 'Not requested for an oversized PR.' };
+  }
+  if (!intakePassed) {
+    return { state: 'pending', detail: 'Not requested until intake passes.' };
+  }
+  return { state: 'pending', detail: 'Not requested.' };
 }
 
 function readinessComment({ intake, ci, coderabbit, draft, override, fileCount }) {
@@ -600,12 +640,17 @@ async function evaluatePullRequest({ repo, number, maintainer }) {
   const reviews = await paginate(`/repos/${repo}/pulls/${number}/reviews`);
   const intakePassed = intake.errors.length === 0;
   const reviewEligible = !pr.draft && !intake.oversized && intakePassed;
-  const ci = reviewEligible
+  const ci = shouldEvaluateCi({ oversized: intake.oversized, override })
     ? await ciGate(repo, pr.merge_commit_sha)
-    : { state: 'pending', detail: 'Waiting for intake readiness.' };
+    : { state: 'skipped', detail: 'Not run for an oversized PR.' };
   const coderabbit = reviewEligible
     ? codeRabbitGate(reviews, pr.head.sha)
-    : { state: 'pending', detail: 'Waiting for intake readiness.' };
+    : deferredCodeRabbitGate({
+        draft: pr.draft,
+        oversized: intake.oversized,
+        intakePassed,
+        override,
+      });
   const ready =
     !pr.draft &&
     (override ||

--- a/scripts/pr-readiness.mjs
+++ b/scripts/pr-readiness.mjs
@@ -445,13 +445,13 @@ function codeRabbitGate(reviews, headSha) {
   return { state: 'pending', detail: `CodeRabbit review state: ${review.state}.` };
 }
 
-async function ciGate(repo, mergeCommitSha) {
-  if (!mergeCommitSha) {
-    return { state: 'failure', detail: 'The PR has no testable merge commit.' };
+async function ciGate(repo, commitSha) {
+  if (!commitSha) {
+    return { state: 'failure', detail: 'The PR has no testable head commit.' };
   }
 
   const result = await request(
-    `/repos/${repo}/commits/${mergeCommitSha}/check-runs?filter=latest&per_page=100`,
+    `/repos/${repo}/commits/${commitSha}/check-runs?filter=latest&per_page=100`,
   );
   const requiredJobs = ['repository', 'mobile', 'bridge', 'functions'];
   const checks = new Map(result.check_runs?.map((check) => [check.name, check]) ?? []);
@@ -484,6 +484,10 @@ function gateIcon(state) {
 
 export function shouldEvaluateCi({ oversized, override }) {
   return !oversized || override;
+}
+
+export function ciCheckSha(pr) {
+  return pr.head?.sha ?? null;
 }
 
 export function deferredCodeRabbitGate({ draft, oversized, intakePassed, override }) {
@@ -655,7 +659,7 @@ async function evaluatePullRequest({ repo, number, maintainer }) {
     override,
   });
   const ci = shouldEvaluateCi({ oversized: intake.oversized, override })
-    ? await ciGate(repo, pr.merge_commit_sha)
+    ? await ciGate(repo, ciCheckSha(pr))
     : { state: 'skipped', detail: 'Not run for an oversized PR.' };
   const coderabbit = reviewEligible
     ? codeRabbitGate(reviews, pr.head.sha)

--- a/scripts/pr-readiness.test.mjs
+++ b/scripts/pr-readiness.test.mjs
@@ -8,6 +8,7 @@ import {
   evaluateIntake,
   getField,
   getSection,
+  isCodeRabbitReviewEligible,
   isHighRiskPath,
   isReviewPolicyPath,
   isUiRelatedPath,
@@ -314,5 +315,26 @@ test('explains why CodeRabbit was not requested', () => {
       override: true,
     }),
     { state: 'skipped', detail: 'Skipped by maintainer override.' },
+  );
+});
+
+test('does not request CodeRabbit when a maintainer override applies', () => {
+  assert.equal(
+    isCodeRabbitReviewEligible({
+      draft: false,
+      oversized: false,
+      intakePassed: true,
+      override: true,
+    }),
+    false,
+  );
+  assert.equal(
+    isCodeRabbitReviewEligible({
+      draft: false,
+      oversized: false,
+      intakePassed: true,
+      override: false,
+    }),
+    true,
   );
 });

--- a/scripts/pr-readiness.test.mjs
+++ b/scripts/pr-readiness.test.mjs
@@ -3,6 +3,8 @@ import test from 'node:test';
 
 import {
   MAX_REVIEW_FILES,
+  SMALL_PR_FILES,
+  deferredCodeRabbitGate,
   evaluateIntake,
   getField,
   getSection,
@@ -10,6 +12,7 @@ import {
   isReviewPolicyPath,
   isUiRelatedPath,
   requiresReviewPolicyOverride,
+  shouldEvaluateCi,
   sizeLabel,
 } from './pr-readiness.mjs';
 
@@ -98,6 +101,15 @@ test('extracts markdown sections and multiline fields', () => {
   );
 });
 
+test('accepts CRLF line endings from GitHub web form edits', () => {
+  const result = evaluateIntake({
+    body: body().replace(/\n/g, '\r\n'),
+    files: ['apps/mobile/lib/features/settings/state/settings_cubit.dart'],
+    fileCount: 1,
+  });
+  assert.deepEqual(result.errors, []);
+});
+
 test('accepts a complete non-UI PR', () => {
   const result = evaluateIntake({
     body: body(),
@@ -107,6 +119,56 @@ test('accepts a complete non-UI PR', () => {
   assert.deepEqual(result.errors, []);
   assert.equal(result.uiRelated, false);
   assert.equal(result.size, 'size:S');
+});
+
+test('treats supporting context as advisory for a small low-risk PR', () => {
+  const result = evaluateIntake({
+    body: body({
+      why: '',
+      outOfScope: '',
+      splitPlan: '',
+      manual: '',
+      platform: '',
+    }),
+    files: ['apps/mobile/lib/features/settings/state/settings_cubit.dart'],
+    fileCount: SMALL_PR_FILES,
+  });
+  assert.deepEqual(result.errors, []);
+  assert.equal(result.lightweight, true);
+  assert.equal(result.warnings.length, 5);
+});
+
+test('keeps supporting context mandatory for high-risk PRs', () => {
+  const result = evaluateIntake({
+    body: body({ manual: '' }),
+    files: ['packages/bridge/src/websocket.ts'],
+    fileCount: 1,
+  });
+  assert.ok(result.errors.some((error) => error.includes('Manual validation')));
+  assert.equal(result.lightweight, false);
+});
+
+test('keeps supporting context mandatory when the author selects high risk', () => {
+  const result = evaluateIntake({
+    body: body({ risk: 'High', manual: '' }),
+    files: ['docs/maintenance.md'],
+    fileCount: 1,
+  });
+  assert.ok(result.errors.some((error) => error.includes('Manual validation')));
+  assert.equal(result.highRisk, true);
+  assert.equal(result.lightweight, false);
+});
+
+test('keeps supporting context mandatory above the small PR limit', () => {
+  const result = evaluateIntake({
+    body: body({ splitPlan: '' }),
+    files: Array.from({ length: SMALL_PR_FILES + 1 }, (_, index) =>
+      `docs/file-${index}.md`,
+    ),
+    fileCount: SMALL_PR_FILES + 1,
+  });
+  assert.ok(result.errors.some((error) => error.includes('Split plan')));
+  assert.equal(result.lightweight, false);
 });
 
 test('requires a reason when mobile files claim no visual change', () => {
@@ -213,5 +275,44 @@ test('requires maintainer override for external review-policy changes', () => {
       override: false,
     }),
     false,
+  );
+});
+
+test('evaluates CI independently from intake readiness', () => {
+  assert.equal(
+    shouldEvaluateCi({ oversized: false, override: false, intakePassed: false }),
+    true,
+  );
+  assert.equal(shouldEvaluateCi({ oversized: true, override: false }), false);
+  assert.equal(shouldEvaluateCi({ oversized: true, override: true }), true);
+});
+
+test('explains why CodeRabbit was not requested', () => {
+  assert.deepEqual(
+    deferredCodeRabbitGate({
+      draft: true,
+      oversized: false,
+      intakePassed: true,
+      override: false,
+    }),
+    { state: 'pending', detail: 'Not requested while the PR is a draft.' },
+  );
+  assert.deepEqual(
+    deferredCodeRabbitGate({
+      draft: false,
+      oversized: false,
+      intakePassed: false,
+      override: false,
+    }),
+    { state: 'pending', detail: 'Not requested until intake passes.' },
+  );
+  assert.deepEqual(
+    deferredCodeRabbitGate({
+      draft: false,
+      oversized: false,
+      intakePassed: false,
+      override: true,
+    }),
+    { state: 'skipped', detail: 'Skipped by maintainer override.' },
   );
 });

--- a/scripts/pr-readiness.test.mjs
+++ b/scripts/pr-readiness.test.mjs
@@ -4,6 +4,7 @@ import test from 'node:test';
 import {
   MAX_REVIEW_FILES,
   SMALL_PR_FILES,
+  ciCheckSha,
   deferredCodeRabbitGate,
   evaluateIntake,
   getField,
@@ -286,6 +287,17 @@ test('evaluates CI independently from intake readiness', () => {
   );
   assert.equal(shouldEvaluateCi({ oversized: true, override: false }), false);
   assert.equal(shouldEvaluateCi({ oversized: true, override: true }), true);
+});
+
+test('reads Test check runs from the PR head commit', () => {
+  assert.equal(
+    ciCheckSha({
+      head: { sha: 'head-sha' },
+      merge_commit_sha: 'temporary-merge-sha',
+    }),
+    'head-sha',
+  );
+  assert.equal(ciCheckSha({}), null);
 });
 
 test('explains why CodeRabbit was not requested', () => {


### PR DESCRIPTION
## Summary

Fix CRLF parsing false negatives in PR Readiness and introduce a lightweight intake lane for small, low-risk pull requests while preserving strict checks for high-risk changes.

## Why This Is A PR

- Related Issue / Prompt Request: None — this is a focused correction and policy adjustment prompted by PR #230.
- Why this is ready for PR review: The policy changes are covered by focused unit tests and were independently self-reviewed.

## Changes

- Normalize CRLF and CR line endings before parsing PR template sections.
- Treat five supporting context fields as advisory for PRs with 10 files or fewer that do not touch or declare high-risk areas.
- Evaluate CI independently from Intake readiness.
- Distinguish CodeRabbit pending and skipped reasons for draft, oversized, intake-blocked, and override cases.
- Add regression and boundary tests for each policy change.

## Scope Check

- Single primary goal: Make PR Readiness reliable and proportionate for small, low-risk contributions.
- Intentionally out of scope: Changing the 150-file hard limit, relaxing high-risk review requirements, or changing CodeRabbit review content.
- Split plan or why this cannot be split: The parser fix, lightweight lane, and gate-state clarity are one coherent readiness-policy adjustment needed to unblock PR #230 safely.

## Test Evidence

- Automated tests (command and result): `npm run test:pr-readiness` — 17 tests passed; `node --check scripts/pr-readiness.mjs` and `node --check scripts/pr-readiness.test.mjs` — passed; `git diff --check` — passed.
- Manual validation: Evaluated the live CRLF-formatted body and changed paths from PR #230 with the updated checker; result was zero errors and zero warnings.
- Target platform and version: macOS, Node.js 22.22.1.

## Risk and Rollback

- [ ] Low
- [ ] Medium
- [x] High
- Main risks: Incorrect classification could admit under-documented PRs or delay review automation. High-risk paths and author-selected High risk remain on the strict lane, and oversized PR behavior remains unchanged.
- Rollback plan: Revert commit b0466aa2.

## UI Evidence

- [x] No user-visible UI change
- [ ] User-visible UI change
- No-visual-change reason: This changes GitHub PR automation only.
- Before: N/A
- After: N/A
- Device / platform: GitHub Actions

## Author Checklist

- [x] I reviewed the complete diff and can explain and maintain this change.
- [x] This PR contains no unrelated changes.
- [x] User-facing or breaking changes are documented, or documentation is not applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added streamlined intake handling for small, low-risk pull requests.
  * Added clearer status reporting for CI and deferred review checks, including drafts, oversized changes, overrides, and intake failures.
  * CI checks now run for oversized pull requests when an approved override is provided.
  * Added eligibility checks for automated CodeRabbit reviews.

* **Bug Fixes**
  * Improved parsing of intake details across different line-ending formats.
  * Advisory omissions for eligible small pull requests now appear as warnings instead of errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->