### PR TITLE
fix(ci): accept completed CodeRabbit reviews

### DIFF
--- a/scripts/pr-readiness.mjs
+++ b/scripts/pr-readiness.mjs
@@ -429,20 +429,43 @@ function latestReviewFor(reviews, predicate) {
     )[0];
 }
 
-function codeRabbitGate(reviews, headSha) {
-  const review = latestReviewFor(reviews, (item) =>
-    CODERABBIT_REVIEWERS.has(String(item.user?.login ?? '').toLowerCase()),
+export function codeRabbitGate(reviews, statuses, headSha) {
+  const review = latestReviewFor(
+    reviews,
+    (item) =>
+      item.commit_id === headSha &&
+      CODERABBIT_REVIEWERS.has(String(item.user?.login ?? '').toLowerCase()),
   );
-  if (!review || review.commit_id !== headSha) {
-    return { state: 'pending', detail: 'Waiting for CodeRabbit review on the latest commit.' };
+  if (review) {
+    if (review.state === 'APPROVED') {
+      return { state: 'success', detail: 'CodeRabbit approved the latest commit.' };
+    }
+    if (review.state === 'CHANGES_REQUESTED') {
+      return { state: 'failure', detail: 'Resolve CodeRabbit change requests.' };
+    }
+    return { state: 'pending', detail: `CodeRabbit review state: ${review.state}.` };
   }
-  if (review.state === 'APPROVED') {
-    return { state: 'success', detail: 'CodeRabbit approved the latest commit.' };
+
+  const status = statuses
+    .filter((item) => String(item.context ?? '').toLowerCase() === 'coderabbit')
+    .sort((left, right) =>
+      String(right.updated_at ?? right.created_at ?? '').localeCompare(
+        String(left.updated_at ?? left.created_at ?? ''),
+      ),
+    )[0];
+  if (
+    status?.state === 'success' &&
+    /^review completed$/i.test(String(status.description ?? '').trim())
+  ) {
+    return {
+      state: 'success',
+      detail: 'CodeRabbit completed the latest review with no change request.',
+    };
   }
-  if (review.state === 'CHANGES_REQUESTED') {
-    return { state: 'failure', detail: 'Resolve CodeRabbit change requests.' };
+  if (status?.state === 'failure' || status?.state === 'error') {
+    return { state: 'failure', detail: 'Resolve CodeRabbit check failures.' };
   }
-  return { state: 'pending', detail: `CodeRabbit review state: ${review.state}.` };
+  return { state: 'pending', detail: 'Waiting for CodeRabbit review on the latest commit.' };
 }
 
 async function ciGate(repo, commitSha) {
@@ -661,8 +684,11 @@ async function evaluatePullRequest({ repo, number, maintainer }) {
   const ci = shouldEvaluateCi({ oversized: intake.oversized, override })
     ? await ciGate(repo, ciCheckSha(pr))
     : { state: 'skipped', detail: 'Not run for an oversized PR.' };
+  const commitStatus = reviewEligible
+    ? await request(`/repos/${repo}/commits/${pr.head.sha}/status`)
+    : { statuses: [] };
   const coderabbit = reviewEligible
-    ? codeRabbitGate(reviews, pr.head.sha)
+    ? codeRabbitGate(reviews, commitStatus.statuses ?? [], pr.head.sha)
     : deferredCodeRabbitGate({
         draft: pr.draft,
         oversized: intake.oversized,

--- a/scripts/pr-readiness.mjs
+++ b/scripts/pr-readiness.mjs
@@ -447,7 +447,15 @@ export function codeRabbitGate(reviews, statuses, headSha) {
   }
 
   const status = statuses
-    .filter((item) => String(item.context ?? '').toLowerCase() === 'coderabbit')
+    .filter((item) => {
+      if (String(item.context ?? '').toLowerCase() !== 'coderabbit') return false;
+      const creator = item.creator?.login;
+      // CodeRabbit's current commit statuses use a null creator. Reject an
+      // explicitly foreign creator while retaining compatibility with that output.
+      return (
+        !creator || CODERABBIT_REVIEWERS.has(String(creator).toLowerCase())
+      );
+    })
     .sort((left, right) =>
       String(right.updated_at ?? right.created_at ?? '').localeCompare(
         String(left.updated_at ?? left.created_at ?? ''),
@@ -684,11 +692,11 @@ async function evaluatePullRequest({ repo, number, maintainer }) {
   const ci = shouldEvaluateCi({ oversized: intake.oversized, override })
     ? await ciGate(repo, ciCheckSha(pr))
     : { state: 'skipped', detail: 'Not run for an oversized PR.' };
-  const commitStatus = reviewEligible
-    ? await request(`/repos/${repo}/commits/${pr.head.sha}/status`)
-    : { statuses: [] };
+  const commitStatuses = reviewEligible
+    ? await paginate(`/repos/${repo}/commits/${pr.head.sha}/statuses`)
+    : [];
   const coderabbit = reviewEligible
-    ? codeRabbitGate(reviews, commitStatus.statuses ?? [], pr.head.sha)
+    ? codeRabbitGate(reviews, commitStatuses, pr.head.sha)
     : deferredCodeRabbitGate({
         draft: pr.draft,
         oversized: intake.oversized,

--- a/scripts/pr-readiness.test.mjs
+++ b/scripts/pr-readiness.test.mjs
@@ -5,6 +5,7 @@ import {
   MAX_REVIEW_FILES,
   SMALL_PR_FILES,
   ciCheckSha,
+  codeRabbitGate,
   deferredCodeRabbitGate,
   evaluateIntake,
   getField,
@@ -327,6 +328,147 @@ test('explains why CodeRabbit was not requested', () => {
       override: true,
     }),
     { state: 'skipped', detail: 'Skipped by maintainer override.' },
+  );
+});
+
+test('accepts a completed CodeRabbit status when no review object was created', () => {
+  assert.deepEqual(
+    codeRabbitGate(
+      [],
+      [
+        {
+          context: 'CodeRabbit',
+          state: 'success',
+          description: 'Review completed',
+        },
+      ],
+      'head-sha',
+    ),
+    {
+      state: 'success',
+      detail: 'CodeRabbit completed the latest review with no change request.',
+    },
+  );
+});
+
+test('does not accept a skipped CodeRabbit success status', () => {
+  assert.deepEqual(
+    codeRabbitGate(
+      [],
+      [
+        {
+          context: 'CodeRabbit',
+          state: 'success',
+          description: 'Review skipped: excluded by label configuration',
+        },
+      ],
+      'head-sha',
+    ),
+    {
+      state: 'pending',
+      detail: 'Waiting for CodeRabbit review on the latest commit.',
+    },
+  );
+});
+
+test('requires an exact CodeRabbit review-completed description', () => {
+  assert.deepEqual(
+    codeRabbitGate(
+      [],
+      [
+        {
+          context: 'CodeRabbit',
+          state: 'success',
+          description: 'Review completed: review skipped',
+        },
+      ],
+      'head-sha',
+    ),
+    {
+      state: 'pending',
+      detail: 'Waiting for CodeRabbit review on the latest commit.',
+    },
+  );
+});
+
+test('uses the latest CodeRabbit status when older completed statuses remain', () => {
+  assert.deepEqual(
+    codeRabbitGate(
+      [],
+      [
+        {
+          context: 'CodeRabbit',
+          state: 'success',
+          description: 'Review completed',
+          updated_at: '2026-08-29T00:00:00Z',
+        },
+        {
+          context: 'CodeRabbit',
+          state: 'success',
+          description: 'Review skipped: excluded by label configuration',
+          updated_at: '2026-08-29T00:01:00Z',
+        },
+      ],
+      'head-sha',
+    ),
+    {
+      state: 'pending',
+      detail: 'Waiting for CodeRabbit review on the latest commit.',
+    },
+  );
+});
+
+test('keeps latest CodeRabbit change requests blocking', () => {
+  assert.deepEqual(
+    codeRabbitGate(
+      [
+        {
+          user: { login: 'coderabbitai' },
+          commit_id: 'head-sha',
+          state: 'CHANGES_REQUESTED',
+          submitted_at: '2026-08-29T00:00:00Z',
+        },
+      ],
+      [
+        {
+          context: 'CodeRabbit',
+          state: 'success',
+          description: 'Review completed',
+        },
+      ],
+      'head-sha',
+    ),
+    { state: 'failure', detail: 'Resolve CodeRabbit change requests.' },
+  );
+});
+
+test('does not let a late old-commit review hide head change requests', () => {
+  assert.deepEqual(
+    codeRabbitGate(
+      [
+        {
+          user: { login: 'coderabbitai' },
+          commit_id: 'head-sha',
+          state: 'CHANGES_REQUESTED',
+          submitted_at: '2026-08-29T00:00:00Z',
+        },
+        {
+          user: { login: 'coderabbitai' },
+          commit_id: 'old-sha',
+          state: 'APPROVED',
+          submitted_at: '2026-08-29T00:01:00Z',
+        },
+      ],
+      [
+        {
+          context: 'CodeRabbit',
+          state: 'success',
+          description: 'Review completed',
+        },
+      ],
+      'head-sha',
+    ),
+    { state: 'failure', detail: 'Resolve CodeRabbit change requests.' },
   );
 });
 

--- a/scripts/pr-readiness.test.mjs
+++ b/scripts/pr-readiness.test.mjs
@@ -391,6 +391,42 @@ test('requires an exact CodeRabbit review-completed description', () => {
   );
 });
 
+test('rejects a CodeRabbit context status from an explicitly foreign creator', () => {
+  assert.deepEqual(
+    codeRabbitGate(
+      [],
+      [
+        {
+          context: 'CodeRabbit',
+          state: 'success',
+          description: 'Review completed',
+          creator: { login: 'unrelated-bot' },
+        },
+      ],
+      'head-sha',
+    ),
+    {
+      state: 'pending',
+      detail: 'Waiting for CodeRabbit review on the latest commit.',
+    },
+  );
+});
+
+test('finds a CodeRabbit status after the first API page', () => {
+  const statuses = Array.from({ length: 100 }, (_, index) => ({
+    context: `other-check-${index}`,
+    state: 'success',
+    description: 'Completed',
+  }));
+  statuses.push({
+    context: 'CodeRabbit',
+    state: 'success',
+    description: 'Review completed',
+  });
+
+  assert.equal(codeRabbitGate([], statuses, 'head-sha').state, 'success');
+});
+
 test('uses the latest CodeRabbit status when older completed statuses remain', () => {
   assert.deepEqual(
     codeRabbitGate(


### PR DESCRIPTION
## Summary

Allow PR Readiness to accept CodeRabbit's successful `Review completed` commit status when a no-actionable-comments review does not create a GitHub Review object.

## Why This Is A PR

- Related Issue / Prompt Request: None — this is a focused readiness deadlock discovered while validating PR #230.
- Why this is ready for PR review: The change is isolated to CodeRabbit gate interpretation and has explicit positive, negative, stale-status, and Request Changes regression tests.

## Changes

- Accept an exact latest `CodeRabbit: success / Review completed` status as a successful gate when no latest-head Review object exists.
- Continue rejecting skipped success statuses and failed checks.
- Prioritize latest-head `CHANGES_REQUESTED` reviews over commit statuses.
- Sort repeated CodeRabbit statuses by timestamp to avoid stale success results.

## Scope Check

- Single primary goal: Prevent permanent Readiness pending states after successful no-comment CodeRabbit reviews.
- Intentionally out of scope: Changing CodeRabbit configuration, pre-merge checks, or bypassing Request Changes.
- Split plan or why this cannot be split: The gate logic and its regression tests are one atomic fix.

## Test Evidence

- Automated tests (command and result): `npm run test:pr-readiness` — 25 tests passed; `node --check scripts/pr-readiness.mjs` — passed; `git diff --check` — passed.
- Manual validation: Confirmed PR #230 has no Review object and an actual latest CodeRabbit status of `success` with exact description `Review completed`.
- Target platform and version: GitHub Actions, macOS local validation, Node.js 22.

## Risk and Rollback

- [ ] Low
- [ ] Medium
- [x] High
- Main risks: A loose status match could incorrectly admit skipped reviews. Exact description matching, latest-status selection, and latest-head Request Changes precedence prevent that case.
- Rollback plan: Revert commit 329515f5.

## UI Evidence

- [x] No user-visible UI change
- [ ] User-visible UI change
- No-visual-change reason: This changes GitHub PR automation only.
- Before: N/A
- After: N/A
- Device / platform: GitHub Actions

## Author Checklist

- [x] I reviewed the complete diff and can explain and maintain this change.
- [x] This PR contains no unrelated changes.
- [x] User-facing or breaking changes are documented, or documentation is not applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull-request readiness checks to recognize completed CodeRabbit reviews reported through commit statuses.
  * Checks now include statuses beyond the initial results page and correctly prioritize the latest applicable review.
  * Skipped, incomplete, failed, or explicitly foreign-author checks continue to block readiness, while statuses without author information remain supported.
  * Change requests on the current commit remain correctly enforced.

* **Tests**
  * Added coverage for status discovery, precedence rules, skipped reviews, foreign authors, and blocking change requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->