### PR TITLE
chore(review): gate external PR quality before maintainer handoff

### DIFF
--- a/.claude/skills/triage/SKILL.md
+++ b/.claude/skills/triage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: triage
-description: "GitHub Issue・PRを低トークンでトリアージし、要望、実現難易度、重複、リスク、対応判断をレポートする。Issue/PR番号、トリアージ、優先度、対応判断、PRレビュー準備判定を依頼されたときに使用する。PRはReadiness、CI、CodeRabbitを先に確認し、未通過ならdiffを読まず終了する。"
+description: "GitHub Issue・PRを低トークンでトリアージする。Issue/PR番号、優先度、対応判断、外部PRの受入基準を扱う。PRはReadiness、CI、CodeRabbitを先に確認し、未通過ならdiffを読まず終了。通過後は製品判断に絞り、取り込み依頼時はCodex側で修正・検証してマージする。"
 ---
 
 # Issue / PR Triage
@@ -18,17 +18,21 @@ description: "GitHub Issue・PRを低トークンでトリアージし、要望�
 - PRでは必ずReadiness判定を最初に行う。
 - ReadyでないPRのdiff、全コメント、コードベースを読まない。
 - CodeRabbitの指摘を再レビューせず、製品判断・設計・高リスク箇所に集中する。
+- 品質基準は `CONTRIBUTING.md` と `.coderabbit.yaml`。AI利用や文章の雰囲気ではなく、スコープ、実装の必要性、検証証拠で判断する。
+- Codexフェーズでは投稿者へRequest Changesや修正ラリーを返さない。取り込めるならこちらで直し、費用対効果が悪ければ見送る。
 - サブエージェントはMedium/High以上で独立した調査面がある場合だけ使う。
 - `--force`時は、バイパスした条件と理由をレポートする。
-- コメント投稿、ラベル変更、クローズなどのGitHub更新は、ユーザーが依頼した場合だけ行う。
+- `/triage <number>`単独は判断を返す。取り込み・マージまで依頼済みなら修正、検証、マージまで進め、同じ許可を再確認しない。コメント投稿は明示依頼がある場合だけ行う。
 
 ## Phase 0: 種別判定
 
-まずIssueとして取得し、取得できなければPRとして扱う。
+共通のIssue APIで種別を判定する。APIエラーをPR扱いしない。PR判定前にコメントを取得しない。
 
 ```bash
-gh issue view <number> --json number,title,body,labels,state,comments,author,createdAt
-gh pr view <number> --json number,title,body,labels,state,isDraft,author,createdAt,changedFiles,additions,deletions,headRefOid,reviewDecision,statusCheckRollup
+gh api "repos/{owner}/{repo}/issues/<number>" \
+  --jq '{number,title,body,labels:[.labels[].name],state,author:.user.login,isPR:(.pull_request != null)}'
+# PRの場合だけ追加取得。bodyは再取得しない。
+gh pr view <number> --json number,isDraft,changedFiles,additions,deletions,headRefOid,reviewDecision,statusCheckRollup
 ```
 
 Issueなら「Issueフロー」、PRなら「PRフロー」へ進む。
@@ -46,16 +50,18 @@ Issueなら「Issueフロー」、PRなら「PRフロー」へ進む。
    - 51〜150: 関連Issue / Prompt Requestと分割不能理由を必須とする
    - 150超: `NOT READY`。Size以外のgateは判定せず、分割依頼とクローズだけを推奨して、ここで終了する
 2. **Draft**: Draftなら`NOT READY`
-3. **レビュー基盤**: 外部PRが`.coderabbit.yaml`、`.github/workflows/**`、PRテンプレート、PR Readiness checker、エージェント指示・設定を変更する場合、メンテナの`review:override`がなければ`NOT READY`
-4. **PR本文**: テンプレートの必須欄とAuthor Checklistを確認する
-5. **UI証拠**
-   - visible UI変更: Before / Afterとdevice/platformを必須とする
+3. **品質保留**: `status:quality-hold`があれば`NOT READY`として終了。CodeRabbitのSlop検出ラベルをReadinessが停止条件にする。訂正後・誤検出時の解除はメンテナが行う。自動クローズやAI利用だけを理由とした拒否はしない。
+4. **レビュー基盤**: 外部PRが`.coderabbit.yaml`、`.github/workflows/**`、PRテンプレート、PR Readiness checker、エージェント指示・設定を変更する場合、メンテナの`review:override`がなければ`NOT READY`
+5. **PR本文**: テンプレートの必須欄とAuthor Checklistを確認する。10ファイル以下かつ低リスクでは、補足理由、対象外、分割計画、手動検証、platformはReadiness上の助言項目。OS依存の変更では対象環境の検証証拠を必須とする。
+6. **UI証拠**
+   - レイアウト・外観・操作変更: Before / Afterとdevice/platformを必須とする
    - 新規UI: Beforeは`N/A — 理由`を許可する
+   - 文言のみ: 成功した `flutter test ...` のコマンド・結果と画像不要理由で代替可能
    - mobile UI領域の非表示変更: スクリーンショット不要理由を必須とする
-6. **PR Readiness status**: 最新head commitで成功していることを確認する
-7. **CI**: `Test` workflowが成功していることを確認する
-8. **CodeRabbit**: 最新head commitがApprove済みで、未解決のRequest Changesがないことを確認する
-9. **Ready label**: `ready-for-maintainer-review`が付いていることを確認する
+7. **PR Readiness status**: 最新head commitで成功していることを確認する
+8. **CI**: `Test` workflowが成功していることを確認する
+9. **CodeRabbit**: 最新headのレビュー完了と明示的なApprove、未解決Request Changesなしを必須とする。`Review completed`や緑のstatusだけでは不足。
+10. **Ready label**: `ready-for-maintainer-review`が付いていることを確認する
 
 必要ならレビュー状態だけを小さく取得する。本文は取得しない。
 
@@ -65,6 +71,8 @@ gh pr view <number> --json statusCheckRollup --jq '.statusCheckRollup'
 gh api "repos/{owner}/{repo}/pulls/<number>/reviews?per_page=100" --paginate \
   --jq '[.[] | {author: .user.login, state, commitId: .commit_id, submittedAt: .submitted_at}]'
 ```
+
+自動Readinessが成功していても、CodeRabbit walkthroughの設定済み必須チェックが未実行、Inconclusive、無断でignoredなら通常のReadyとして扱わない。詳細な指摘の再レビューは不要。利用プラン・障害でチェックできない場合は基盤の問題として報告し、投稿者に同じ修正を繰り返させない。
 
 いずれかが未通過なら、次の短い形式で終了する。diff取得、既存コード調査、サブエージェント起動を禁止する。
 
@@ -85,6 +93,7 @@ Size gateで終了し、他のgateとdiffは確認していません。
 | Gate | Status |
 | --- | --- |
 | Size | [status] |
+| Quality hold | [status] |
 | Template | [status] |
 | UI evidence | [status] |
 | CI | [status] |
@@ -96,16 +105,20 @@ Size gateで終了し、他のgateとdiffは確認していません。
 深掘りレビューはまだ実施していません。
 ```
 
-`--force`が指定された場合だけPhase 2へ進み、未通過条件を冒頭に残す。
+`--force`、またはメンテナの理由付き`review:override`がある場合だけ未通過でもPhase 2へ進み、未通過条件を冒頭に残す。通常の取り込み修正のためにoverrideを使わない。
 
 ### Phase 2: Risk map
 
-ReadyなPRだけ、変更ファイル名とCodeRabbitのwalkthrough・指摘要約を確認する。
+ReadyなPRだけ、変更ファイル名とCodeRabbitの最新walkthrough・指摘要約を確認する。Phase 1で取得済みの情報は再利用する。
 
 ```bash
 gh pr view <number> --json files --jq '.files[] | {path, additions, deletions}'
-gh pr view <number> --json comments,reviews --jq '{comments, reviews}'
+# Phase 1の必須チェック確認でもこれを使い、最新のbotコメントだけ出力する。
+gh api "repos/{owner}/{repo}/issues/<number>/comments?per_page=100" --paginate --slurp \
+  --jq '[.[][] | select(.user.login == "coderabbitai[bot]" or .user.login == "coderabbitai") | select(.body | contains("<!-- walkthrough_start -->"))] | max_by(.updated_at) | {body,html_url}'
 ```
+
+walkthroughの形式が変わった場合も最新のbot要約だけを取得し、全コメント・全レビュー本文を出力しない。製品価値が低い、合意した目的と違う、保守できないことがここで明白なら`見送り`で終了する。
 
 変更を次のリスクに分類する。
 
@@ -148,6 +161,8 @@ gh pr diff <number>
 - 認証、許可ディレクトリ、path traversal、process cleanup、secret
 - 正式サポート環境への回帰リスク
 
+読む範囲を広げるのは未解決の具体的な疑問がある場合だけ。Lowでは目的と関連patchが一致し、既存パターン・検証証拠に問題がなければ終了する。CodeRabbitの全指摘の追認や全リポジトリ再レビューをしない。
+
 Medium/High以上でBridgeとFlutterなど独立した調査面がある場合だけ、Exploreサブエージェントへ対象を限定して依頼する。Lowまたは単一ファイルでは使わない。
 
 ### Phase 4: PRレポート
@@ -178,11 +193,13 @@ Medium/High以上でBridgeとFlutterなど独立した調査面がある場合�
 | ユーザー価値 | [高/中/低 — 理由] |
 | 取り込みコスト | [高/中/低 — 理由] |
 | 回帰・保守リスク | [高/中/低 — 理由] |
-| 推奨 | [直接マージ / 修正依頼 / 部分取り込み / 再実装 / 見送り] |
+| 推奨 | [直接マージ / こちらで修正してマージ / 部分取り込み / 見送り] |
 
 ### 推奨アクション
 - [具体的な次の手順]
 ```
+
+Lowでは「Ready根拠・目的・リスク・判断・こちらで直す点」を数行で返せばよい。形式を埋めるための追加調査をしない。
 
 ## Issueフロー
 
@@ -264,13 +281,23 @@ experimental / 未サポート環境では次を追加で見る。
 
 ### 外部PRの取り込み
 
-全PRを再実装しない。品質とリスクで選ぶ。
+Ready通過後の担当はメンテナ / Codex。投稿者へのRequest Changes、修正依頼コメント、細かな再提出要求を選択肢にしない。事前ゲートへの対応は投稿者とCodeRabbitに任せる。
 
 - 小規模、Ready、規約準拠: 直接マージ候補
-- 一部調整が必要: 投稿者へ修正依頼または部分取り込み
-- 設計不一致、大規模、高リスク: Prompt Requestへ戻すか参考にして再実装
+- 目的に合い、残作業と検証方法が具体的: こちらで修正してマージ。命名・小さな設計調整・不足テスト・競合解消はまとめて処理する
+- 一部だけ有用: 小さなメンテナブランチに部分取り込みして検証する
+- 価値より修正・検証・継続保守の負担が大きい、目的不一致、対象環境で検証不能: 見送り。救済のための全面再実装や無期限の修正を始めない
 
-投稿者のコードを部分取り込みまたは再実装した場合は`Co-authored-by`でクレジットし、取り込んだ点と調整点を説明する。
+取り込みまで依頼されている場合:
+
+1. 対象head SHAを記録し、隔離したブランチ / worktreeで修正する。forkの更新権限がなければメンテナブランチへ取り込み、投稿者への依頼待ちにしない。
+2. 必要な修正を一度にまとめ、変更領域に応じた検証とセルフレビューを行う。修正でReadyが外れても対応担当はCodexのまま。
+3. 実際にマージするブランチの最新headでCI、CodeRabbit、必要なUI証拠を再確認する。古いApproveを流用せず、リモートheadが変わったら差分を確認する。
+4. マージ依頼があれば検証済みheadに限定してマージする。別PRで取り込んだ場合の元PRのクローズは取り込みの完了処理として行い、コメントは明示依頼時だけ投稿する。
+
+CodeRabbitの `approve` / トップレベルの `resolve` コマンドはレビュー完了や必須チェックを迂回し得るため、通常の通過手段に使わない。
+
+投稿者のコードを部分取り込みまたは再実装した場合は`Co-authored-by`でクレジットし、取り込んだ点と調整点をコミット / PR説明に残す。
 
 ```bash
 gh api users/<username> --jq '.name, .email, .id'

--- a/.claude/skills/triage/SKILL.md
+++ b/.claude/skills/triage/SKILL.md
@@ -50,9 +50,10 @@ Issueなら「Issueフロー」、PRなら「PRフロー」へ進む。
    - 51〜150: 関連Issue / Prompt Requestと分割不能理由を必須とする
    - 150超: `NOT READY`。Size以外のgateは判定せず、分割依頼とクローズだけを推奨して、ここで終了する
 2. **Draft**: Draftなら`NOT READY`
-3. **品質保留**: `status:quality-hold`があれば`NOT READY`として終了。CodeRabbitのSlop検出ラベルをReadinessが停止条件にする。訂正後・誤検出時の解除はメンテナが行う。自動クローズやAI利用だけを理由とした拒否はしない。
+3. **品質保留**: `status:quality-hold`があれば`NOT READY`として終了。`--force`や`review:override`でも進めず、訂正後・誤検出時にメンテナがラベルを明示解除する。自動クローズやAI利用だけを理由とした拒否はしない。
 4. **レビュー基盤**: 外部PRが`.coderabbit.yaml`、`.github/workflows/**`、PRテンプレート、PR Readiness checker、エージェント指示・設定を変更する場合、メンテナの`review:override`がなければ`NOT READY`
 5. **PR本文**: テンプレートの必須欄とAuthor Checklistを確認する。10ファイル以下かつ低リスクでは、補足理由、対象外、分割計画、手動検証、platformはReadiness上の助言項目。OS依存の変更では対象環境の検証証拠を必須とする。
+   - メンテナ自身の50ファイル以下のPRは、スコープ判断を本文に残せば別Issue不要。外部PRの非自明な変更と全投稿者の50ファイル超にはIssue / Prompt Requestでの合意を求める。
 6. **UI証拠**
    - レイアウト・外観・操作変更: Before / Afterとdevice/platformを必須とする
    - 新規UI: Beforeは`N/A — 理由`を許可する
@@ -105,7 +106,7 @@ Size gateで終了し、他のgateとdiffは確認していません。
 深掘りレビューはまだ実施していません。
 ```
 
-`--force`、またはメンテナの理由付き`review:override`がある場合だけ未通過でもPhase 2へ進み、未通過条件を冒頭に残す。通常の取り込み修正のためにoverrideを使わない。
+品質保留を除き、`--force`、またはメンテナの理由付き`review:override`がある場合だけ未通過でもPhase 2へ進み、未通過条件を冒頭に残す。通常の取り込み修正のためにoverrideを使わない。
 
 ### Phase 2: Risk map
 

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -47,10 +47,12 @@ reviews:
           Pass when every changed area is needed for the stated primary goal,
           its tests, or necessary documentation. Fail for unrelated fixes,
           opportunistic refactors, formatting churn, or speculative features.
-          Non-trivial features, new packages, architecture changes, and PRs over
-          50 files need a linked Issue or Prompt Request with maintainer scope
-          agreement; a link alone is not agreement. Small self-contained fixes
-          may use "None — reason". Cite the unrelated paths or missing scope
+          External non-trivial features, new packages, architecture changes, and
+          all PRs over 50 files need a linked Issue or Prompt Request with
+          maintainer scope agreement; a link alone is not agreement.
+          Maintainer-authored PRs up to 50 files may record their scope decision
+          in the PR body without a separate Issue. Small self-contained external
+          fixes may use "None — reason". Cite the unrelated paths or missing scope
           agreement on failure. Do not infer quality from AI use or prose style.
       - name: Maintainable implementation
         mode: error

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -8,6 +8,12 @@ reviews:
   poem: false
   review_status: true
 
+  # Detection alone is advisory; PR Readiness blocks this label from the queue.
+  slop_detection:
+    enabled: true
+    include_all_authors: true
+    label: status:quality-hold
+
   # PR Readiness adds this label only after the author-facing intake gate passes.
   auto_review:
     enabled: false
@@ -35,6 +41,28 @@ reviews:
     issue_assessment:
       mode: warning
     custom_checks:
+      - name: Focused scope
+        mode: error
+        instructions: >-
+          Pass when every changed area is needed for the stated primary goal,
+          its tests, or necessary documentation. Fail for unrelated fixes,
+          opportunistic refactors, formatting churn, or speculative features.
+          Non-trivial features, new packages, architecture changes, and PRs over
+          50 files need a linked Issue or Prompt Request with maintainer scope
+          agreement; a link alone is not agreement. Small self-contained fixes
+          may use "None — reason". Cite the unrelated paths or missing scope
+          agreement on failure. Do not infer quality from AI use or prose style.
+      - name: Maintainable implementation
+        mode: error
+        instructions: >-
+          Fail for newly introduced unused code or dependencies, duplicate
+          implementations of existing repository functionality, speculative
+          extension points with no current caller, or fallback paths that hide
+          failures and report success. Cite concrete code and its unnecessary
+          cost or incorrect behavior. Pass when the change uses existing patterns
+          or explains a necessary deviation. Do not fail on style preferences,
+          AI authorship, or merely having an abstraction. Do not require rewrites
+          or extra framework layers without a demonstrated problem.
       - name: UI evidence
         mode: error
         instructions: >-
@@ -52,9 +80,16 @@ reviews:
       - name: Validation evidence
         mode: error
         instructions: >-
-          Pass only when the PR description gives the exact automated test
-          commands and results, manual validation performed, and target platform
-          and version. "N/A" is acceptable only with a concrete reason.
+          Pass when exact automated commands and results support the stated
+          behavior, or "N/A — reason" explains a documentation-only or similarly
+          low-impact change. For bug fixes, require a regression test that can
+          catch the reported failure, or reproducible before/after validation
+          when automation is impractical. Fail for placeholder results, claims
+          contradicted by CI, or tests that only mirror implementation without
+          checking observable behavior. Manual validation and platform/version
+          are required above 10 files, for high-risk changes, and for OS-specific
+          behavior; they are advisory for small low-risk changes otherwise.
+          Inspect supplied evidence and test code; do not try to run tests here.
       - name: Breaking change documentation
         mode: error
         instructions: >-
@@ -78,6 +113,14 @@ reviews:
     - "!**/coverage/**"
 
   path_instructions:
+    - path: "**"
+      instructions: |
+        Apply CONTRIBUTING.md's contribution quality bar. Focus on concrete
+        correctness, scope, regression, and maintenance problems; avoid style
+        nits, speculative improvements, and repeating CI diagnostics. AI use
+        itself is allowed. Group related findings with a concrete path and fix.
+        The author handles this automated review before maintainer handoff;
+        maintainers then make bounded integration fixes themselves.
     - path: "packages/bridge/src/**"
       instructions: |
         Focus on authentication and authorization boundaries, allowed-directory

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,7 @@ Write "None — <reason>" only for a small, self-contained change.
 
 ## Changes
 
-<!-- List the key changes. -->
+<!-- List only changes needed for the primary goal. Omit unrelated refactors and speculative additions. -->
 
 -
 
@@ -28,7 +28,13 @@ Write "None — <reason>" only for a small, self-contained change.
 
 ## Test Evidence
 
-<!-- Include exact commands and results. Write "N/A — <reason>" when needed. -->
+<!--
+Include exact commands and actual results. Bug fixes need a regression test or
+reproducible before/after validation when automation is impractical.
+Write "N/A — <reason>" when validation does not apply.
+For <=10-file low-risk PRs, supporting context and manual/platform fields are
+advisory; UI and OS-dependent changes still require their relevant evidence.
+-->
 
 - Automated tests (command and result):
 - Manual validation:
@@ -63,6 +69,12 @@ image or recording is required. Before may be "N/A — <reason>" only for a new 
 - Device / platform:
 
 ## Author Checklist
+
+<!--
+Address CI and CodeRabbit findings before requesting maintainer review.
+After handoff, maintainers may finish bounded fixes themselves and merge with
+attribution, or decline if the integration cost outweighs the value.
+-->
 
 - [ ] I reviewed the complete diff and can explain and maintain this change.
 - [ ] This PR contains no unrelated changes.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,6 +7,7 @@
 <!--
 For non-trivial changes, open a Prompt Request or Issue first.
 Write "None — <reason>" only for a small, self-contained change.
+Maintainer-authored PRs up to 50 files may instead document their scope decision here.
 -->
 
 - Related Issue / Prompt Request: <!-- Link or "None — <reason>" -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,15 +100,33 @@ and continue discussion in an Issue instead.
 CC Pocket is maintained as a personal project.
 PR review happens on an availability basis, not in submission order.
 
-Opening a PR does **not** guarantee immediate review.
-Large PRs may remain untouched until:
+Opening a PR does **not** guarantee review or acceptance. Authors prepare the
+contribution with CI and CodeRabbit before maintainer review begins. Maintainers
+do not provide an implementation coaching loop for unready PRs.
 
-- the author explicitly asks for review
-- the scope is clarified
-- the PR is split into reviewable pieces
+### Contribution Quality Bar
 
-If a PR is large, stacked, or architectural, silence usually means "not ready
-for review yet" rather than "merged soon."
+AI-assisted contributions are welcome. We judge the submitted change by concrete
+evidence and maintenance cost:
+
+- **Focused scope:** every changed area supports one agreed goal, its tests, or
+  necessary documentation. Non-trivial features, new packages, architecture
+  changes, and PRs over 50 files need prior maintainer agreement in an Issue or
+  Prompt Request; a link alone is not agreement. Small self-contained fixes may
+  explain why no prior Issue is needed.
+- **Necessary implementation:** use existing patterns. Remove unused code and
+  dependencies, duplicate implementations, speculative extension points, and
+  fallbacks that hide failure. Style preferences alone are not blockers.
+- **Credible validation:** give commands and results that support the claimed
+  behavior. Bug fixes need a regression test or reproducible before/after
+  validation when automation is impractical. Tests must check useful behavior.
+  Documentation-only and similarly low-impact changes may explain why tests do
+  not apply. OS-dependent changes need validation on the target environment.
+
+CodeRabbit checks these criteria before handoff. Address its concrete findings
+and explain disagreements there; do not manufacture validation results or add
+unrelated code just to satisfy a suggestion. Maintainer review focuses on
+product fit and risk that automation cannot settle.
 
 ### Automated Review Readiness
 
@@ -117,11 +135,29 @@ Maintainer review starts only after all of these gates pass:
 1. The PR is marked ready for review and its template is complete
 2. The scope and validation evidence pass the `PR Readiness` check
 3. The `Test` workflow passes
-4. CodeRabbit approves the latest commit and its conversations are resolved
+4. CodeRabbit completes its review and explicitly approves the latest commit,
+   with required feedback resolved and required pre-merge checks passing
+5. No `status:quality-hold` label is present
 
 PR Readiness adds `ready-for-maintainer-review` and requests maintainer review
 only after every gate passes. A new commit clears readiness until CI and
 CodeRabbit approve the new head commit.
+
+A green `CodeRabbit` status or `Review completed` message alone is insufficient.
+Do not use top-level `@coderabbitai approve` or `@coderabbitai resolve` commands
+to bypass review or pre-merge checks. Missing, inconclusive, or ignored required
+checks need maintainer assessment; they are not evidence that the criteria pass.
+Custom pre-merge checks require a CodeRabbit plan that supports them. Maintainers
+must verify that the configured checks actually run before relying on this gate.
+
+CodeRabbit's initial full review can flag low-quality submissions with
+`status:quality-hold`. PR Readiness then excludes them from the maintainer queue,
+even if CI is green. This signal does not automatically close a PR or prove AI
+authorship. A maintainer can remove the label after correction or a false-positive
+assessment; ordinary readiness synchronization never removes it. Incremental
+reviews do not rerun Slop Detection. See the [CodeRabbit Slop Detection
+documentation](https://docs.coderabbit.ai/pr-reviews/slop-detection) and
+[pre-merge check requirements](https://docs.coderabbit.ai/pr-reviews/pre-merge-checks).
 
 The file-count policy is intentionally strict:
 
@@ -141,10 +177,32 @@ automated maintainer queue when authored externally. They require a
 maintainer-authored PR or an explicit `review:override`, because those files
 define the review gate itself.
 
-For user-visible UI changes, attach Before and After evidence in the PR body.
-An After image or recording is always required. Before may be written as
+For visual or interaction UI changes, attach Before and After evidence in the PR
+body. An After image or recording is required. Before may be written as
 `N/A — <reason>` only for a new UI. Changes under the mobile UI area that are
-not visible must explain why no visual evidence is needed.
+not visible must explain why no visual evidence is needed. Text-only changes may
+instead provide a successful `flutter test ...` command and result, plus a reason
+images are unnecessary.
+
+For small low-risk PRs (10 files or fewer), supporting rationale, out-of-scope
+notes, split plans, manual validation, and platform details are advisory. The
+primary goal, automated evidence or a concrete reason it does not apply, risk,
+rollback, and author checklist remain required. UI and OS-dependent changes
+still need their relevant evidence.
+
+### Maintainer Handoff and Merge
+
+After readiness passes, maintainers may use Codex to finish integration. We make
+bounded fixes ourselves, including small design adjustments, missing tests, and
+conflict resolution, then validate and merge. We do not send the contributor
+through another Request Changes round at this stage. If a fork cannot be edited,
+we can incorporate the contribution on a maintainer branch with attribution.
+
+Readiness is an entry criterion, not a promise to merge. We decline changes when
+product fit is poor or correction, verification, or long-term support costs
+outweigh their value. We do not undertake an open-ended rewrite to rescue every
+PR. Maintainer fixes must pass CI and CodeRabbit on the actual branch and latest
+commit being merged; approval of the original commit does not carry forward.
 
 ### Environment-Dependent PRs — Especially Welcome
 
@@ -193,7 +251,7 @@ these apply:
 If you do send a PR, we may close it and re-implement the change ourselves to fit the codebase's conventions and architecture. In that case:
 
 - Your contribution will be credited via `Co-authored-by` in the commit
-- We'll comment on the PR explaining what we incorporated and what we adjusted
+- The commit or PR description will explain what we incorporated and adjusted
 
 This isn't a rejection of your work — it's how we maintain consistency while honoring your contribution.
 
@@ -214,6 +272,7 @@ Maintainers may apply labels like these when triaging Issues and PRs:
 - `help wanted` — contributions are welcome
 - `status:needs-author` — the automated intake, CI, or CodeRabbit gate needs author action
 - `status:needs-split` — the PR is too large and must be split
+- `status:quality-hold` — CodeRabbit flagged quality; maintainer assessment is needed to clear the hold
 - `review:coderabbit` — intake passed and CodeRabbit review is enabled
 - `ready-for-maintainer-review` — intake, CI, and CodeRabbit approval all passed
 - `risk:high` — the PR touches a security, protocol, process, or release boundary
@@ -270,7 +329,7 @@ If you discover a vulnerability, please report it privately via [GitHub Security
 PR を送っていただいた場合でも、コードベースの規約やアーキテクチャに合わせるため、クローズした上でメンテナ側で再実装することがあります。その際は:
 
 - コミットに `Co-authored-by` を付与して貢献をクレジットします
-- PR コメントで、何を取り込み何を調整したかを説明します
+- コミットや PR 説明に、何を取り込み何を調整したかを残します
 
 これは PR の否定ではなく、一貫性を保ちつつ貢献を活かすための運用です。
 
@@ -297,14 +356,25 @@ CC Pocket は個人プロジェクトとして運営しており、PR レビュ�
 メンテナの余力ベースで行います。
 
 PR を開いただけでは、すぐにレビューが始まるとは限りません。
-特に大きい PR は、次のいずれかが揃うまで保留になることがあります:
+PR の提出はレビューや採用を保証しません。投稿者が CI と CodeRabbit で受付条件を
+満たしてからメンテナレビューへ進みます。未準備の PR の実装を何往復も指導する
+運用は行いません。
 
-- 投稿者から明確にレビュー依頼がある
-- スコープが整理されている
-- 分割されてレビュー可能な大きさになっている
+#### コントリビューションの品質基準
 
-大規模・stacked・アーキテクチャ寄りの PR に対して反応がない場合、それは
-「近いうちに取り込む予定」ではなく、「まだレビュー可能な状態ではない」という意味です。
+AI を利用した投稿は歓迎します。提出物の根拠と保守負担で判断します。
+
+- **スコープ:** 合意した一つの目的、テスト、必要な説明に変更を絞る。非自明な機能、
+  新パッケージ、設計変更、50ファイル超の PR は Issue / Prompt Request で事前合意が必要。
+  リンクだけでは合意とみなさない。小さな独立した修正は Issue 不要の理由で代替可能。
+- **必要な実装:** 既存パターンを使い、未使用コード・依存、重複実装、現在の利用箇所がない
+  拡張点、失敗を隠すフォールバックを持ち込まない。スタイルの好みだけでは止めない。
+- **検証根拠:** 主張する動作を確かめるコマンドと結果を示す。バグ修正には回帰テスト、
+  自動化が難しければ再現可能な修正前後の検証を示す。docs など低影響の変更はテスト不要の
+  具体的な理由を許可する。OS 依存の変更は対象環境での検証を必要とする。
+
+CodeRabbit がこれらを確認します。具体的な指摘への対応や異論の説明はそこで済ませ、
+メンテナは製品への適合性と残るリスクに集中します。
 
 #### 自動レビュー準備判定
 
@@ -313,11 +383,23 @@ PR を開いただけでは、すぐにレビューが始まるとは限りま�
 1. Draft が解除され、PR テンプレートが記入済み
 2. スコープと検証証拠が `PR Readiness` を通過
 3. `Test` Workflow が成功
-4. 最新コミットを CodeRabbit が Approve し、指摘が解決済み
+4. 最新コミットの CodeRabbit レビューが完了し、明示的な Approve、指摘の解決、必須チェックの通過が揃う
+5. `status:quality-hold` が付いていない
 
 すべて通過すると `ready-for-maintainer-review` が付き、メンテナへレビューが
 依頼されます。新しいコミットを push すると、CI と CodeRabbit がそのコミットを
 確認するまで Ready 状態は解除されます。
+
+緑の status や `Review completed` だけでは通過しません。トップレベルの
+`@coderabbitai approve` / `@coderabbitai resolve` でレビューや必須チェックを迂回しないでください。
+必須チェックが未実行、Inconclusive、ignored の場合はメンテナ判断が必要です。
+カスタムチェックを使える CodeRabbit プランと、設定したチェックの実行結果を
+メンテナが確認してから運用します。
+
+CodeRabbit の初回フルレビューで品質上の疑いを検出すると `status:quality-hold` が付き、
+CI が成功していても Readiness はメンテナ待ちへ進めません。自動クローズや AI 利用の
+断定は行いません。訂正後や誤検出時はメンテナがラベルを解除します。通常のラベル同期で
+自動解除せず、incremental review では Slop Detection 自体も再実行されません。
 
 変更ファイル数は次の基準で扱います。
 
@@ -334,10 +416,27 @@ CodeRabbit 設定、GitHub Workflow、PR テンプレート、PR Readiness check
 外部PRは自動でメンテナレビュー待ちには進まず、メンテナ作成のPRまたは明示的な
 `review:override` が必要です。
 
-ユーザーに見える UI 変更では PR 本文に Before / After を添付してください。
+レイアウト・外観・操作の UI 変更では PR 本文に Before / After を添付してください。
 After の画像または動画は必須です。新規 UI に限り、Before は
 `N/A — <理由>` と記載できます。mobile UI 領域を変更して見た目が変わらない場合は、
 スクリーンショットが不要な理由を記載してください。
+文言だけの変更は、成功した `flutter test ...` のコマンド・結果と画像不要理由で代替できます。
+
+10ファイル以下かつ低リスクなら、補足理由、対象外、分割計画、手動検証、platform は
+助言項目です。主目的、自動検証または不要理由、リスク、ロールバック、Author Checklist は
+必須です。UI・OS 依存の変更ではそれぞれの検証証拠が必要です。
+
+#### メンテナへの引き継ぎとマージ
+
+Ready 通過後はメンテナ / Codex が取り込みを担当します。小さな設計調整、不足テスト、
+競合解消はまとめてこちらで直し、検証してマージします。この段階で投稿者へ
+Request Changes を返して往復を増やしません。fork を編集できなければ、クレジットを
+残してメンテナブランチへ取り込めます。
+
+Ready は受付条件であり採用の約束ではありません。目的が合わない、修正・検証・継続保守の
+負担が価値を上回る場合は見送ります。全 PR の救済や全面再実装は行いません。
+こちらで修正した場合も、実際にマージするブランチの最新コミットで CI と CodeRabbit の
+通過を確認し、元コミットの Approve を流用しません。
 
 ### バグ報告・機能提案
 
@@ -404,6 +503,7 @@ Issue / PR には次のようなラベルを付けることがあります:
 - `help wanted` — コントリビューション歓迎
 - `status:needs-author` — 自動受付、CI、CodeRabbit のいずれかで投稿者の対応が必要
 - `status:needs-split` — PR が大きすぎるため分割が必要
+- `status:quality-hold` — CodeRabbit の品質検出で保留。解除にはメンテナ判断が必要
 - `review:coderabbit` — 受付条件を満たし、CodeRabbit レビュー対象になった
 - `ready-for-maintainer-review` — 受付、CI、CodeRabbit Approve をすべて通過
 - `risk:high` — セキュリティ、プロトコル、プロセス、リリース境界を変更

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,10 +110,11 @@ AI-assisted contributions are welcome. We judge the submitted change by concrete
 evidence and maintenance cost:
 
 - **Focused scope:** every changed area supports one agreed goal, its tests, or
-  necessary documentation. Non-trivial features, new packages, architecture
-  changes, and PRs over 50 files need prior maintainer agreement in an Issue or
+  necessary documentation. External non-trivial features, new packages,
+  architecture changes, and all PRs over 50 files need prior maintainer agreement in an Issue or
   Prompt Request; a link alone is not agreement. Small self-contained fixes may
-  explain why no prior Issue is needed.
+  explain why no prior Issue is needed. For maintainer-authored PRs up to 50 files,
+  the scope decision may be documented in the PR itself; no separate Issue is needed.
 - **Necessary implementation:** use existing patterns. Remove unused code and
   dependencies, duplicate implementations, speculative extension points, and
   fallbacks that hide failure. Style preferences alone are not blockers.
@@ -154,7 +155,8 @@ CodeRabbit's initial full review can flag low-quality submissions with
 `status:quality-hold`. PR Readiness then excludes them from the maintainer queue,
 even if CI is green. This signal does not automatically close a PR or prove AI
 authorship. A maintainer can remove the label after correction or a false-positive
-assessment; ordinary readiness synchronization never removes it. Incremental
+assessment; `review:override` cannot bypass it, and ordinary readiness
+synchronization never removes it. Incremental
 reviews do not rerun Slop Detection. See the [CodeRabbit Slop Detection
 documentation](https://docs.coderabbit.ai/pr-reviews/slop-detection) and
 [pre-merge check requirements](https://docs.coderabbit.ai/pr-reviews/pre-merge-checks).
@@ -364,9 +366,10 @@ PR の提出はレビューや採用を保証しません。投稿者が CI と 
 
 AI を利用した投稿は歓迎します。提出物の根拠と保守負担で判断します。
 
-- **スコープ:** 合意した一つの目的、テスト、必要な説明に変更を絞る。非自明な機能、
-  新パッケージ、設計変更、50ファイル超の PR は Issue / Prompt Request で事前合意が必要。
+- **スコープ:** 合意した一つの目的、テスト、必要な説明に変更を絞る。外部PRの非自明な機能、
+  新パッケージ、設計変更、および全投稿者の50ファイル超の PR は Issue / Prompt Request で事前合意が必要。
   リンクだけでは合意とみなさない。小さな独立した修正は Issue 不要の理由で代替可能。
+  メンテナ自身の50ファイル以下の PR は、本文にスコープ判断を記載すれば別Issueは不要。
 - **必要な実装:** 既存パターンを使い、未使用コード・依存、重複実装、現在の利用箇所がない
   拡張点、失敗を隠すフォールバックを持ち込まない。スタイルの好みだけでは止めない。
 - **検証根拠:** 主張する動作を確かめるコマンドと結果を示す。バグ修正には回帰テスト、
@@ -398,7 +401,8 @@ CodeRabbit がこれらを確認します。具体的な指摘への対応や異
 
 CodeRabbit の初回フルレビューで品質上の疑いを検出すると `status:quality-hold` が付き、
 CI が成功していても Readiness はメンテナ待ちへ進めません。自動クローズや AI 利用の
-断定は行いません。訂正後や誤検出時はメンテナがラベルを解除します。通常のラベル同期で
+断定は行いません。訂正後や誤検出時はメンテナがラベルを解除します。`review:override` では
+迂回できません。通常のラベル同期で
 自動解除せず、incremental review では Slop Detection 自体も再実行されません。
 
 変更ファイル数は次の基準で扱います。

--- a/scripts/pr-readiness.mjs
+++ b/scripts/pr-readiness.mjs
@@ -42,6 +42,12 @@ const LABELS = {
     color: '006b75',
     description: 'Maintainer override for automated readiness gates',
   },
+  // CodeRabbit applies this label; only a maintainer clears it after assessment.
+  // Keep it out of MANAGED_LABELS so normal synchronization cannot remove it.
+  'status:quality-hold': {
+    color: 'b60205',
+    description: 'CodeRabbit flagged contribution quality; excluded from review queue',
+  },
   'risk:high': {
     color: 'b60205',
     description: 'Touches a security, protocol, process, or release boundary',
@@ -207,7 +213,7 @@ export function requiresReviewPolicyOverride({ files, author, maintainer, overri
   return files.some(isReviewPolicyPath) && author !== maintainer && !override;
 }
 
-export function evaluateIntake({ body, files, fileCount, draft = false }) {
+export function evaluateIntake({ body, files, fileCount, draft = false, qualityHold = false }) {
   const errors = [];
   const warnings = [];
   const oversized = fileCount > MAX_REVIEW_FILES;
@@ -215,9 +221,11 @@ export function evaluateIntake({ body, files, fileCount, draft = false }) {
   const uiRelated = files.some(isUiRelatedPath);
   const pathHighRisk = files.some(isHighRiskPath);
 
-  if (oversized) {
+  if (oversized || qualityHold) {
     errors.push(
-      `This PR changes ${fileCount} files. The project limit is ${MAX_REVIEW_FILES}; split it into independently reviewable PRs.`,
+      oversized
+        ? `This PR changes ${fileCount} files. The project limit is ${MAX_REVIEW_FILES}; split it into independently reviewable PRs.`
+        : 'CodeRabbit flagged contribution quality. Address its concrete findings; a maintainer can clear status:quality-hold after correction or a false-positive assessment.',
     );
     return {
       errors,
@@ -477,20 +485,21 @@ function latestReviewFor(reviews, predicate) {
 }
 
 export function codeRabbitGate(reviews, statuses, headSha) {
-  const review = latestReviewFor(
-    reviews,
+  const decisions = reviews.filter(
     (item) =>
-      item.commit_id === headSha &&
-      CODERABBIT_REVIEWERS.has(String(item.user?.login ?? '').toLowerCase()),
+      CODERABBIT_REVIEWERS.has(String(item.user?.login ?? '').toLowerCase()) &&
+      ['APPROVED', 'CHANGES_REQUESTED', 'DISMISSED'].includes(item.state),
   );
-  if (review) {
-    if (review.state === 'APPROVED') {
-      return { state: 'success', detail: 'CodeRabbit approved the latest commit.' };
-    }
-    if (review.state === 'CHANGES_REQUESTED') {
-      return { state: 'failure', detail: 'Resolve CodeRabbit change requests.' };
-    }
-    return { state: 'pending', detail: `CodeRabbit review state: ${review.state}.` };
+  const review = latestReviewFor(
+    decisions,
+    (item) => item.commit_id === headSha,
+  );
+  const latestDecision = latestReviewFor(decisions, () => true);
+  if (
+    review?.state === 'CHANGES_REQUESTED' ||
+    latestDecision?.state === 'CHANGES_REQUESTED'
+  ) {
+    return { state: 'failure', detail: 'Resolve CodeRabbit change requests.' };
   }
 
   const status = statuses
@@ -509,18 +518,19 @@ export function codeRabbitGate(reviews, statuses, headSha) {
       ),
     )[0];
   if (
+    review?.state === 'APPROVED' &&
     status?.state === 'success' &&
     /^review completed$/i.test(String(status.description ?? '').trim())
   ) {
     return {
       state: 'success',
-      detail: 'CodeRabbit completed the latest review with no change request.',
+      detail: 'CodeRabbit reviewed and approved the latest commit.',
     };
   }
   if (status?.state === 'failure' || status?.state === 'error') {
     return { state: 'failure', detail: 'Resolve CodeRabbit check failures.' };
   }
-  return { state: 'pending', detail: 'Waiting for CodeRabbit review on the latest commit.' };
+  return { state: 'pending', detail: 'Waiting for CodeRabbit review and approval on the latest commit.' };
 }
 
 async function ciGate(repo, commitSha) {
@@ -704,8 +714,9 @@ async function evaluatePullRequest({ repo, number, maintainer }) {
 
   const currentLabels = pr.labels.map((label) => label.name);
   const override = currentLabels.includes('review:override');
+  const qualityHold = currentLabels.includes('status:quality-hold') && !override;
   const files =
-    pr.changed_files > MAX_REVIEW_FILES && !override
+    (pr.changed_files > MAX_REVIEW_FILES && !override) || qualityHold
       ? []
       : await paginate(`/repos/${repo}/pulls/${number}/files`);
   const paths = files.map((file) => file.filename);
@@ -714,6 +725,7 @@ async function evaluatePullRequest({ repo, number, maintainer }) {
     files: paths,
     fileCount: pr.changed_files,
     draft: pr.draft,
+    qualityHold,
   });
   if (
     requiresReviewPolicyOverride({
@@ -728,7 +740,6 @@ async function evaluatePullRequest({ repo, number, maintainer }) {
     );
   }
 
-  const reviews = await paginate(`/repos/${repo}/pulls/${number}/reviews`);
   const intakePassed = intake.errors.length === 0;
   const reviewEligible = isCodeRabbitReviewEligible({
     draft: pr.draft,
@@ -736,6 +747,9 @@ async function evaluatePullRequest({ repo, number, maintainer }) {
     intakePassed,
     override,
   });
+  const reviews = reviewEligible || override
+    ? await paginate(`/repos/${repo}/pulls/${number}/reviews`)
+    : [];
   const ci = shouldEvaluateCi({ oversized: intake.oversized, override })
     ? await ciGate(repo, ciCheckSha(pr))
     : { state: 'skipped', detail: 'Not run for an oversized PR.' };

--- a/scripts/pr-readiness.mjs
+++ b/scripts/pr-readiness.mjs
@@ -621,7 +621,7 @@ function readinessComment({ intake, ci, coderabbit, draft, override, fileCount }
     `| Draft | ${draft ? '⏳ Draft' : '✅ Ready'} |`,
   ];
 
-  if (override) lines.push('| Maintainer override | ✅ Applied |');
+  if (override) lines.push('| Maintainer override | ✅ Applied; quality holds still block |');
   if (actionItems.length > 0) {
     lines.push('', '### Action required', '', ...actionItems.map((item) => `- ${item}`));
   }
@@ -714,7 +714,7 @@ async function evaluatePullRequest({ repo, number, maintainer }) {
 
   const currentLabels = pr.labels.map((label) => label.name);
   const override = currentLabels.includes('review:override');
-  const qualityHold = currentLabels.includes('status:quality-hold') && !override;
+  const qualityHold = currentLabels.includes('status:quality-hold');
   const files =
     (pr.changed_files > MAX_REVIEW_FILES && !override) || qualityHold
       ? []
@@ -747,7 +747,7 @@ async function evaluatePullRequest({ repo, number, maintainer }) {
     intakePassed,
     override,
   });
-  const reviews = reviewEligible || override
+  const reviews = (reviewEligible || override) && !qualityHold
     ? await paginate(`/repos/${repo}/pulls/${number}/reviews`)
     : [];
   const ci = shouldEvaluateCi({ oversized: intake.oversized, override })
@@ -766,6 +766,7 @@ async function evaluatePullRequest({ repo, number, maintainer }) {
       });
   const ready =
     !pr.draft &&
+    !qualityHold &&
     (override ||
       (intakePassed && ci.state === 'success' && coderabbit.state === 'success'));
 

--- a/scripts/pr-readiness.test.mjs
+++ b/scripts/pr-readiness.test.mjs
@@ -1,4 +1,7 @@
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import test from 'node:test';
 
 import {
@@ -14,6 +17,7 @@ import {
   isHighRiskPath,
   isReviewPolicyPath,
   isUiRelatedPath,
+  main,
   requiresReviewPolicyOverride,
   shouldEvaluateCi,
   sizeLabel,
@@ -435,6 +439,108 @@ test('rejects PRs above the hard file limit before parsing the body', () => {
   assert.equal(result.size, 'size:XL');
 });
 
+test('stops quality-held PRs before parsing the body or requiring more evidence', () => {
+  const result = evaluateIntake({
+    body: '',
+    files: [],
+    fileCount: 2,
+    qualityHold: true,
+  });
+  assert.equal(result.errors.length, 1);
+  assert.match(result.errors[0], /status:quality-hold/);
+  assert.equal(result.oversized, false);
+  assert.equal(isCodeRabbitReviewEligible({
+    draft: false,
+    oversized: result.oversized,
+    intakePassed: result.errors.length === 0,
+    override: false,
+  }), false);
+});
+
+test('keeps the size gate first even for quality-held PRs', () => {
+  const result = evaluateIntake({
+    body: '', files: [], fileCount: MAX_REVIEW_FILES + 1, qualityHold: true,
+  });
+  assert.equal(result.errors.length, 1);
+  assert.match(result.errors[0], /split it/);
+});
+
+test('quality hold removes readiness without reading patches or closing the PR, and can be cleared', async (t) => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'ccpocket-readiness-'));
+  const eventPath = path.join(directory, 'event.json');
+  fs.writeFileSync(eventPath, JSON.stringify({ pull_request: { number: 42 } }));
+  const environment = {
+    GITHUB_TOKEN: 'test-only-token', GITHUB_EVENT_PATH: eventPath,
+    GITHUB_REPOSITORY: 'example/repo', MAINTAINER_LOGIN: 'maintainer',
+  };
+  const previous = Object.fromEntries(Object.keys(environment).map((key) => [key, process.env[key]]));
+  Object.assign(process.env, environment);
+  t.after(() => {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    fs.rmSync(directory, { recursive: true, force: true });
+  });
+  const labels = new Set(['size:S', 'status:quality-hold', 'ready-for-maintainer-review', 'review:coderabbit']);
+  const requests = [];
+  const base = '/repos/example/repo';
+  t.mock.method(globalThis, 'fetch', async (url, options) => {
+    const route = decodeURIComponent(new URL(url).pathname);
+    const method = options.method;
+    const payload = options.body ? JSON.parse(options.body) : undefined;
+    requests.push({ route, method, payload });
+    let response;
+    if (method === 'GET') {
+      if (route === `${base}/labels`) response = [...labels].map((name) => ({ name }));
+      else if (route === `${base}/pulls/42`) response = {
+        number: 42, state: 'open', draft: false, changed_files: 2, body: body(),
+        labels: [...labels].map((name) => ({ name })), head: { sha: 'head-sha' },
+        user: { login: 'contributor' }, requested_reviewers: [{ login: 'maintainer' }],
+        html_url: 'https://github.com/example/repo/pull/42',
+      };
+      else if (route === `${base}/commits/head-sha/check-runs`) response = {
+        check_runs: ['repository', 'mobile', 'bridge', 'functions'].map((name) => ({
+          name, status: 'completed', conclusion: 'success',
+        })),
+      };
+      else if (route === `${base}/issues/42/comments`) response = [];
+      else if (route === `${base}/commits/head-sha/status`) response = { statuses: [] };
+      else if (route === `${base}/pulls/42/files`) response = [{ filename: 'docs/fix.md' }];
+      else if (route === `${base}/pulls/42/reviews`) response = [rabbitReview()];
+      else if (route === `${base}/commits/head-sha/statuses`) response = completedRabbitStatus;
+      else assert.fail(`Unexpected GET ${route}`);
+    } else {
+      if (route === `${base}/issues/42/labels` && method === 'POST') {
+        for (const label of payload.labels) labels.add(label);
+      } else if (route.startsWith(`${base}/issues/42/labels/`) && method === 'DELETE') {
+        labels.delete(route.slice(`${base}/issues/42/labels/`.length));
+      }
+      response = {};
+    }
+    return new Response(JSON.stringify(response), { status: 200 });
+  });
+
+  await main();
+  assert.ok(labels.has('status:quality-hold'));
+  assert.ok(labels.has('status:needs-author'));
+  assert.ok(!labels.has('ready-for-maintainer-review'));
+  assert.ok(!labels.has('review:coderabbit'));
+  assert.ok(!requests.some(({ route }) => /\/42\/(?:files|reviews)$/.test(route)));
+  assert.ok(!requests.some(({ method, payload }) => method === 'PATCH' && payload.state === 'closed'));
+  assert.ok(requests.some(({ route, method }) => route.endsWith('/requested_reviewers') && method === 'DELETE'));
+  assert.ok(requests.some(({ route, payload }) => route.endsWith('/statuses/head-sha') && payload.state === 'failure'));
+
+  // A maintainer clears the hold; the same green CI and real head approval now qualify.
+  labels.delete('status:quality-hold');
+  requests.length = 0;
+  await main();
+  assert.ok(labels.has('ready-for-maintainer-review'));
+  assert.ok(labels.has('review:coderabbit'));
+  assert.ok(!labels.has('status:needs-author'));
+  assert.ok(requests.some(({ route, payload }) => route.endsWith('/statuses/head-sha') && payload.state === 'success'));
+});
+
 test('classifies generated UI files and high-risk paths', () => {
   assert.equal(isUiRelatedPath('apps/mobile/lib/router/app_router.gr.dart'), false);
   assert.equal(isUiRelatedPath('apps/mobile/lib/features/chat/chat_screen.dart'), true);
@@ -523,7 +629,20 @@ test('explains why CodeRabbit was not requested', () => {
   );
 });
 
-test('accepts a completed CodeRabbit status when no review object was created', () => {
+function rabbitReview(state = 'APPROVED', commit = 'head-sha', minute = '00') {
+  return {
+    user: { login: 'coderabbitai[bot]' },
+    commit_id: commit,
+    state,
+    submitted_at: `2026-08-29T00:${minute}:00Z`,
+  };
+}
+
+const completedRabbitStatus = [{
+  context: 'CodeRabbit', state: 'success', description: 'Review completed',
+}];
+
+test('requires explicit approval even when the CodeRabbit status is completed', () => {
   assert.deepEqual(
     codeRabbitGate(
       [],
@@ -537,8 +656,8 @@ test('accepts a completed CodeRabbit status when no review object was created', 
       'head-sha',
     ),
     {
-      state: 'success',
-      detail: 'CodeRabbit completed the latest review with no change request.',
+      state: 'pending',
+      detail: 'Waiting for CodeRabbit review and approval on the latest commit.',
     },
   );
 });
@@ -546,7 +665,7 @@ test('accepts a completed CodeRabbit status when no review object was created', 
 test('does not accept a skipped CodeRabbit success status', () => {
   assert.deepEqual(
     codeRabbitGate(
-      [],
+      [rabbitReview()],
       [
         {
           context: 'CodeRabbit',
@@ -558,7 +677,7 @@ test('does not accept a skipped CodeRabbit success status', () => {
     ),
     {
       state: 'pending',
-      detail: 'Waiting for CodeRabbit review on the latest commit.',
+      detail: 'Waiting for CodeRabbit review and approval on the latest commit.',
     },
   );
 });
@@ -566,7 +685,7 @@ test('does not accept a skipped CodeRabbit success status', () => {
 test('requires an exact CodeRabbit review-completed description', () => {
   assert.deepEqual(
     codeRabbitGate(
-      [],
+      [rabbitReview()],
       [
         {
           context: 'CodeRabbit',
@@ -578,7 +697,7 @@ test('requires an exact CodeRabbit review-completed description', () => {
     ),
     {
       state: 'pending',
-      detail: 'Waiting for CodeRabbit review on the latest commit.',
+      detail: 'Waiting for CodeRabbit review and approval on the latest commit.',
     },
   );
 });
@@ -586,7 +705,7 @@ test('requires an exact CodeRabbit review-completed description', () => {
 test('rejects a CodeRabbit context status from an explicitly foreign creator', () => {
   assert.deepEqual(
     codeRabbitGate(
-      [],
+      [rabbitReview()],
       [
         {
           context: 'CodeRabbit',
@@ -599,7 +718,7 @@ test('rejects a CodeRabbit context status from an explicitly foreign creator', (
     ),
     {
       state: 'pending',
-      detail: 'Waiting for CodeRabbit review on the latest commit.',
+      detail: 'Waiting for CodeRabbit review and approval on the latest commit.',
     },
   );
 });
@@ -616,13 +735,13 @@ test('finds a CodeRabbit status after the first API page', () => {
     description: 'Review completed',
   });
 
-  assert.equal(codeRabbitGate([], statuses, 'head-sha').state, 'success');
+  assert.equal(codeRabbitGate([rabbitReview()], statuses, 'head-sha').state, 'success');
 });
 
 test('uses the latest CodeRabbit status when older completed statuses remain', () => {
   assert.deepEqual(
     codeRabbitGate(
-      [],
+      [rabbitReview()],
       [
         {
           context: 'CodeRabbit',
@@ -641,7 +760,7 @@ test('uses the latest CodeRabbit status when older completed statuses remain', (
     ),
     {
       state: 'pending',
-      detail: 'Waiting for CodeRabbit review on the latest commit.',
+      detail: 'Waiting for CodeRabbit review and approval on the latest commit.',
     },
   );
 });
@@ -698,6 +817,61 @@ test('does not let a late old-commit review hide head change requests', () => {
     ),
     { state: 'failure', detail: 'Resolve CodeRabbit change requests.' },
   );
+});
+
+test('accepts an explicit head approval after a completed review', () => {
+  assert.equal(
+    codeRabbitGate([rabbitReview()], completedRabbitStatus, 'head-sha').state,
+    'success',
+  );
+});
+
+test('does not accept approval from an unrelated reviewer or an old commit', () => {
+  for (const review of [
+    { ...rabbitReview(), user: { login: 'external-contributor' } },
+    rabbitReview('APPROVED', 'old-sha'),
+    rabbitReview('DISMISSED'),
+  ]) {
+    assert.equal(codeRabbitGate([review], completedRabbitStatus, 'head-sha').state, 'pending');
+  }
+});
+
+test('requires a completed review even after an explicit approval command', () => {
+  for (const statuses of [[], [{ context: 'CodeRabbit', state: 'pending' }]]) {
+    assert.equal(codeRabbitGate([rabbitReview()], statuses, 'head-sha').state, 'pending');
+  }
+  assert.equal(codeRabbitGate(
+    [rabbitReview()], [{ context: 'CodeRabbit', state: 'failure' }], 'head-sha',
+  ).state, 'failure');
+});
+
+test('does not let commentary clear a change request or invalidate an approval', () => {
+  for (const [state, expected] of [['APPROVED', 'success'], ['CHANGES_REQUESTED', 'failure']]) {
+    assert.equal(codeRabbitGate([
+      rabbitReview(state),
+      rabbitReview('COMMENTED', 'head-sha', '01'),
+    ], completedRabbitStatus, 'head-sha').state, expected);
+  }
+});
+
+test('keeps old-head change requests blocking until a new approval supersedes them', () => {
+  const requested = rabbitReview('CHANGES_REQUESTED', 'old-sha');
+  assert.equal(codeRabbitGate([requested], completedRabbitStatus, 'head-sha').state, 'failure');
+  assert.equal(codeRabbitGate([
+    requested, rabbitReview('APPROVED', 'head-sha', '01'),
+  ], completedRabbitStatus, 'head-sha').state, 'success');
+});
+
+test('blocks a late change request on an old head after the head was approved', () => {
+  assert.equal(codeRabbitGate([
+    rabbitReview(), rabbitReview('CHANGES_REQUESTED', 'old-sha', '01'),
+  ], completedRabbitStatus, 'head-sha').state, 'failure');
+});
+
+test('does not reuse an earlier approval after a later head review is dismissed', () => {
+  assert.equal(codeRabbitGate([
+    rabbitReview(), rabbitReview('DISMISSED', 'head-sha', '01'),
+  ], completedRabbitStatus, 'head-sha').state, 'pending');
 });
 
 test('does not request CodeRabbit when a maintainer override applies', () => {

--- a/scripts/pr-readiness.test.mjs
+++ b/scripts/pr-readiness.test.mjs
@@ -531,7 +531,18 @@ test('quality hold removes readiness without reading patches or closing the PR, 
   assert.ok(requests.some(({ route, method }) => route.endsWith('/requested_reviewers') && method === 'DELETE'));
   assert.ok(requests.some(({ route, payload }) => route.endsWith('/statuses/head-sha') && payload.state === 'failure'));
 
+  // An override for other gates cannot substitute for explicitly clearing the hold.
+  labels.add('review:override');
+  requests.length = 0;
+  await main();
+  assert.ok(labels.has('status:quality-hold'));
+  assert.ok(!labels.has('ready-for-maintainer-review'));
+  assert.ok(!labels.has('review:coderabbit'));
+  assert.ok(!requests.some(({ route }) => /\/42\/(?:files|reviews)$/.test(route)));
+  assert.ok(requests.some(({ route, payload }) => route.endsWith('/statuses/head-sha') && payload.state === 'failure'));
+
   // A maintainer clears the hold; the same green CI and real head approval now qualify.
+  labels.delete('review:override');
   labels.delete('status:quality-hold');
   requests.length = 0;
   await main();


### PR DESCRIPTION
## Summary

Keep low-quality external PRs out of the maintainer queue and let Codex finish bounded integration fixes after automated review. A completed CodeRabbit status alone no longer satisfies readiness: the current head must also have an explicit approval.

## Why This Is A PR

- Related Issue / Prompt Request: None — maintainer-requested, self-contained refinement of the existing repository review policy across six related files.
- Why this is ready for PR review: The maintainer approved this scope. Readiness regression tests, official CodeRabbit schema validation, skill validation, and an independent Codex review passed; this PR provides the live CI and CodeRabbit verification before merging.

## Changes

- Enable CodeRabbit Slop Detection and prevent `status:quality-hold` PRs from entering the maintainer queue; retain the hold until a maintainer clears it.
- Keep quality holds blocking even with `review:override`; allow maintainer-authored PRs up to 50 files to record scope decisions in the PR body instead of a separate Issue.
- Require a completed CodeRabbit review and explicit approval for the latest head, preserving unresolved change requests and rejecting stale or dismissed approvals.
- Add focused-scope and maintainability checks, align validation requirements with small-PR exceptions, and keep the contribution guide, template, and triage skill consistent.
- Make Codex handle bounded fixes after handoff without another contributor Request Changes round; decline changes whose integration cost exceeds their value.
- Cover quality-hold removal/recovery with a mocked GitHub API flow and add review-state regression cases.

## Scope Check

- Single primary goal: Reduce maintainer review effort while preserving an explicit contribution quality gate.
- Intentionally out of scope: Application behavior, releases, unrelated workflows, and automatic merging or closing of quality-held PRs.
- Split plan or why this cannot be split: The policy, CodeRabbit configuration, readiness checker, and contributor instructions must agree on the same handoff criteria.

## Test Evidence

- Automated tests (command and result): `node --test --test-reporter=dot scripts/pr-readiness.test.mjs` — all 50 tests passed. CodeRabbit YAML validated against its official `schema.v2.json` with Ajv 2020; triage passed `quick_validate.py`; `git diff --check` passed.
- Manual validation: Inspected the English/Japanese policy and triage command flow; an independent, read-only Codex review returned LGTM. Live PR Readiness and CodeRabbit results will be checked on this PR before merge.
- Target platform and version: macOS development host, Node.js v22.22.1; GitHub Actions repository job uses Node.js 22.

## Risk and Rollback

- [ ] Low
- [ ] Medium
- [x] High
- Main risks: These files control review policy. Slop false positives require maintainer assessment; custom pre-merge checks must be available and actually run. Mandatory checks with missing or inconclusive results are escalated to maintainer assessment before triage reads patches.
- Rollback plan: Revert this PR to restore the prior checker, CodeRabbit configuration, and contribution policy together.

## UI Evidence

- [x] No user-visible UI change
- [ ] User-visible text-only change
- [ ] Visual or interaction UI change
- No-visual-change reason: Repository automation and contributor instructions only; no mobile UI or rendering code changes.
- Before: N/A — no UI change.
- After: N/A — no UI change.
- Device / platform: N/A — repository automation only.

## Author Checklist

- [x] I reviewed the complete diff and can explain and maintain this change.
- [x] This PR contains no unrelated changes.
- [x] User-facing or breaking changes are documented, or documentation is not applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Workflow Updates**
  * Added quality-hold handling to keep affected pull requests blocked until the hold is removed; review overrides cannot bypass it.
  * Readiness checks now require explicit, current CodeRabbit approval and completed walkthrough validation.
  * External contributions receive clearer maintainer handoff, revalidation, merge, and crediting procedures.

* **Documentation**
  * Updated contribution guidance and pull request templates with clearer requirements for scope, testing evidence, CI findings, and review feedback.
  * Maintainer-authored changes up to 50 files may document scope decisions directly instead of opening an additional request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->